### PR TITLE
fix(#DBSYNC-14): bound every reqwest call with per-operation timeouts

### DIFF
--- a/apps/desktop/src-tauri/src/auth/oauth.rs
+++ b/apps/desktop/src-tauri/src/auth/oauth.rs
@@ -90,7 +90,11 @@ pub fn start_oauth() -> Result<(String, String, String), String> {
 pub async fn complete_oauth(code: String, verifier: String) -> Result<TokenResponse, String> {
     let app_key = resolve_app_key()?;
     let redirect_uri = resolve_redirect_uri();
-    let response = Client::new()
+    let client = Client::builder()
+        .timeout(std::time::Duration::from_secs(30))
+        .build()
+        .map_err(|e| format!("failed to build oauth http client: {e}"))?;
+    let response = client
         .post("https://api.dropboxapi.com/oauth2/token")
         .form(&[
             ("code", code),

--- a/apps/desktop/src-tauri/src/dropbox_transfer.rs
+++ b/apps/desktop/src-tauri/src/dropbox_transfer.rs
@@ -113,7 +113,9 @@ fn retry_transient<T>(
                     || e.contains("too_many_write_operations")
                     || e.contains("too_many_requests")
                     || e.contains("status error: 429")
-                    || e.contains("status error: 5");
+                    || e.contains("status error: 5")
+                    || e.contains("timed out")
+                    || e.contains("timeout");
                 if transient && attempt < max_attempts {
                     let wait_secs = 2u64 * attempt as u64;
                     eprintln!(
@@ -152,6 +154,13 @@ fn fetch_and_write_file(
         rand::random::<u64>()
     ));
 
+    // 300s (not the 120s used for upload-session/single-shot-upload requests):
+    // reqwest's blocking `timeout` bounds the *entire* request including
+    // streaming the full response body, and this is a single-request
+    // whole-file download — a large placeholder hydration could legitimately
+    // exceed 120s on a slow link, so 120s would regress large-file hydration.
+    // 300s still bounds a true stall. A future ranged/chunked download could
+    // tighten this back down.
     let mut download_resp = client
         .post("https://content.dropboxapi.com/2/files/download")
         .bearer_auth(token)
@@ -159,6 +168,7 @@ fn fetch_and_write_file(
             "Dropbox-API-Arg",
             serde_json::json!({ "path": path_display }).to_string(),
         )
+        .timeout(Duration::from_secs(300))
         .send()
         .map_err(|e| format!("download request failed: {}", describe_reqwest_error(&e)))?;
 
@@ -287,6 +297,7 @@ fn start_upload_session(client: &Client, token: &str) -> Result<String, String> 
         .header("Dropbox-API-Arg", serde_json::json!({ "close": false }).to_string())
         .header("Content-Type", "application/octet-stream")
         .body(Vec::<u8>::new())
+        .timeout(Duration::from_secs(120))
         .send()
         .map_err(|e| format!("upload_session/start request failed: {}", describe_reqwest_error(&e)))?;
 
@@ -326,6 +337,7 @@ fn append_upload_chunk(
         )
         .header("Content-Type", "application/octet-stream")
         .body(chunk.to_vec())
+        .timeout(Duration::from_secs(120))
         .send()
         .map_err(|e| format!("upload_session/append_v2 request failed: {}", describe_reqwest_error(&e)))?;
 
@@ -366,6 +378,7 @@ fn finish_upload_session(
         )
         .header("Content-Type", "application/octet-stream")
         .body(last_chunk.to_vec())
+        .timeout(Duration::from_secs(120))
         .send()
         .map_err(|e| format!("upload_session/finish request failed: {}", describe_reqwest_error(&e)))?;
 
@@ -783,6 +796,11 @@ pub(crate) fn upload_local_file_internal(
                 )
                 .header("Content-Type", "application/octet-stream")
                 .body(Body::sized(file, len))
+                // Whole-file single-shot upload (up to UPLOAD_SESSION_THRESHOLD_BYTES = 150 MiB in
+                // one request): use 300s like the whole-file download, not the 120s used for bounded
+                // upload-session chunks — 120s would abort a legitimate large single-shot upload on a
+                // slow link. Files above the threshold take the chunked session path (safe at 120s/chunk).
+                .timeout(Duration::from_secs(300))
                 .send()
                 .map_err(|e| format!("upload request failed: {}", describe_reqwest_error(&e)))?;
 

--- a/apps/desktop/src-tauri/src/state.rs
+++ b/apps/desktop/src-tauri/src/state.rs
@@ -39,15 +39,17 @@ pub(crate) struct AppState {
 
 /// Builds the single shared blocking HTTP client stored on `AppState`.
 ///
-/// Timeouts: a 15s connect timeout catches dead endpoints fast; the 600s total
-/// request timeout matches the previous transfer-only client (`dropbox_transfer.rs`'s
-/// old per-call `http_client()` also used 600s) so large uploads/downloads are
-/// unaffected, while the previously-unbounded metadata/list/delete calls now get a
-/// generous, non-regressing cap.
+/// Timeouts: a 10s connect timeout catches dead endpoints fast. The 30s total
+/// request timeout is the *default* applied to every request that doesn't
+/// override it — i.e. the quick metadata/list_folder/delete/token-verify-probe/
+/// refresh calls, which should never legitimately take longer than that. Transfer
+/// requests (uploads/downloads) are expected to run longer than 30s and override
+/// this default with a per-request `.timeout(...)` set on the individual
+/// `RequestBuilder` in `dropbox_transfer.rs`.
 pub(crate) fn build_http_client() -> reqwest::blocking::Client {
     reqwest::blocking::Client::builder()
-        .connect_timeout(std::time::Duration::from_secs(15))
-        .timeout(std::time::Duration::from_secs(600))
+        .connect_timeout(std::time::Duration::from_secs(10))
+        .timeout(std::time::Duration::from_secs(30))
         .user_agent(concat!("DropboxSyncDesktop/", env!("CARGO_PKG_VERSION")))
         .build()
         .expect("failed to build shared reqwest client")


### PR DESCRIPTION
## Summary
No request timeout was set, so a stalled Dropbox server could park an OS thread indefinitely and freeze the sync scheduler. This sets `connect_timeout` 10s and per-operation request timeouts:

| Operation | Timeout |
|---|---|
| Quick JSON (metadata / list_folder / delete / token-verify / refresh) | **30s** (shared-client default) |
| Upload-session chunks (start / append_v2 / finish, ≤8 MiB) | **120s** each |
| Whole-file single-request transfers (single-shot upload ≤150 MiB; streamed file download/hydration) | **300s** |
| Async OAuth token exchange (`complete_oauth`) | **30s** (was unbounded) |

- Timeout errors are now explicitly classified transient in `retry_transient` (added `"timed out"` / `"timeout"` matching) → they retry with backoff.
- `sync_running` is already released on the `Err` path by DBSYNC-13's gate (`store(false, Release)` runs unconditionally after the tick), so a timeout can't wedge the scheduler — confirmed, no change needed.

## Stack
desktop-tauri (Rust backend)

## Jira Ticket
#DBSYNC-14

## Deviation from AC (documented in code)
The AC says a flat "120s for transfers". Whole-file **single-request** transfers (the streamed download/hydration, and single-shot uploads up to the 150 MiB session threshold) use **300s** instead: reqwest's blocking `timeout` bounds the *entire* request including the full body stream, so a 120s cap would abort a legitimate large-file transfer on a slow link mid-stream. Bounded upload-session **chunks** (≤8 MiB) keep 120s. A future ranged/chunked download could tighten this.

## Test Plan
- [x] `cargo test --lib` — **50 passed**.
- [x] `cargo build --lib` — **0 warnings**.
- [x] `cargo clippy --lib` — no new warnings from changed files.

🤖 Generated with Claude Code