### PR TITLE
feat(#DBSYNC-11): stream large-file upload/download to fix OOM

### DIFF
--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -934,6 +934,7 @@ dependencies = [
  "url",
  "urlencoding",
  "walkdir",
+ "windows-sys 0.59.0",
  "winreg",
 ]
 

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -35,3 +35,4 @@ tempfile = "3"
 
 [target.'cfg(windows)'.dependencies]
 winreg = "0.55"
+windows-sys = { version = "0.59", features = ["Win32_Storage_FileSystem"] }

--- a/apps/desktop/src-tauri/src/dropbox_transfer.rs
+++ b/apps/desktop/src-tauri/src/dropbox_transfer.rs
@@ -1,18 +1,139 @@
 use std::collections::HashMap;
-use std::fs;
-use std::path::PathBuf;
+use std::fs::{self, File};
+use std::io;
+use std::io::Read;
+use std::path::{Path, PathBuf};
 
-use reqwest::blocking::Client;
+use reqwest::blocking::{Body, Client};
+use tauri::{Emitter, EventTarget};
 
 use crate::auth_session::get_access_token;
 use crate::models::{
-    DropboxListFolderResponse, ListRemoteFolderResponse, RemoteEntry,
+    DropboxListFolderResponse, ListRemoteFolderResponse, RemoteEntry, UploadProgressEvent,
+    UploadSessionStartResponse,
 };
 use crate::path_util::{
     hash_file, is_path_allowed, normalize_dropbox_path, parse_prefix_csv,
 };
 use crate::state::AppState;
 use crate::storage::db::FileIndexRow;
+
+/// Atomically replaces `target` with the contents of `temp`, which must live in
+/// the same directory as `target` so the replace is a single filesystem
+/// metadata update rather than a cross-volume copy.
+#[cfg(windows)]
+fn atomic_replace(temp: &Path, target: &Path) -> Result<(), String> {
+    use std::os::windows::ffi::OsStrExt;
+
+    use windows_sys::Win32::Storage::FileSystem::{MoveFileExW, MOVEFILE_REPLACE_EXISTING};
+
+    let temp_wide: Vec<u16> = temp
+        .as_os_str()
+        .encode_wide()
+        .chain(std::iter::once(0))
+        .collect();
+    let target_wide: Vec<u16> = target
+        .as_os_str()
+        .encode_wide()
+        .chain(std::iter::once(0))
+        .collect();
+
+    // SAFETY: `temp_wide` and `target_wide` are valid, NUL-terminated UTF-16
+    // buffers (LPCWSTR) owned by this function and kept alive for the
+    // duration of the call; `MoveFileExW` only reads them and does not retain
+    // the pointers past its return.
+    let ok = unsafe {
+        MoveFileExW(
+            temp_wide.as_ptr(),
+            target_wide.as_ptr(),
+            MOVEFILE_REPLACE_EXISTING,
+        )
+    };
+
+    if ok == 0 {
+        return Err(format!(
+            "atomic replace failed ({} -> {}): {}",
+            temp.display(),
+            target.display(),
+            io::Error::last_os_error()
+        ));
+    }
+
+    Ok(())
+}
+
+/// Atomically replaces `target` with the contents of `temp` (same-directory rename).
+#[cfg(not(windows))]
+fn atomic_replace(temp: &Path, target: &Path) -> Result<(), String> {
+    fs::rename(temp, target).map_err(|e| {
+        format!(
+            "atomic replace failed ({} -> {}): {e}",
+            temp.display(),
+            target.display()
+        )
+    })
+}
+
+/// Downloads `path_display` from Dropbox and writes it to `target` without
+/// buffering the whole response body in memory: the body is streamed straight
+/// to a same-directory temp file, which is then atomically renamed onto
+/// `target` so a crash or interruption mid-download never leaves `target`
+/// truncated or corrupted.
+fn fetch_and_write_file(
+    client: &Client,
+    token: &str,
+    path_display: &str,
+    target: &Path,
+) -> Result<(), String> {
+    if let Some(parent) = target.parent() {
+        fs::create_dir_all(parent)
+            .map_err(|e| format!("failed to create parent directory: {e}"))?;
+    }
+
+    let file_name = target.file_name().map(|n| n.to_string_lossy().to_string()).unwrap_or_default();
+    let temp = target.with_file_name(format!(
+        "{file_name}.dropboxsync-tmp-{}-{}",
+        std::process::id(),
+        rand::random::<u64>()
+    ));
+
+    let mut download_resp = client
+        .post("https://content.dropboxapi.com/2/files/download")
+        .bearer_auth(token)
+        .header(
+            "Dropbox-API-Arg",
+            serde_json::json!({ "path": path_display }).to_string(),
+        )
+        .send()
+        .map_err(|e| format!("download request failed: {e}"))?;
+
+    if !download_resp.status().is_success() {
+        let status = download_resp.status();
+        let body = download_resp.text().unwrap_or_else(|_| "<unreadable body>".to_string());
+        return Err(format!(
+            "download status error for {path_display}: {status}; body: {body}"
+        ));
+    }
+
+    let write_result = File::create(&temp)
+        .map_err(|e| format!("failed creating temp file: {e}"))
+        .and_then(|mut tmp_file| {
+            io::copy(&mut download_resp, &mut tmp_file)
+                .map_err(|e| format!("failed writing local file: {e}"))
+        });
+
+    if let Err(e) = write_result {
+        let _ = fs::remove_file(&temp);
+        return Err(e);
+    }
+
+    if let Err(e) = atomic_replace(&temp, target) {
+        let _ = fs::remove_file(&temp);
+        return Err(e);
+    }
+
+    Ok(())
+}
 
 pub(crate) fn list_remote_folder(
     state: &AppState,
@@ -77,6 +198,221 @@ pub(crate) fn list_remote_folder(
     })
 }
 
+/// Size threshold above which uploads should switch from a single-shot
+/// request to a chunked upload session (wired in a later slice). Dropbox
+/// itself caps single-request uploads at 150 MiB.
+const UPLOAD_SESSION_THRESHOLD_BYTES: u64 = 150 * 1024 * 1024;
+
+/// Chunk size used when streaming a file through the Dropbox upload-session
+/// API (`upload_session/start` + `append_v2` + `finish`). Chosen to bound
+/// peak memory usage regardless of file size.
+const UPLOAD_CHUNK_SIZE: usize = 8 * 1024 * 1024;
+
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) enum UploadStrategy {
+    SingleShot,
+    Session,
+}
+
+/// Pure routing helper: decides which upload strategy a file of `size_bytes`
+/// should use.
+pub(crate) fn choose_upload_strategy(size_bytes: u64) -> UploadStrategy {
+    if size_bytes >= UPLOAD_SESSION_THRESHOLD_BYTES {
+        UploadStrategy::Session
+    } else {
+        UploadStrategy::SingleShot
+    }
+}
+
+/// Starts a new Dropbox upload session and returns its `session_id`.
+fn start_upload_session(client: &Client, token: &str) -> Result<String, String> {
+    let resp = client
+        .post("https://content.dropboxapi.com/2/files/upload_session/start")
+        .bearer_auth(token)
+        .header("Dropbox-API-Arg", serde_json::json!({ "close": false }).to_string())
+        .header("Content-Type", "application/octet-stream")
+        .body(Vec::<u8>::new())
+        .send()
+        .map_err(|e| format!("upload_session/start request failed: {e}"))?;
+
+    if !resp.status().is_success() {
+        let status = resp.status();
+        let body = resp.text().unwrap_or_else(|_| "<unreadable body>".to_string());
+        return Err(format!(
+            "upload_session/start status error: {status}; body: {body}"
+        ));
+    }
+
+    let parsed: UploadSessionStartResponse = resp
+        .json()
+        .map_err(|e| format!("upload_session/start parse failed: {e}"))?;
+
+    Ok(parsed.session_id)
+}
+
+/// Appends one chunk of data to an in-progress upload session at `offset`.
+fn append_upload_chunk(
+    client: &Client,
+    token: &str,
+    session_id: &str,
+    offset: u64,
+    chunk: &[u8],
+) -> Result<(), String> {
+    let resp = client
+        .post("https://content.dropboxapi.com/2/files/upload_session/append_v2")
+        .bearer_auth(token)
+        .header(
+            "Dropbox-API-Arg",
+            serde_json::json!({
+                "cursor": { "session_id": session_id, "offset": offset },
+                "close": false
+            })
+            .to_string(),
+        )
+        .header("Content-Type", "application/octet-stream")
+        .body(chunk.to_vec())
+        .send()
+        .map_err(|e| format!("upload_session/append_v2 request failed: {e}"))?;
+
+    if !resp.status().is_success() {
+        let status = resp.status();
+        let body = resp.text().unwrap_or_else(|_| "<unreadable body>".to_string());
+        return Err(format!(
+            "upload_session/append_v2 status error: {status}; body: {body}"
+        ));
+    }
+
+    Ok(())
+}
+
+/// Finishes an upload session, committing the accumulated bytes plus
+/// `last_chunk` to `dropbox_path` (overwrite mode).
+fn finish_upload_session(
+    client: &Client,
+    token: &str,
+    session_id: &str,
+    offset: u64,
+    dropbox_path: &str,
+    last_chunk: &[u8],
+) -> Result<(), String> {
+    let resp = client
+        .post("https://content.dropboxapi.com/2/files/upload_session/finish")
+        .bearer_auth(token)
+        .header(
+            "Dropbox-API-Arg",
+            serde_json::json!({
+                "cursor": { "session_id": session_id, "offset": offset },
+                "commit": {
+                    "path": dropbox_path,
+                    "mode": { ".tag": "overwrite" }
+                }
+            })
+            .to_string(),
+        )
+        .header("Content-Type", "application/octet-stream")
+        .body(last_chunk.to_vec())
+        .send()
+        .map_err(|e| format!("upload_session/finish request failed: {e}"))?;
+
+    if !resp.status().is_success() {
+        let status = resp.status();
+        let body = resp.text().unwrap_or_else(|_| "<unreadable body>".to_string());
+        return Err(format!(
+            "upload_session/finish status error: {status}; body: {body}"
+        ));
+    }
+
+    Ok(())
+}
+
+/// Pure boundary check: is the chunk just read (`bytes_read` bytes, starting
+/// at `offset`) the last one for a file of `total_len` bytes? Also treats an
+/// overshoot (`offset + bytes_read > total_len`) as final, defensively.
+fn is_final_chunk(offset: u64, bytes_read: usize, total_len: u64) -> bool {
+    offset + bytes_read as u64 >= total_len
+}
+
+/// Emits an `upload-progress` event to the main webview, if an `AppHandle` has been set
+/// on `state::APP_HANDLE` (see its doc comment). No-ops silently when no handle is set
+/// yet, which keeps offline unit tests (which never call `setup()`) window/handle-free.
+fn emit_upload_progress(path: &str, transferred: u64, total: u64) {
+    let Some(handle) = crate::state::APP_HANDLE.get() else {
+        return;
+    };
+
+    let event = UploadProgressEvent {
+        path: path.to_string(),
+        transferred,
+        total,
+    };
+
+    match handle.emit_to(EventTarget::webview_window("main"), "upload-progress", event.clone()) {
+        Ok(()) => {}
+        Err(e) => {
+            eprintln!("emit_to webview_window(main): {e}");
+            if let Err(e2) = handle.emit("upload-progress", event) {
+                eprintln!("emit global upload-progress: {e2}");
+            }
+        }
+    }
+}
+
+/// Uploads `file` (of `len` bytes) to `dropbox_path` via the Dropbox chunked
+/// upload-session API, reading and sending at most `UPLOAD_CHUNK_SIZE` bytes
+/// at a time so peak memory stays bounded regardless of file size.
+///
+/// The upload is a point-in-time snapshot of `len` bytes: `len` is captured
+/// once by the caller. If the file is truncated concurrently, EOF is reached
+/// before `offset` hits `len` and the session is finished with whatever bytes
+/// were read (never a busy-loop). Concurrent growth beyond `len` is ignored.
+fn upload_via_session(
+    token: &str,
+    mut file: File,
+    len: u64,
+    dropbox_path: &str,
+) -> Result<(), String> {
+    let client = Client::new();
+    let session_id = start_upload_session(&client, token)?;
+
+    let mut buf = vec![0u8; UPLOAD_CHUNK_SIZE];
+    let mut offset: u64 = 0;
+
+    loop {
+        let mut n = 0usize;
+        while n < buf.len() {
+            let read = file
+                .read(&mut buf[n..])
+                .map_err(|e| format!("failed reading local file for upload: {e}"))?;
+            if read == 0 {
+                break;
+            }
+            n += read;
+        }
+
+        // Premature EOF (file shrank since `len` was read): finishing here
+        // avoids an infinite loop of empty `append_v2` calls when `offset < len`.
+        // When `is_final_chunk` is already true this is a no-op distinction.
+        if n == 0 && !is_final_chunk(offset, n, len) {
+            finish_upload_session(&client, token, &session_id, offset, dropbox_path, &[])?;
+            emit_upload_progress(dropbox_path, offset, len);
+            break;
+        }
+
+        if is_final_chunk(offset, n, len) {
+            finish_upload_session(&client, token, &session_id, offset, dropbox_path, &buf[..n])?;
+            offset += n as u64;
+            emit_upload_progress(dropbox_path, offset, len);
+            break;
+        } else {
+            append_upload_chunk(&client, token, &session_id, offset, &buf[..n])?;
+            offset += n as u64;
+            emit_upload_progress(dropbox_path, offset, len);
+        }
+    }
+
+    Ok(())
+}
+
 pub(crate) fn upload_local_file_internal(state: &AppState, relative: &str) -> Result<(), String> {
     if relative.ends_with(".cloudsc") {
         return Ok(());
@@ -110,33 +446,45 @@ pub(crate) fn upload_local_file_internal(state: &AppState, relative: &str) -> Re
         }
     }
 
-    let bytes = fs::read(&local_path)
-        .map_err(|e| format!("failed reading local file bytes for upload: {e}"))?;
+    let file = File::open(&local_path)
+        .map_err(|e| format!("failed opening local file for upload: {e}"))?;
+    let len = file
+        .metadata()
+        .map_err(|e| format!("failed reading local file metadata: {e}"))?
+        .len();
 
     let dropbox_path = normalize_dropbox_path(relative);
-    let client = Client::new();
-    let resp = client
-        .post("https://content.dropboxapi.com/2/files/upload")
-        .bearer_auth(&token)
-        .header(
-            "Dropbox-API-Arg",
-            serde_json::json!({
-                "path": dropbox_path,
-                "mode": { ".tag": "overwrite" }
-            })
-            .to_string(),
-        )
-        .header("Content-Type", "application/octet-stream")
-        .body(bytes)
-        .send()
-        .map_err(|e| format!("upload request failed: {e}"))?;
 
-    if !resp.status().is_success() {
-        let status = resp.status();
-        let body = resp.text().unwrap_or_else(|_| "<unreadable body>".to_string());
-        return Err(format!(
-            "upload status error for {dropbox_path}: {status}; body: {body}"
-        ));
+    match choose_upload_strategy(len) {
+        UploadStrategy::SingleShot => {
+            let client = Client::new();
+            let resp = client
+                .post("https://content.dropboxapi.com/2/files/upload")
+                .bearer_auth(&token)
+                .header(
+                    "Dropbox-API-Arg",
+                    serde_json::json!({
+                        "path": dropbox_path,
+                        "mode": { ".tag": "overwrite" }
+                    })
+                    .to_string(),
+                )
+                .header("Content-Type", "application/octet-stream")
+                .body(Body::sized(file, len))
+                .send()
+                .map_err(|e| format!("upload request failed: {e}"))?;
+
+            if !resp.status().is_success() {
+                let status = resp.status();
+                let body = resp.text().unwrap_or_else(|_| "<unreadable body>".to_string());
+                return Err(format!(
+                    "upload status error for {dropbox_path}: {status}; body: {body}"
+                ));
+            }
+        }
+        UploadStrategy::Session => {
+            upload_via_session(&token, file, len, &dropbox_path)?;
+        }
     }
 
     Ok(())
@@ -203,36 +551,9 @@ pub(crate) fn download_remote_file_internal(state: &AppState, path_display: &str
         return Ok(());
     }
 
-    let client = Client::new();
-    let download_resp = client
-        .post("https://content.dropboxapi.com/2/files/download")
-        .bearer_auth(&token)
-        .header(
-            "Dropbox-API-Arg",
-            serde_json::json!({ "path": path_display }).to_string(),
-        )
-        .send()
-        .map_err(|e| format!("download request failed: {e}"))?;
-
-    if !download_resp.status().is_success() {
-        let status = download_resp.status();
-        let body = download_resp.text().unwrap_or_else(|_| "<unreadable body>".to_string());
-        return Err(format!(
-            "download status error for {path_display}: {status}; body: {body}"
-        ));
-    }
-
-    let bytes = download_resp
-        .bytes()
-        .map_err(|e| format!("download bytes failed: {e}"))?;
-
     let target = PathBuf::from(&folder).join(&relative);
-    if let Some(parent) = target.parent() {
-        fs::create_dir_all(parent)
-            .map_err(|e| format!("failed to create parent directory: {e}"))?;
-    }
+    fetch_and_write_file(&Client::new(), &token, path_display, &target)?;
 
-    fs::write(&target, &bytes).map_err(|e| format!("failed writing local file: {e}"))?;
     let (hash, size_bytes, modified_ts) = hash_file(&target)?;
     state
         .db
@@ -295,33 +616,8 @@ pub(crate) fn hydrate_remote_folder_internal(
             }
 
             let target = PathBuf::from(&folder).join(&relative);
-            if let Some(parent) = target.parent() {
-                fs::create_dir_all(parent)
-                    .map_err(|e| format!("failed to create parent directory: {e}"))?;
-            }
+            fetch_and_write_file(&client, &token, path_display, &target)?;
 
-            let download_resp = client
-                .post("https://content.dropboxapi.com/2/files/download")
-                .bearer_auth(&token)
-                .header(
-                    "Dropbox-API-Arg",
-                    serde_json::json!({ "path": path_display }).to_string(),
-                )
-                .send()
-                .map_err(|e| format!("download request failed: {e}"))?;
-
-            if !download_resp.status().is_success() {
-                let status = download_resp.status();
-                let body = download_resp.text().unwrap_or_else(|_| "<unreadable body>".to_string());
-                return Err(format!(
-                    "download status error for {path_display}: {status}; body: {body}"
-                ));
-            }
-
-            let bytes = download_resp
-                .bytes()
-                .map_err(|e| format!("download bytes failed: {e}"))?;
-            fs::write(&target, &bytes).map_err(|e| format!("failed writing local file: {e}"))?;
             let (hash, size_bytes, modified_ts) = hash_file(&target)?;
             state.db.upsert_local_file(&relative, &hash, size_bytes, modified_ts)?;
             downloaded += 1;
@@ -397,36 +693,12 @@ pub(crate) fn pull_remote_snapshot_internal(state: &AppState) -> Result<usize, S
 
             let relative = path_display.trim_start_matches('/').to_string();
             let target = PathBuf::from(&folder).join(&relative);
-            if let Some(parent) = target.parent() {
-                fs::create_dir_all(parent)
-                    .map_err(|e| format!("failed to create parent directory: {e}"))?;
-            }
 
             if known_map.contains_key(&relative) && target.exists() {
                 continue;
             }
 
-            let download_resp = client
-                .post("https://content.dropboxapi.com/2/files/download")
-                .bearer_auth(&token)
-                .header(
-                    "Dropbox-API-Arg",
-                    serde_json::json!({ "path": path_display }).to_string(),
-                )
-                .send()
-                .map_err(|e| format!("download request failed: {e}"))?;
-            if !download_resp.status().is_success() {
-                let status = download_resp.status();
-                let body = download_resp.text().unwrap_or_else(|_| "<unreadable body>".to_string());
-                return Err(format!(
-                    "download status error for {path_display}: {status}; body: {body}"
-                ));
-            }
-            let bytes = download_resp
-                .bytes()
-                .map_err(|e| format!("download bytes failed: {e}"))?;
-
-            fs::write(&target, &bytes).map_err(|e| format!("failed writing local file: {e}"))?;
+            fetch_and_write_file(&client, &token, path_display, &target)?;
             let (hash, size_bytes, modified_ts) = hash_file(&target)?;
             state
                 .db
@@ -457,4 +729,141 @@ pub(crate) fn pull_remote_snapshot_internal(state: &AppState) -> Result<usize, S
     }
 
     Ok(downloaded)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        atomic_replace, choose_upload_strategy, emit_upload_progress, is_final_chunk,
+        UploadStrategy, UPLOAD_CHUNK_SIZE, UPLOAD_SESSION_THRESHOLD_BYTES,
+    };
+
+    // `fetch_and_write_file` performs live HTTP calls against the Dropbox API
+    // and is intentionally left to manual QA (large-file download against a
+    // real account, verifying flat memory usage and crash-safety).
+
+    // The streamed single-shot upload body (`Body::sized` over an open file
+    // handle) in `upload_local_file_internal` is likewise manual-QA-only: it
+    // needs a live Dropbox account to exercise, and this test module only
+    // covers the pure `choose_upload_strategy` routing helper below.
+
+    // `start_upload_session`, `append_upload_chunk`, `finish_upload_session`
+    // and `upload_via_session` all perform live HTTP calls against the
+    // Dropbox API and are manual-QA-only (real >150 MB file, verifying
+    // bounded memory usage and that a retry starts a fresh session). This
+    // module covers the pure `is_final_chunk` boundary-math helper instead.
+
+    #[test]
+    fn choose_upload_strategy_single_shot_for_small_sizes() {
+        assert_eq!(choose_upload_strategy(0), UploadStrategy::SingleShot);
+        assert_eq!(choose_upload_strategy(1), UploadStrategy::SingleShot);
+        assert_eq!(
+            choose_upload_strategy(UPLOAD_SESSION_THRESHOLD_BYTES - 1),
+            UploadStrategy::SingleShot
+        );
+    }
+
+    #[test]
+    fn choose_upload_strategy_session_at_and_above_threshold() {
+        assert_eq!(
+            choose_upload_strategy(UPLOAD_SESSION_THRESHOLD_BYTES),
+            UploadStrategy::Session
+        );
+        assert_eq!(
+            choose_upload_strategy(UPLOAD_SESSION_THRESHOLD_BYTES + 1),
+            UploadStrategy::Session
+        );
+        assert_eq!(
+            choose_upload_strategy(10 * 1024 * 1024 * 1024),
+            UploadStrategy::Session
+        );
+    }
+
+    #[test]
+    fn is_final_chunk_empty_file_is_final() {
+        assert!(is_final_chunk(0, 0, 0));
+    }
+
+    #[test]
+    fn is_final_chunk_mid_file_is_not_final() {
+        let chunk = UPLOAD_CHUNK_SIZE as u64;
+        // First chunk read in full, more than one chunk remains.
+        assert!(!is_final_chunk(0, UPLOAD_CHUNK_SIZE, 3 * chunk));
+    }
+
+    #[test]
+    fn is_final_chunk_not_final_when_bytes_remain_after_exact_chunk() {
+        let chunk = UPLOAD_CHUNK_SIZE as u64;
+        // offset + read lands exactly on a chunk boundary, but a further
+        // chunk still remains beyond it (3-chunk file, second chunk read).
+        assert!(!is_final_chunk(chunk, UPLOAD_CHUNK_SIZE, 3 * chunk));
+    }
+
+    #[test]
+    fn is_final_chunk_final_when_offset_plus_read_equals_total() {
+        let chunk = UPLOAD_CHUNK_SIZE as u64;
+        assert!(is_final_chunk(chunk, UPLOAD_CHUNK_SIZE, 2 * chunk));
+    }
+
+    #[test]
+    fn is_final_chunk_final_with_one_byte_remainder() {
+        // Total length is one byte more than an exact multiple of the chunk
+        // size, so the last read is a 1-byte chunk.
+        let chunk = UPLOAD_CHUNK_SIZE as u64;
+        assert!(is_final_chunk(chunk, 1, chunk + 1));
+    }
+
+    #[test]
+    fn is_final_chunk_treats_overshoot_as_final_defensively() {
+        assert!(is_final_chunk(10, 5, 12));
+    }
+
+    #[test]
+    fn premature_eof_guard_condition_detects_shrunk_file() {
+        // The session loop's premature-EOF guard fires when a read returns 0
+        // bytes (`n == 0`) while `offset < len` (file shrank mid-upload). This
+        // is what prevents the infinite empty-`append_v2` loop (DBSYNC-11 M1).
+        let (offset, n, len) = (16u64, 0usize, 24u64); // read 0 with 8 bytes still "expected"
+        assert!(n == 0 && !is_final_chunk(offset, n, len));
+        // At/after the expected end, a 0-byte read is a normal terminal finish,
+        // not the premature-EOF path.
+        assert!(is_final_chunk(24, 0, 24));
+    }
+
+    #[test]
+    fn atomic_replace_overwrites_existing_target() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let temp = dir.path().join("file.tmp");
+        let target = dir.path().join("file.txt");
+
+        std::fs::write(&temp, b"new").expect("write temp");
+        std::fs::write(&target, b"old").expect("write target");
+
+        atomic_replace(&temp, &target).expect("atomic_replace");
+
+        assert_eq!(std::fs::read(&target).expect("read target"), b"new");
+        assert!(!temp.exists(), "temp file should no longer exist");
+    }
+
+    #[test]
+    fn atomic_replace_creates_when_target_absent() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let temp = dir.path().join("file.tmp");
+        let target = dir.path().join("file.txt");
+
+        std::fs::write(&temp, b"contents").expect("write temp");
+        assert!(!target.exists());
+
+        atomic_replace(&temp, &target).expect("atomic_replace");
+
+        assert_eq!(std::fs::read(&target).expect("read target"), b"contents");
+        assert!(!temp.exists(), "temp file should no longer exist");
+    }
+
+    #[test]
+    fn emit_upload_progress_is_a_no_op_without_app_handle() {
+        // `state::APP_HANDLE` is unset in this offline test binary (`setup()` never
+        // runs), so this must not panic and must not attempt to emit anything.
+        emit_upload_progress("x/y.txt", 10, 20);
+    }
 }

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -155,6 +155,11 @@ pub fn run() {
                 crate::overlay_state::refresh_overlay_state_internal(state.inner());
             }
 
+            // Single set-once site for `state::APP_HANDLE`, read by
+            // `dropbox_transfer::emit_upload_progress` to emit `upload-progress` events
+            // from background sync work. Not duplicated in `start_background_scheduler`.
+            let _ = crate::state::APP_HANDLE.set(app.handle().clone());
+
             Ok(())
         })
         .invoke_handler(tauri::generate_handler![

--- a/apps/desktop/src-tauri/src/models.rs
+++ b/apps/desktop/src-tauri/src/models.rs
@@ -40,6 +40,11 @@ pub(crate) struct DropboxListFolderResponse {
 }
 
 #[derive(Deserialize)]
+pub(crate) struct UploadSessionStartResponse {
+    pub session_id: String,
+}
+
+#[derive(Deserialize)]
 pub(crate) struct DropboxEntry {
     #[serde(rename = ".tag")]
     pub tag: String,
@@ -88,6 +93,16 @@ pub(crate) struct DropboxOauthFinishedEvent {
     pub ok: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub message: Option<String>,
+}
+
+/// Emitted to the webview while `upload_via_session` streams a large file, so the UI can
+/// show progress without polling.
+#[derive(Serialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct UploadProgressEvent {
+    pub path: String,
+    pub transferred: u64,
+    pub total: u64,
 }
 
 #[derive(Serialize, Deserialize)]

--- a/apps/desktop/src-tauri/src/state.rs
+++ b/apps/desktop/src-tauri/src/state.rs
@@ -1,6 +1,8 @@
 use std::sync::atomic::AtomicBool;
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Mutex, OnceLock};
 use std::thread::JoinHandle;
+
+use tauri::AppHandle;
 
 use crate::storage::db::Db;
 use crate::storage::secure_store::SecureStore;
@@ -21,3 +23,19 @@ pub(crate) struct AppState {
     pub scheduler_started: Arc<Mutex<bool>>,
     pub oauth_listener: Arc<Mutex<Option<OauthListenerControl>>>,
 }
+
+/// Set once in `setup()` after the Tauri `AppHandle` becomes available; read by
+/// `dropbox_transfer::emit_upload_progress` to push `upload-progress` events to the
+/// webview during large-file uploads. Unset (`None`) in unit tests, which never call
+/// `setup()`, so progress emission no-ops safely offline.
+///
+/// This is intentionally a free-standing static rather than an `AppState` field.
+/// Empirically, storing `tauri::AppHandle` as an `AppState` field — even wrapped in
+/// `Arc<Mutex<Option<AppHandle>>>` or `Arc<OnceLock<AppHandle>>`, and even though the
+/// value is never populated or read in tests — makes the `cargo test` unit-test binary
+/// crash on startup with `STATUS_ENTRYPOINT_NOT_FOUND` (0xC0000139) on this toolchain
+/// (rustc 1.94.1, tauri 2.10.3, Windows). Confirmed by bisection: swapping the field's
+/// type to `String` (or dropping it) makes the crash disappear; moving the exact same
+/// `AppHandle` value to this module-level `static` also makes it disappear, while
+/// preserving the same "single set-once site" semantics.
+pub(crate) static APP_HANDLE: OnceLock<AppHandle> = OnceLock::new();

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -267,6 +267,29 @@ function App() {
     };
   }, []);
 
+  // Rust emits `upload-progress` while streaming a large file through the chunked
+  // upload-session API, so the log shows liveness for uploads that take a while.
+  useEffect(() => {
+    let active = true;
+    let unlisten: (() => void) | undefined;
+
+    void listen<{ path: string; transferred: number; total: number }>("upload-progress", (event) => {
+      if (!active) return;
+      pushLog(`Uploading ${event.payload.path}: ${event.payload.transferred}/${event.payload.total} bytes`);
+    }).then((fn) => {
+      if (!active) {
+        fn();
+      } else {
+        unlisten = fn;
+      }
+    });
+
+    return () => {
+      active = false;
+      unlisten?.();
+    };
+  }, []);
+
   // Fallback while waiting: slow poll (WebView often throttles `setInterval` when the browser has focus).
   useEffect(() => {
     if (!awaitingCallback) return;


### PR DESCRIPTION
## Summary
Fixes OOM on large-file transfers by converting the transfer layer to constant-memory streaming, and makes downloads crash-safe. Delivered as 4 vertical slices (S1∥S2 → S3 → S4).

- **S1 — Download streaming + atomic replace:** `fetch_and_write_file` streams the response via `std::io::copy` into a same-directory temp file, then atomically replaces the target (Windows `MoveFileExW(MOVEFILE_REPLACE_EXISTING)` via `windows-sys` / POSIX `fs::rename`). One shared helper routes all 3 download call sites; no partial file ever appears at the final path.
- **S2 — Streaming upload <150MB:** replaced `fs::read` with `Body::sized(file, len)`; added a 150MB threshold const + pure `choose_upload_strategy`.
- **S3 — Chunked upload-session ≥150MB:** `start`/`append_v2`/`finish` with an 8MB reused buffer and advancing cursor offset; a premature-EOF guard prevents a busy-loop if the file is truncated mid-upload.
- **S4 — Upload progress:** emits `upload-progress {path,transferred,total}` from the session path via a set-once `static APP_HANDLE: OnceLock<AppHandle>`; minimal `App.tsx` listener.

## Stack
desktop-tauri

## Jira Ticket
#DBSYNC-11

## Design notes
- **No async migration, no new reqwest feature flags** — `reqwest::blocking::Response: Read` (download) and `Body::sized`/`From<Vec<u8>>` (upload) all work under the existing `blocking` feature. Only new dep: `windows-sys` (Windows-only, already present transitively via `winreg`).
- **AppHandle plumbing deviation (from planned D1):** storing `AppHandle` as a field on the `.manage()`-registered `AppState` crashed the test binary (`STATUS_ENTRYPOINT_NOT_FOUND`) on this toolchain (rustc 1.94.1 / tauri 2.10.3 / Windows). Switched to a module-level `static OnceLock<AppHandle>` set once in `setup()` — functionally equivalent, set-once, no-op when unset. Documented inline in `state.rs`.
- Scheduler thread and `sync_running` guard untouched. Upload-session resumability across retries is an explicit non-goal (a retry starts a fresh session).

## Test Plan
- [x] Automated tests pass — `cargo test` **23/23** (in `apps/desktop/src-tauri`)
- [x] Lint — `cargo clippy` clean on all changed files (4 pre-existing baseline warnings elsewhere, unrelated)
- [x] Frontend — `npm --workspace apps/desktop run build` OK

### Stack-specific validation (desktop-tauri)
Unit tests cover the pure logic: `atomic_replace` (overwrite existing + create-when-absent), `choose_upload_strategy` threshold routing, `is_final_chunk` boundaries (empty file, exact-multiple, remainder, overshoot), premature-EOF guard condition, and `emit_upload_progress` no-op when no AppHandle.

**Deferred to manual QA (needs a real >1GB file over live Dropbox — no HTTP mocking in the crate):**
- [ ] Upload & download a real >1GB file; confirm memory stays flat (RSS)
- [ ] Correct content hash after transfer; atomic overwrite of an existing target
- [ ] No partial/temp file left after a forced mid-transfer kill
- [ ] Visible `upload-progress` log lines during a large (>150MB) upload

🤖 Generated with Claude Code