### PR TITLE
fix(#DBSYNC-10): drain multiple jobs per sync tick

### DIFF
--- a/apps/desktop/src-tauri/src/commands.rs
+++ b/apps/desktop/src-tauri/src/commands.rs
@@ -289,16 +289,9 @@ pub fn process_sync_queue(state: tauri::State<AppState>) -> Result<bool, String>
 
 #[tauri::command]
 pub fn sync_tick(state: tauri::State<AppState>) -> Result<SyncTickResult, String> {
-    let enqueued_jobs = scan_local_changes_internal(state.inner())?;
-    let processed_job = process_sync_queue_internal(state.inner())?;
-
-    let scanned_files = state.db.list_local_files()?.len();
-
-    Ok(SyncTickResult {
-        scanned_files,
-        enqueued_jobs,
-        processed_job,
-    })
+    // Delegate to the shared implementation so this IPC entry point drains the
+    // queue in batches too (DBSYNC-10), instead of only one job per call.
+    run_sync_tick_internal(state.inner())
 }
 
 #[tauri::command]

--- a/apps/desktop/src-tauri/src/sync_pipeline.rs
+++ b/apps/desktop/src-tauri/src/sync_pipeline.rs
@@ -19,6 +19,11 @@ use crate::overlay_state;
 use crate::state::AppState;
 use crate::storage::db::FileIndexRow;
 
+/// Max jobs drained from the queue in a single `run_sync_tick_internal` call, so
+/// one tick makes real progress on large backlogs instead of processing exactly
+/// one job every 60s (see DBSYNC-10).
+const SYNC_BATCH_CAP: usize = 50;
+
 pub(crate) fn refresh_queue_depth_internal(state: &AppState) -> Result<(), String> {
     let queue_depth = state.db.count_active_jobs()?;
 
@@ -240,11 +245,165 @@ pub(crate) fn process_sync_queue_internal(state: &AppState) -> Result<bool, Stri
 
 pub(crate) fn run_sync_tick_internal(state: &AppState) -> Result<SyncTickResult, String> {
     let enqueued_jobs = scan_local_changes_internal(state)?;
-    let processed_job = process_sync_queue_internal(state)?;
+
+    // Drain up to `SYNC_BATCH_CAP` due jobs in this tick instead of exactly one,
+    // so large backlogs make real progress every 60s. Mirrors the drain loop in
+    // `open_handlers::spawn_drain_sync_queue_if_idle`: `Ok(true)` keeps draining,
+    // `Ok(false)` means the queue is empty (or nothing is due yet). Per-job
+    // failures are handled inside `process_sync_queue_internal` (marked
+    // retry_wait/failed, still `Ok(true)`); an `Err(_)` here is an infra/DB
+    // error, so we stop this tick's drain and let the next tick retry, without
+    // aborting the tick itself.
+    let mut processed_job = false;
+    for _ in 0..SYNC_BATCH_CAP {
+        match process_sync_queue_internal(state) {
+            Ok(true) => processed_job = true,
+            Ok(false) => break,
+            Err(e) => {
+                eprintln!("process_sync_queue (sync tick): {e}");
+                break;
+            }
+        }
+    }
+
     let scanned_files = state.db.list_local_files()?.len();
     Ok(SyncTickResult {
         scanned_files,
         enqueued_jobs,
         processed_job,
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::{Arc, Mutex};
+
+    use chrono::{Duration, Utc};
+    use tempfile::tempdir;
+
+    use super::{run_sync_tick_internal, SYNC_BATCH_CAP};
+    use crate::state::AppState;
+    use crate::storage::db::Db;
+    use crate::storage::secure_store::SecureStore;
+    use crate::sync::engine::SyncEngine;
+
+    /// Builds an `AppState` backed by an isolated temp DB, with `sync_folder`
+    /// pointed at a separate, empty temp directory (kept apart from the DB file
+    /// itself, so `scan_local_changes_internal`'s directory walk never picks up
+    /// the SQLite file as a "local change"). Using only "local_delete" jobs
+    /// targeting non-existent relative paths keeps these tests free of any
+    /// Dropbox network I/O: `delete_local_file_internal` no-ops when the local
+    /// file is absent, and `refresh_remote_index_and_enqueue_downloads_internal`
+    /// short-circuits (no network call) whenever `local_file_index` is empty,
+    /// which it stays here since we enqueue jobs directly instead of going
+    /// through the local file scan.
+    fn build_state(root: &std::path::Path) -> AppState {
+        let sync_folder = root.join("synced");
+        std::fs::create_dir_all(&sync_folder).expect("create sync folder");
+        let db_path = root.join("db").join("app.db");
+        std::fs::create_dir_all(db_path.parent().unwrap()).expect("create db dir");
+        let db = Db::new_at(&db_path).expect("db init");
+        db.set_sync_folder(&sync_folder.to_string_lossy())
+            .expect("set sync folder");
+        AppState {
+            secure_store: SecureStore::new(),
+            db: Arc::new(db),
+            sync_engine: Arc::new(Mutex::new(SyncEngine::new())),
+            token_cache: Arc::new(Mutex::new(None)),
+            scheduler_started: Arc::new(Mutex::new(false)),
+            oauth_listener: Arc::new(Mutex::new(None)),
+        }
+    }
+
+    #[test]
+    fn drains_multiple_jobs_up_to_batch_cap_in_one_tick() {
+        let tmp = tempdir().expect("tempdir");
+        let state = build_state(tmp.path());
+
+        let total_jobs = SYNC_BATCH_CAP + 15;
+        for i in 0..total_jobs {
+            state
+                .db
+                .enqueue_job(
+                    "local_delete",
+                    Some(&format!("job-{i}.txt")),
+                    Some(&format!("job-{i}.txt")),
+                )
+                .expect("enqueue");
+        }
+
+        let result = run_sync_tick_internal(&state).expect("tick");
+
+        assert!(
+            result.processed_job,
+            "expected at least one job processed this tick"
+        );
+
+        let remaining = state.db.count_active_jobs().expect("count active");
+        assert_eq!(
+            remaining,
+            total_jobs - SYNC_BATCH_CAP,
+            "tick should drain exactly SYNC_BATCH_CAP jobs, leaving the rest queued"
+        );
+
+        let done_jobs = state
+            .db
+            .list_recent_jobs((total_jobs + 1) as i64)
+            .expect("list jobs")
+            .into_iter()
+            .filter(|j| j.status == "done")
+            .count();
+        assert_eq!(
+            done_jobs, SYNC_BATCH_CAP,
+            "batch cap must not be exceeded within a single tick"
+        );
+    }
+
+    #[test]
+    fn empty_queue_tick_processes_nothing() {
+        let tmp = tempdir().expect("tempdir");
+        let state = build_state(tmp.path());
+
+        let result = run_sync_tick_internal(&state).expect("tick");
+
+        assert!(!result.processed_job);
+        assert_eq!(result.enqueued_jobs, 0);
+        assert_eq!(state.db.count_active_jobs().expect("count active"), 0);
+    }
+
+    #[test]
+    fn retry_wait_job_with_future_retry_time_is_not_processed_this_tick() {
+        let tmp = tempdir().expect("tempdir");
+        let state = build_state(tmp.path());
+
+        state
+            .db
+            .enqueue_job("local_delete", Some("future.txt"), Some("future.txt"))
+            .expect("enqueue");
+
+        // Move the job into `retry_wait` with a `next_retry_at` far in the future,
+        // simulating a job that failed once and is backing off.
+        let job = state
+            .db
+            .pick_next_due_job()
+            .expect("pick job")
+            .expect("job present");
+        let future_retry_at = (Utc::now() + Duration::seconds(3600)).to_rfc3339();
+        state
+            .db
+            .mark_job_retry_wait(job.id, 1, &future_retry_at, Some("simulated failure"))
+            .expect("mark retry_wait");
+
+        let result = run_sync_tick_internal(&state).expect("tick");
+
+        assert!(
+            !result.processed_job,
+            "a retry_wait job whose next_retry_at is in the future must not run this tick"
+        );
+        assert_eq!(
+            state.db.count_active_jobs().expect("count active"),
+            1,
+            "the future retry_wait job should remain queued/pending, untouched"
+        );
+    }
 }


### PR DESCRIPTION
## Summary
- `run_sync_tick_internal` now drains up to `SYNC_BATCH_CAP` (50) due jobs per 60s tick instead of exactly one, via a bounded loop mirroring `open_handlers::spawn_drain_sync_queue_if_idle`.
- The `sync_tick` IPC command was collapsed to delegate to the same shared implementation, so both tick entry points batch (previously it was a hand-copied duplicate still draining 1 job/call).
- Fixes a backlog that took 8+ hours to drain 500 pending files.

## Stack
desktop-tauri

## Jira Ticket
#DBSYNC-10

## Design notes
- `pick_next_due_job` already claims jobs atomically under the DB write lock; the loop adds no new shared state.
- Per-job failures stay inside `process_sync_queue_internal` (marked `retry_wait`/`failed`, still `Ok(true)`); an `Err(_)` is an infra/DB error → break the drain, let the next tick retry, without aborting the tick.
- Scheduler thread and the `sync_running` guard are intentionally untouched (TOCTOU race is DBSYNC-13). Batch cap is a compile-time const (no config, YAGNI).

## Test Plan
- [x] Automated tests pass (`cargo test` — 11/11)
- [x] Lint clean on touched files (`cargo clippy` — no new warnings from `sync_pipeline.rs`/`commands.rs`; 4 pre-existing warnings elsewhere are unrelated)

### Stack-specific validation (desktop-tauri)
- New unit tests exercise: batch-cap enforcement (drains exactly 50 of 65 queued, leaves 15), empty-queue tick (`processed_job == false`), and a `retry_wait` job with a future `next_retry_at` not re-processed in the same tick.
- Deferred to manual QA: real upload/download/delete jobs round-tripping through the Dropbox API within a batched tick, and the 60s scheduler thread invoking the batched tick in production (thread intentionally unchanged).

🤖 Generated with Claude Code