### PR TITLE
fix(#DBSYNC-13): make sync gate and token refresh race-free

### DIFF
--- a/apps/desktop/src-tauri/src/auth_session.rs
+++ b/apps/desktop/src-tauri/src/auth_session.rs
@@ -1,3 +1,6 @@
+use std::sync::atomic::Ordering;
+use std::sync::{Arc, Mutex};
+
 use chrono::{Duration, Utc};
 use reqwest::blocking::Client;
 
@@ -34,47 +37,90 @@ fn session_needs_refresh(session: &TokenSession) -> bool {
     session.refresh_token.is_some()
 }
 
+/// Serializes concurrent token refreshes: only one caller runs `refresher` per
+/// staleness window; losers re-check the cache after acquiring the lock and reuse
+/// whatever the winner just stored, instead of racing Dropbox's token endpoint.
+///
+/// `force` skips the cache short-circuit: a forced refresh (401 recovery) must
+/// exchange the refresh token even when the cache holds a token that is still
+/// time-fresh but server-revoked. It still serializes on the refresh mutex, so
+/// concurrent forced refreshes never race Dropbox's endpoint (they run one at a
+/// time; a loser reading an already-rotated refresh token simply fails and the
+/// next tick reuses the winner's valid cached token).
+fn refresh_token_guarded(
+    token_cache: &Arc<Mutex<Option<TokenSession>>>,
+    token_refresh_lock: &Arc<Mutex<()>>,
+    force: bool,
+    refresher: impl FnOnce() -> Result<TokenSession, String>,
+) -> Result<TokenSession, String> {
+    // A `Mutex<()>` guards no invariant, so a prior panic while holding it cannot
+    // corrupt anything — recover from poison rather than permanently wedging every
+    // future refresh with "lock poisoned".
+    let _guard = token_refresh_lock
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+
+    // Double-check: a peer may have refreshed while we waited for the lock. Skipped
+    // for a forced refresh, which must not reuse a possibly-revoked cached token.
+    if !force {
+        if let Ok(cache) = token_cache.lock() {
+            if let Some(session) = cache.as_ref() {
+                if !session_needs_refresh(session) {
+                    return Ok(session.clone());
+                }
+            }
+        }
+    }
+
+    let session = refresher()?;
+
+    if let Ok(mut cache) = token_cache.lock() {
+        *cache = Some(session.clone());
+    }
+
+    Ok(session)
+}
+
 /// Clears the in-memory cache and performs a refresh using the session from the keychain.
 pub(crate) fn force_refresh_session(state: &AppState) -> Result<TokenSession, String> {
     if let Ok(mut c) = state.token_cache.lock() {
         *c = None;
     }
 
-    let mut session = state
+    let session = state
         .secure_store
         .get_session()
         .map_err(|_| "missing dropbox token session".to_string())?;
 
-    let Some(refresh_token) = session.refresh_token.as_deref() else {
+    let Some(refresh_token) = session.refresh_token.clone() else {
         return Err("dropbox token expired and no refresh_token available".to_string());
     };
 
-    let refreshed = refresh_access_token_blocking(refresh_token)?;
+    refresh_token_guarded(&state.token_cache, &state.token_refresh_lock, true, || {
+        let refreshed = refresh_access_token_blocking(&refresh_token)?;
 
-    let new_refresh_token = refreshed
-        .refresh_token
-        .or_else(|| session.refresh_token.clone());
+        let new_refresh_token = refreshed
+            .refresh_token
+            .clone()
+            .or_else(|| session.refresh_token.clone());
 
-    let new_expires_at = refreshed
-        .expires_in
-        .map(|in_s| (Utc::now() + Duration::seconds(in_s)).to_rfc3339());
+        let new_expires_at = refreshed
+            .expires_in
+            .map(|in_s| (Utc::now() + Duration::seconds(in_s)).to_rfc3339());
 
-    session = TokenSession {
-        access_token: refreshed.access_token,
-        refresh_token: new_refresh_token,
-        expires_at: new_expires_at.or_else(|| session.expires_at.clone()),
-    };
+        let new_session = TokenSession {
+            access_token: refreshed.access_token,
+            refresh_token: new_refresh_token,
+            expires_at: new_expires_at.or_else(|| session.expires_at.clone()),
+        };
 
-    state
-        .secure_store
-        .store_session(&session)
-        .map_err(|e| format!("failed storing refreshed token session: {e}"))?;
+        state
+            .secure_store
+            .store_session(&new_session)
+            .map_err(|e| format!("failed storing refreshed token session: {e}"))?;
 
-    if let Ok(mut cache) = state.token_cache.lock() {
-        *cache = Some(session.clone());
-    }
-
-    Ok(session)
+        Ok(new_session)
+    })
 }
 
 pub(crate) fn get_access_token(state: &AppState) -> Result<String, String> {
@@ -86,7 +132,7 @@ pub(crate) fn get_access_token(state: &AppState) -> Result<String, String> {
         }
     }
 
-    let mut session = match state.secure_store.get_session() {
+    let session = match state.secure_store.get_session() {
         Ok(s) => s,
         Err(_) => {
             let legacy_token = state
@@ -103,19 +149,31 @@ pub(crate) fn get_access_token(state: &AppState) -> Result<String, String> {
         }
     };
 
-    if session_needs_refresh(&session) {
-        if let Some(refresh_token) = session.refresh_token.as_deref() {
-            let refreshed = refresh_access_token_blocking(refresh_token)?;
+    if !session_needs_refresh(&session) {
+        if let Ok(mut cache) = state.token_cache.lock() {
+            *cache = Some(session.clone());
+        }
+        return Ok(session.access_token);
+    }
+
+    let Some(refresh_token) = session.refresh_token.clone() else {
+        return Err("dropbox token expired and no refresh_token available".to_string());
+    };
+
+    let refreshed_session =
+        refresh_token_guarded(&state.token_cache, &state.token_refresh_lock, false, || {
+            let refreshed = refresh_access_token_blocking(&refresh_token)?;
 
             let new_refresh_token = refreshed
                 .refresh_token
+                .clone()
                 .or_else(|| session.refresh_token.clone());
 
             let new_expires_at = refreshed
                 .expires_in
                 .map(|in_s| (Utc::now() + Duration::seconds(in_s)).to_rfc3339());
 
-            session = TokenSession {
+            let new_session = TokenSession {
                 access_token: refreshed.access_token,
                 refresh_token: new_refresh_token,
                 expires_at: new_expires_at.or_else(|| session.expires_at.clone()),
@@ -123,18 +181,13 @@ pub(crate) fn get_access_token(state: &AppState) -> Result<String, String> {
 
             state
                 .secure_store
-                .store_session(&session)
+                .store_session(&new_session)
                 .map_err(|e| format!("failed storing refreshed token session: {e}"))?;
-        } else {
-            return Err("dropbox token expired and no refresh_token available".to_string());
-        }
-    }
 
-    if let Ok(mut cache) = state.token_cache.lock() {
-        *cache = Some(session.clone());
-    }
+            Ok(new_session)
+        })?;
 
-    Ok(session.access_token)
+    Ok(refreshed_session.access_token)
 }
 
 pub(crate) fn verify_dropbox_token_internal(state: &AppState) -> Result<bool, String> {
@@ -185,11 +238,11 @@ pub(crate) fn verify_dropbox_token_internal(state: &AppState) -> Result<bool, St
 }
 
 pub(crate) fn current_tray_status_label(state: &AppState) -> String {
+    if state.sync_running.load(Ordering::Acquire) {
+        return "Syncing".to_string();
+    }
     if let Ok(engine) = state.sync_engine.lock() {
-        if engine.is_sync_running() {
-            return "Syncing".to_string();
-        }
-        if engine.current_status().last_error.is_some() {
+        if engine.current_status(false).last_error.is_some() {
             return "Error".to_string();
         }
     }
@@ -199,5 +252,63 @@ pub(crate) fn current_tray_status_label(state: &AppState) -> String {
 pub(crate) fn update_tray_tooltip(app: &tauri::AppHandle, label: &str) {
     if let Some(tray) = app.tray_by_id("main") {
         let _ = tray.set_tooltip(Some(format!("DropboxSyncDesktop - {label}")));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{refresh_token_guarded, TokenSession};
+    use chrono::{Duration, Utc};
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::{Arc, Mutex};
+
+    fn fresh_session() -> TokenSession {
+        TokenSession {
+            access_token: "canned-access-token".to_string(),
+            refresh_token: Some("canned-refresh-token".to_string()),
+            // Far in the future so `session_needs_refresh` returns false and the
+            // double-check reuses it instead of refreshing again.
+            expires_at: Some((Utc::now() + Duration::hours(1)).to_rfc3339()),
+        }
+    }
+
+    // Two threads both find the cache stale and race the guarded refresh; the
+    // dedicated lock + double-checked cache re-read must collapse them into a
+    // SINGLE invocation of the injected refresher (no concurrent Dropbox token
+    // exchange / refresh-token rotation).
+    #[test]
+    fn concurrent_refreshers_collapse_to_a_single_refresh() {
+        let cache: Arc<Mutex<Option<TokenSession>>> = Arc::new(Mutex::new(None));
+        let lock: Arc<Mutex<()>> = Arc::new(Mutex::new(()));
+        let calls = Arc::new(AtomicUsize::new(0));
+
+        let handles: Vec<_> = (0..4)
+            .map(|_| {
+                let cache = Arc::clone(&cache);
+                let lock = Arc::clone(&lock);
+                let calls = Arc::clone(&calls);
+                std::thread::spawn(move || {
+                    refresh_token_guarded(&cache, &lock, false, || {
+                        calls.fetch_add(1, Ordering::SeqCst);
+                        // Widen the race window so the peers reliably arrive
+                        // while the winner still holds the lock.
+                        std::thread::sleep(std::time::Duration::from_millis(20));
+                        Ok(fresh_session())
+                    })
+                })
+            })
+            .collect();
+
+        let results: Vec<_> = handles.into_iter().map(|h| h.join().unwrap()).collect();
+
+        assert_eq!(
+            calls.load(Ordering::SeqCst),
+            1,
+            "refresher must run exactly once across concurrent callers"
+        );
+        for r in results {
+            let session = r.expect("guarded refresh should succeed");
+            assert_eq!(session.access_token, "canned-access-token");
+        }
     }
 }

--- a/apps/desktop/src-tauri/src/commands.rs
+++ b/apps/desktop/src-tauri/src/commands.rs
@@ -1,4 +1,5 @@
 use std::fs;
+use std::sync::atomic::Ordering;
 use std::time::Duration as StdDuration;
 
 use chrono::Utc;
@@ -199,32 +200,25 @@ pub fn start_background_scheduler(
             .flatten()
             .map(|v| !v.trim().is_empty())
             .unwrap_or(false);
-        if ready {
-            let can_run = app_state
-                .sync_engine
-                .lock()
-                .map(|e| !e.is_sync_running())
-                .unwrap_or(false);
-            if can_run {
-                if let Ok(mut engine) = app_state.sync_engine.lock() {
-                    engine.set_sync_running(true);
-                }
-                // Run the sync tick first so a local folder deletion is detected,
-                // its `delete` job enqueued, and drained within this same tick
-                // (deleting the folder remotely) before discovery runs. Otherwise
-                // discovery would still see the (now-orphaned) remote folder and
-                // re-create its `.cloudsc` placeholder.
-                let _ = run_sync_tick_internal(&app_state);
-                match index_materialized_folders_as_cloudsc_placeholders_internal(&app_state) {
-                    Ok(n) if n > 0 => eprintln!("indexed {n} new remote placeholder(s)"),
-                    Ok(_) => {}
-                    Err(e) => eprintln!("remote placeholder indexing failed: {e}"),
-                }
-                if let Ok(mut engine) = app_state.sync_engine.lock() {
-                    engine.set_sync_running(false);
-                }
-                update_tray_tooltip(&app, &current_tray_status_label(&app_state));
+        if ready
+            && app_state
+                .sync_running
+                .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+                .is_ok()
+        {
+            // Run the sync tick first so a local folder deletion is detected,
+            // its `delete` job enqueued, and drained within this same tick
+            // (deleting the folder remotely) before discovery runs. Otherwise
+            // discovery would still see the (now-orphaned) remote folder and
+            // re-create its `.cloudsc` placeholder.
+            let _ = run_sync_tick_internal(&app_state);
+            match index_materialized_folders_as_cloudsc_placeholders_internal(&app_state) {
+                Ok(n) if n > 0 => eprintln!("indexed {n} new remote placeholder(s)"),
+                Ok(_) => {}
+                Err(e) => eprintln!("remote placeholder indexing failed: {e}"),
             }
+            app_state.sync_running.store(false, Ordering::Release);
+            update_tray_tooltip(&app, &current_tray_status_label(&app_state));
         }
         std::thread::sleep(StdDuration::from_secs(60));
     });
@@ -257,7 +251,7 @@ pub fn get_sync_status(state: tauri::State<AppState>) -> Result<SyncStatus, Stri
         .sync_engine
         .lock()
         .map_err(|_| "sync engine lock poisoned".to_string())?;
-    Ok(engine.current_status())
+    Ok(engine.current_status(state.sync_running.load(Ordering::Acquire)))
 }
 
 #[tauri::command]
@@ -270,7 +264,7 @@ pub fn get_sync_dashboard(state: tauri::State<AppState>) -> Result<SyncDashboard
         .sync_engine
         .lock()
         .map_err(|_| "sync engine lock poisoned".to_string())?
-        .current_status();
+        .current_status(state.sync_running.load(Ordering::Acquire));
 
     Ok(SyncDashboard {
         status,
@@ -306,15 +300,12 @@ pub fn sync_tick(state: tauri::State<AppState>) -> Result<SyncTickResult, String
 
 #[tauri::command]
 pub fn trigger_sync_tick(state: tauri::State<AppState>) -> Result<TriggerSyncResponse, String> {
+    if state
+        .sync_running
+        .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+        .is_err()
     {
-        let mut engine = state
-            .sync_engine
-            .lock()
-            .map_err(|_| "sync engine lock poisoned".to_string())?;
-        if engine.is_sync_running() {
-            return Ok(TriggerSyncResponse { accepted: false });
-        }
-        engine.set_sync_running(true);
+        return Ok(TriggerSyncResponse { accepted: false });
     }
 
     let app_state = state.inner().clone();
@@ -325,9 +316,7 @@ pub fn trigger_sync_tick(state: tauri::State<AppState>) -> Result<TriggerSyncRes
                 engine.set_last_error(format!("sync tick failed: {err}"));
             }
         }
-        if let Ok(mut engine) = app_state.sync_engine.lock() {
-            engine.set_sync_running(false);
-        }
+        app_state.sync_running.store(false, Ordering::Release);
     });
 
     Ok(TriggerSyncResponse { accepted: true })
@@ -361,15 +350,12 @@ pub fn trigger_hydrate_cloudsc_placeholder(
     state: tauri::State<AppState>,
     placeholder_local_rel_path: String,
 ) -> Result<TriggerActionResponse, String> {
+    if state
+        .sync_running
+        .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+        .is_err()
     {
-        let mut engine = state
-            .sync_engine
-            .lock()
-            .map_err(|_| "sync engine lock poisoned".to_string())?;
-        if engine.is_sync_running() {
-            return Ok(TriggerActionResponse { accepted: false });
-        }
-        engine.set_sync_running(true);
+        return Ok(TriggerActionResponse { accepted: false });
     }
 
     let app_state = state.inner().clone();
@@ -384,8 +370,8 @@ pub fn trigger_hydrate_cloudsc_placeholder(
         }
         if let Ok(mut engine) = app_state.sync_engine.lock() {
             engine.set_last_scan_at(Utc::now().to_rfc3339());
-            engine.set_sync_running(false);
         }
+        app_state.sync_running.store(false, Ordering::Release);
     });
 
     Ok(TriggerActionResponse { accepted: true })
@@ -396,15 +382,12 @@ pub fn trigger_download_remote_file(
     state: tauri::State<AppState>,
     path_display: String,
 ) -> Result<TriggerActionResponse, String> {
+    if state
+        .sync_running
+        .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+        .is_err()
     {
-        let mut engine = state
-            .sync_engine
-            .lock()
-            .map_err(|_| "sync engine lock poisoned".to_string())?;
-        if engine.is_sync_running() {
-            return Ok(TriggerActionResponse { accepted: false });
-        }
-        engine.set_sync_running(true);
+        return Ok(TriggerActionResponse { accepted: false });
     }
 
     let app_state = state.inner().clone();
@@ -417,8 +400,8 @@ pub fn trigger_download_remote_file(
         }
         if let Ok(mut engine) = app_state.sync_engine.lock() {
             engine.set_last_scan_at(Utc::now().to_rfc3339());
-            engine.set_sync_running(false);
         }
+        app_state.sync_running.store(false, Ordering::Release);
     });
 
     Ok(TriggerActionResponse { accepted: true })
@@ -429,15 +412,12 @@ pub fn trigger_hydrate_remote_folder(
     state: tauri::State<AppState>,
     folder_path_display: String,
 ) -> Result<TriggerActionResponse, String> {
+    if state
+        .sync_running
+        .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+        .is_err()
     {
-        let mut engine = state
-            .sync_engine
-            .lock()
-            .map_err(|_| "sync engine lock poisoned".to_string())?;
-        if engine.is_sync_running() {
-            return Ok(TriggerActionResponse { accepted: false });
-        }
-        engine.set_sync_running(true);
+        return Ok(TriggerActionResponse { accepted: false });
     }
 
     let app_state = state.inner().clone();
@@ -452,8 +432,8 @@ pub fn trigger_hydrate_remote_folder(
         }
         if let Ok(mut engine) = app_state.sync_engine.lock() {
             engine.set_last_scan_at(Utc::now().to_rfc3339());
-            engine.set_sync_running(false);
         }
+        app_state.sync_running.store(false, Ordering::Release);
     });
 
     Ok(TriggerActionResponse { accepted: true })

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -18,6 +18,7 @@ mod sync_pipeline;
 #[cfg(windows)]
 mod windows_file_assoc;
 
+use std::sync::atomic::AtomicBool;
 use std::sync::{Arc, Mutex};
 
 use state::AppState;
@@ -43,6 +44,8 @@ pub fn run() {
         token_cache: Arc::new(Mutex::new(None)),
         scheduler_started: Arc::new(Mutex::new(false)),
         oauth_listener: Arc::new(Mutex::new(None)),
+        sync_running: Arc::new(AtomicBool::new(false)),
+        token_refresh_lock: Arc::new(Mutex::new(())),
     };
 
     let mut builder = tauri::Builder::default()

--- a/apps/desktop/src-tauri/src/open_handlers.rs
+++ b/apps/desktop/src-tauri/src/open_handlers.rs
@@ -1,4 +1,5 @@
 use std::path::{Path, PathBuf};
+use std::sync::atomic::Ordering;
 
 use tauri::AppHandle;
 use tauri::Manager;
@@ -29,15 +30,12 @@ pub(crate) fn resolve_cloudsc_rel_path(state: &AppState, abs: &Path) -> Result<S
 
 pub(crate) fn spawn_drain_sync_queue_if_idle(app_state: AppState) {
     std::thread::spawn(move || {
+        if app_state
+            .sync_running
+            .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+            .is_err()
         {
-            let mut engine = match app_state.sync_engine.lock() {
-                Ok(e) => e,
-                Err(_) => return,
-            };
-            if engine.is_sync_running() {
-                return;
-            }
-            engine.set_sync_running(true);
+            return;
         }
         let mut safety = 0usize;
         while safety < 1000 {
@@ -51,9 +49,7 @@ pub(crate) fn spawn_drain_sync_queue_if_idle(app_state: AppState) {
                 }
             }
         }
-        if let Ok(mut engine) = app_state.sync_engine.lock() {
-            engine.set_sync_running(false);
-        }
+        app_state.sync_running.store(false, Ordering::Release);
     });
 }
 

--- a/apps/desktop/src-tauri/src/state.rs
+++ b/apps/desktop/src-tauri/src/state.rs
@@ -22,6 +22,13 @@ pub(crate) struct AppState {
     pub token_cache: Arc<Mutex<Option<crate::storage::secure_store::TokenSession>>>,
     pub scheduler_started: Arc<Mutex<bool>>,
     pub oauth_listener: Arc<Mutex<Option<OauthListenerControl>>>,
+    /// Lock-free single-flight gate for sync entry points (replaces the previous
+    /// mutex-guarded `bool` on `SyncEngine`, which allowed a TOCTOU window between
+    /// checking and setting the flag under two separate lock acquisitions).
+    pub sync_running: Arc<AtomicBool>,
+    /// Serializes concurrent access-token refreshes so only one caller ever hits
+    /// Dropbox's token endpoint per staleness window; see `auth_session::refresh_token_guarded`.
+    pub token_refresh_lock: Arc<Mutex<()>>,
 }
 
 /// Set once in `setup()` after the Tauri `AppHandle` becomes available; read by
@@ -39,3 +46,45 @@ pub(crate) struct AppState {
 /// `AppHandle` value to this module-level `static` also makes it disappear, while
 /// preserving the same "single set-once site" semantics.
 pub(crate) static APP_HANDLE: OnceLock<AppHandle> = OnceLock::new();
+
+#[cfg(test)]
+mod tests {
+    use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+    use std::sync::Arc;
+
+    /// Races N threads on a single `Arc<AtomicBool>` gate using the same
+    /// `compare_exchange` pattern used at every sync entry point; exactly one
+    /// thread must observe success.
+    #[test]
+    fn compare_exchange_gate_allows_exactly_one_winner() {
+        const N: usize = 16;
+        let flag = Arc::new(AtomicBool::new(false));
+        let successes = Arc::new(AtomicUsize::new(0));
+
+        let handles: Vec<_> = (0..N)
+            .map(|_| {
+                let flag = Arc::clone(&flag);
+                let successes = Arc::clone(&successes);
+                std::thread::spawn(move || {
+                    if flag
+                        .compare_exchange(
+                            false,
+                            true,
+                            Ordering::AcqRel,
+                            Ordering::Acquire,
+                        )
+                        .is_ok()
+                    {
+                        successes.fetch_add(1, Ordering::AcqRel);
+                    }
+                })
+            })
+            .collect();
+
+        for h in handles {
+            h.join().expect("thread panicked");
+        }
+
+        assert_eq!(successes.load(Ordering::Acquire), 1);
+    }
+}

--- a/apps/desktop/src-tauri/src/sync/engine.rs
+++ b/apps/desktop/src-tauri/src/sync/engine.rs
@@ -22,7 +22,6 @@ pub struct SyncEngine {
     last_scan_at: Option<String>,
     processed_jobs: usize,
     conflicts_detected: usize,
-    sync_running: bool,
 }
 
 impl SyncEngine {
@@ -36,7 +35,6 @@ impl SyncEngine {
             last_scan_at: None,
             processed_jobs: 0,
             conflicts_detected: 0,
-            sync_running: false,
         }
     }
 
@@ -87,15 +85,7 @@ impl SyncEngine {
         self.last_error = None;
     }
 
-    pub fn set_sync_running(&mut self, value: bool) {
-        self.sync_running = value;
-    }
-
-    pub fn is_sync_running(&self) -> bool {
-        self.sync_running
-    }
-
-    pub fn current_status(&self) -> SyncStatus {
+    pub fn current_status(&self, sync_running: bool) -> SyncStatus {
         SyncStatus {
             health: if self.last_error.is_some() {
                 "error".to_string()
@@ -110,7 +100,7 @@ impl SyncEngine {
             last_scan_at: self.last_scan_at.clone(),
             processed_jobs: self.processed_jobs,
             conflicts_detected: self.conflicts_detected,
-            sync_running: self.sync_running,
+            sync_running,
         }
     }
 }

--- a/apps/desktop/src-tauri/src/sync_pipeline.rs
+++ b/apps/desktop/src-tauri/src/sync_pipeline.rs
@@ -347,6 +347,7 @@ pub(crate) fn run_sync_tick_internal(state: &AppState) -> Result<SyncTickResult,
 
 #[cfg(test)]
 mod tests {
+    use std::sync::atomic::AtomicBool;
     use std::sync::{Arc, Mutex};
 
     use chrono::{Duration, Utc};
@@ -383,6 +384,8 @@ mod tests {
             token_cache: Arc::new(Mutex::new(None)),
             scheduler_started: Arc::new(Mutex::new(false)),
             oauth_listener: Arc::new(Mutex::new(None)),
+            sync_running: Arc::new(AtomicBool::new(false)),
+            token_refresh_lock: Arc::new(Mutex::new(())),
         }
     }
 


### PR DESCRIPTION
## Summary
Fixes two TOCTOU concurrency defects in the desktop backend.

- **P1 — `sync_running`:** the scheduler checked the flag and set it in **two separate lock acquisitions**, so two callers could both observe `false` and start a concurrent sync. Moved from a mutex-guarded `bool` on `SyncEngine` to an `Arc<AtomicBool>` on `AppState` (mirrors `OauthListenerControl.cancel`); every gate is now one `compare_exchange(false, true, AcqRel, Acquire)` and every release a `store(false, Release)`. `current_status()` takes the flag as a parameter. Deleting `is_/set_sync_running` from `SyncEngine` made any missed call site a hard compile error (none remained).
- **P2 — token refresh:** `get_access_token` dropped the token-cache lock before the blocking HTTP refresh, so two threads could double-refresh and orphan the access token (Dropbox rotates the refresh token). Serialized behind a dedicated `token_refresh_lock` with a **double-checked cache re-read**, extracted into `refresh_token_guarded(injected refresher)`. `get_access_token` / `force_refresh_session` / `verify_dropbox_token_internal` route through it.

## Stack
desktop-tauri

## Jira Ticket
#DBSYNC-13

## Design / review notes
- Gate/release balance verified: no gated body has an early `return`/`?` between a successful `compare_exchange` and its `store(false)`; every internal `Err` is captured & logged, never propagated before release → no stuck-flag / wedged-sync.
- Orderings: `AcqRel`/`Acquire` on the CAS, `Release` on the store, `Acquire` on status reads.
- **Review fix (Medium):** `force` skips the cache short-circuit — a forced refresh (401 recovery) must always exchange the refresh token, even against a time-fresh-but-revoked cached token; it still serializes on the mutex (no concurrent refresh).
- **Review fix (Low):** the `Mutex<()>` recovers from poison (`into_inner`) so a refresher panic can't permanently wedge every future refresh.
- No lock-ordering inversion (only nesting is `token_refresh_lock` → `token_cache`); the refresher never touches `sync_engine`.
- No API/IPC/frontend change — `SyncStatus.sync_running` shape unchanged (only its source).

## Test Plan
- [x] `cargo test` — **45/45** (in `apps/desktop/src-tauri`): N-thread `compare_exchange` single-winner test; concurrent-refreshers-collapse-to-one test.
- [x] `cargo clippy` — clean on changed files.
- [x] `npm --workspace apps/desktop run build` — OK (SyncStatus shape unchanged).

### Deferred to manual QA (live app / network)
- [ ] No overlapping real sync when a scheduler tick coincides with an IPC trigger.
- [ ] A single real network refresh under concurrent expired-token access (no rotation-induced logout).

🤖 Generated with Claude Code