### PR TITLE
chore(#DBSYNC-44): resolve remaining clippy style lints

### DIFF
--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -62,7 +62,7 @@ pub fn run() {
             let paths = crate::open_handlers::cloudsc_paths_from_argv(&argv);
             if !paths.is_empty() {
                 tracing::info!(?paths, "file open on running instance");
-                crate::open_handlers::handle_cloudsc_paths_from_os(&app, paths);
+                crate::open_handlers::handle_cloudsc_paths_from_os(app, paths);
             }
             // Do not raise an empty dashboard when the user is fully set up (tray-only workflow).
             if let Some(state) = app.try_state::<AppState>() {
@@ -212,6 +212,6 @@ pub fn run() {
         .expect("error while building tauri application");
 
     app.run(|app_handle, event| {
-        run_events::handle_run_event(&app_handle, event);
+        run_events::handle_run_event(app_handle, event);
     });
 }

--- a/apps/desktop/src-tauri/src/run_events.rs
+++ b/apps/desktop/src-tauri/src/run_events.rs
@@ -57,19 +57,18 @@ pub(crate) fn handle_run_event(app_handle: &AppHandle, event: RunEvent) {
                 _ => {}
             }
         }
-        RunEvent::WebviewEvent { event: wv_evt, .. } => {
-            if let WebviewEvent::DragDrop(DragDropEvent::Drop { paths, .. }) = wv_evt {
-                for path in paths.iter() {
-                    let p: &Path = path.as_ref();
-                    tracing::info!(file_path = %p.display(), "file drop (webview)");
-                    if let Err(e) =
-                        app_handle.emit("file-drop", path.to_string_lossy().to_string())
-                    {
-                        tracing::error!(error = %e, "emit file-drop failed");
-                    }
+        RunEvent::WebviewEvent {
+            event: WebviewEvent::DragDrop(DragDropEvent::Drop { paths, .. }),
+            ..
+        } => {
+            for path in paths.iter() {
+                let p: &Path = path.as_ref();
+                tracing::info!(file_path = %p.display(), "file drop (webview)");
+                if let Err(e) = app_handle.emit("file-drop", path.to_string_lossy().to_string()) {
+                    tracing::error!(error = %e, "emit file-drop failed");
                 }
-                handle_cloudsc_paths_from_os(app_handle, paths);
             }
+            handle_cloudsc_paths_from_os(app_handle, paths);
         }
         _ => {}
     }

--- a/apps/desktop/src-tauri/src/storage/db.rs
+++ b/apps/desktop/src-tauri/src/storage/db.rs
@@ -840,15 +840,15 @@ enum DataDirOs {
 fn current_data_dir_os() -> DataDirOs {
     #[cfg(target_os = "windows")]
     {
-        return DataDirOs::Windows;
+        DataDirOs::Windows
     }
     #[cfg(target_os = "macos")]
     {
-        return DataDirOs::Macos;
+        DataDirOs::Macos
     }
     #[cfg(not(any(target_os = "windows", target_os = "macos")))]
     {
-        return DataDirOs::Unix;
+        DataDirOs::Unix
     }
 }
 


### PR DESCRIPTION
## Summary
Clears the 4 remaining `cargo clippy --lib` style warnings on `main` (style-only, no behavior change):
- **db.rs** — `current_data_dir_os()`: cfg arms return via tail expression instead of `return …;` (removes the `needless_return` introduced by DBSYNC-24).
- **lib.rs** — pass `app` / `app_handle` directly instead of `&app` / `&app_handle` (`needless_borrow` ×2).
- **run_events.rs** — collapse the `WebviewEvent::DragDrop` `if let` into the outer match-arm pattern (`collapsible_match`).

## Stack
desktop-tauri (Rust backend)

## Jira Ticket
#DBSYNC-44

## Test Plan
- [x] `cargo clippy --lib` — **0 warnings** (was 4).
- [x] `cargo build --lib` — 0 warnings.
- [x] `cargo test --lib` — **54 passed**.

🤖 Generated with Claude Code