### PR TITLE
fix(#DBSYNC-22): guard OAuth completion against listener/poll race

### DIFF
--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -113,6 +113,11 @@ function App() {
   const didAutoIndexCloudscRef = useRef(false);
   const schedulerStartedRef = useRef(false);
   const loggedTrayHideRef = useRef(false);
+  // OAuth completion can arrive via the primary Rust event OR the fallback poll,
+  // and both can fire for the same login. This once-only guard lets whichever
+  // path arrives first run the state update + log exactly once; the loser no-ops.
+  // Reset in startOAuth so a fresh (re-)connect attempt can complete again.
+  const oauthCompletedRef = useRef(false);
 
   const pushLog = (line: string) =>
     setActivity((prev) => [
@@ -182,6 +187,8 @@ function App() {
 
   const startOAuth = async () => {
     setConnectError(null);
+    // New login attempt: allow the completion handlers to fire once again.
+    oauthCompletedRef.current = false;
     try {
       const payload = await invoke<{ authUrl: string; state: string }>("start_oauth_flow");
       setAuthUrl(payload.authUrl);
@@ -243,6 +250,8 @@ function App() {
       if (!active) return;
       setAwaitingCallback(false);
       if (event.payload.ok) {
+        if (oauthCompletedRef.current) return;
+        oauthCompletedRef.current = true;
         setConnectError(null);
         setAuthOk(true);
         setStartupLoading(false);
@@ -326,6 +335,8 @@ function App() {
         const requirements = await invoke<StartupRequirements>("get_startup_requirements");
         if (disposed || !requirements.authOk) return;
         setAwaitingCallback(false);
+        if (oauthCompletedRef.current) return;
+        oauthCompletedRef.current = true;
         setAuthOk(true);
         setSyncFolderOk(requirements.syncFolderOk);
         if (requirements.syncFolder) {


### PR DESCRIPTION
## Summary
- Fixes a race between the primary `dropbox-oauth-finished` Tauri event listener and the 1500ms fallback poll: both could complete the same login because `setAwaitingCallback(false)` does not synchronously tear down the interval, so an in-flight poll `tick()` could resolve after the listener already ran — producing a duplicate "Dropbox authentication completed" log and a redundant state update.
- Adds a once-only `oauthCompletedRef` guard, checked-and-set at the top of BOTH completion branches (listener success + poll success). First path wins and runs setters + log exactly once; the loser returns early.
- The guard is reset in `startOAuth` so a fresh (re-)connect attempt — including the "Retry login" button after cancel/failure — completes again.
- Fallback polling is **preserved** (not removed): it is a deliberate resilience net for when the WebView throttles/drops the primary event.

## Stack
desktop-tauri (frontend-only change: `apps/desktop/src/App.tsx`)

## Jira Ticket
#DBSYNC-22

## Test Plan
- [x] Automated build/typecheck passes: `npm --workspace apps/desktop run build` (tsc + vite) — ✓ built, 0 TS errors
- [ ] desktop-tauri manual validation (see below)

### Stack-specific validation
- desktop-tauri: Connect to Dropbox and confirm exactly **one** "Dropbox authentication completed…" log entry (no duplicate). Then cancel a connect attempt and retry — confirm the guard reset allows re-auth to complete. No Rust/IPC surface changed (event name + payload unchanged).

## Notes
- No frontend unit-test runner is configured (`npm test` aliases the build); the defect is a runtime timing race not expressible in the current harness, so correctness is covered by the build gate + manual OAuth round-trip, consistent with the ticket's Testing Decisions.
- Diff: +11 lines, single file.

🤖 Generated with Claude Code