### PR TITLE
refactor(#DBSYNC-17): typed-error foundation + leaf modules (phase A)

### DIFF
--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -931,6 +931,7 @@ dependencies = [
  "tauri-plugin-opener",
  "tauri-plugin-single-instance",
  "tempfile",
+ "thiserror 1.0.69",
  "tracing",
  "tracing-appender",
  "tracing-subscriber",

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -26,6 +26,7 @@ sha2 = "0.10"
 tauri = { version = "2", features = ["tray-icon", "image-png", "config-json5"] }
 tauri-plugin-opener = "2"
 tauri-plugin-single-instance = "2"
+thiserror = "1"
 tracing = "0.1"
 tracing-appender = "0.2"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/apps/desktop/src-tauri/src/cloudsc.rs
+++ b/apps/desktop/src-tauri/src/cloudsc.rs
@@ -1,12 +1,14 @@
 use std::fs;
 use std::path::{Path, PathBuf};
 
+use crate::error::{AppError, AppResult};
 use crate::models::CloudscMeta;
 
 pub(crate) const CLOUDSC_MAGIC: &str = "CLOUDSC1";
 
-pub(crate) fn encode_cloudsc_meta(meta: &CloudscMeta) -> Result<Vec<u8>, String> {
-    let json = serde_json::to_vec(meta).map_err(|e| format!("cloudsc encode json failed: {e}"))?;
+pub(crate) fn encode_cloudsc_meta(meta: &CloudscMeta) -> AppResult<Vec<u8>> {
+    let json = serde_json::to_vec(meta)
+        .map_err(|e| AppError::Other(format!("cloudsc encode json failed: {e}")))?;
     let mut out = Vec::new();
     out.extend_from_slice(CLOUDSC_MAGIC.as_bytes());
     out.push(b'\n');
@@ -14,16 +16,21 @@ pub(crate) fn encode_cloudsc_meta(meta: &CloudscMeta) -> Result<Vec<u8>, String>
     Ok(out)
 }
 
-pub(crate) fn decode_cloudsc_meta(bytes: &[u8]) -> Result<CloudscMeta, String> {
+pub(crate) fn decode_cloudsc_meta(bytes: &[u8]) -> AppResult<CloudscMeta> {
     let magic = CLOUDSC_MAGIC.as_bytes();
     if bytes.len() < magic.len() + 1 {
-        return Err("invalid .cloudsc payload (too small)".to_string());
+        return Err(AppError::Other(
+            "invalid .cloudsc payload (too small)".to_string(),
+        ));
     }
     if &bytes[..magic.len()] != magic {
-        return Err("invalid .cloudsc payload (bad magic)".to_string());
+        return Err(AppError::Other(
+            "invalid .cloudsc payload (bad magic)".to_string(),
+        ));
     }
     let json_bytes = &bytes[magic.len() + 1..];
-    serde_json::from_slice(json_bytes).map_err(|e| format!("cloudsc decode json failed: {e}"))
+    serde_json::from_slice(json_bytes)
+        .map_err(|e| AppError::Other(format!("cloudsc decode json failed: {e}")))
 }
 
 pub(crate) fn cloudsc_target_path(placeholder_path: &Path) -> PathBuf {
@@ -33,19 +40,19 @@ pub(crate) fn cloudsc_target_path(placeholder_path: &Path) -> PathBuf {
 pub(crate) fn write_cloudsc_placeholder_file(
     placeholder_path: &Path,
     meta: &CloudscMeta,
-) -> Result<(), String> {
+) -> AppResult<()> {
     if let Some(parent) = placeholder_path.parent() {
         fs::create_dir_all(parent)
-            .map_err(|e| format!("failed creating placeholder parent dir: {e}"))?;
+            .map_err(|e| AppError::Io(format!("failed creating placeholder parent dir: {e}")))?;
     }
     let payload = encode_cloudsc_meta(meta)?;
     fs::write(placeholder_path, payload)
-        .map_err(|e| format!("failed writing placeholder file: {e}"))?;
+        .map_err(|e| AppError::Io(format!("failed writing placeholder file: {e}")))?;
     Ok(())
 }
 
-pub(crate) fn read_cloudsc_placeholder_file(placeholder_path: &Path) -> Result<CloudscMeta, String> {
+pub(crate) fn read_cloudsc_placeholder_file(placeholder_path: &Path) -> AppResult<CloudscMeta> {
     let bytes = fs::read(placeholder_path)
-        .map_err(|e| format!("failed reading placeholder file bytes: {e}"))?;
+        .map_err(|e| AppError::Io(format!("failed reading placeholder file bytes: {e}")))?;
     decode_cloudsc_meta(&bytes)
 }

--- a/apps/desktop/src-tauri/src/error.rs
+++ b/apps/desktop/src-tauri/src/error.rs
@@ -1,0 +1,186 @@
+//! Typed application error, replacing ad-hoc `Result<_, String>` across the crate.
+//!
+//! Internal functions return [`AppResult<T>`]; the Tauri command boundary converts
+//! to `String` for IPC serialization via the `From<AppError> for String` bridge.
+//!
+//! This is phase A of the `Result<_, String>` -> typed error migration (DBSYNC-17):
+//! only a handful of leaf modules use [`AppError`] so far. The bridge `From` impls
+//! between `AppError` and `String` let migrated and not-yet-migrated modules
+//! interoperate through `?` during the transition.
+
+use thiserror::Error;
+
+/// Application-wide typed error. Internal functions return `AppResult<T>`;
+/// the Tauri command boundary converts to `String` for IPC serialization.
+// TODO(DBSYNC-17): remove `allow(dead_code)` once every module producing these
+// variants (auth, dropbox transfer, sync) is migrated off `Result<_, String>`.
+#[allow(dead_code)]
+#[derive(Debug, Error)]
+pub(crate) enum AppError {
+    #[error("network error: {0}")]
+    Network(String),
+    #[error("auth error: {0}")]
+    Auth(String),
+    #[error("dropbox API error (status {status}): {message}")]
+    Dropbox { status: u16, message: String },
+    #[error("storage error: {0}")]
+    Storage(String),
+    #[error("sync error: {0}")]
+    Sync(String),
+    #[error("io error: {0}")]
+    Io(String),
+    #[error("{0}")]
+    Other(String),
+}
+
+pub(crate) type AppResult<T> = std::result::Result<T, AppError>;
+
+impl From<std::io::Error> for AppError {
+    fn from(e: std::io::Error) -> Self {
+        AppError::Io(e.to_string())
+    }
+}
+
+impl From<rusqlite::Error> for AppError {
+    fn from(e: rusqlite::Error) -> Self {
+        AppError::Storage(e.to_string())
+    }
+}
+
+impl From<serde_json::Error> for AppError {
+    fn from(e: serde_json::Error) -> Self {
+        AppError::Other(e.to_string())
+    }
+}
+
+// --- Migration bridges (temporary, removed in the final phase) ---
+// TODO(DBSYNC-17): remove once every module is migrated
+impl From<AppError> for String {
+    fn from(e: AppError) -> Self {
+        e.to_string()
+    }
+}
+
+// TODO(DBSYNC-17): remove once every module is migrated
+#[allow(
+    dead_code,
+    reason = "bridge used once not-yet-migrated callers pass String errors through `?`"
+)]
+impl From<String> for AppError {
+    fn from(s: String) -> Self {
+        AppError::Other(s)
+    }
+}
+
+#[allow(
+    dead_code,
+    reason = "bridge used once not-yet-migrated callers pass &str errors through `?`"
+)]
+impl From<&str> for AppError {
+    fn from(s: &str) -> Self {
+        AppError::Other(s.to_string())
+    }
+}
+
+impl AppError {
+    /// Transient = worth retrying (network blip, rate limit, 5xx). Mirrors the
+    /// current string predicate in `dropbox_transfer::retry_transient`.
+    // TODO(DBSYNC-17): remove `allow(dead_code)` once `dropbox_transfer::retry_transient`
+    // is migrated to use this instead of its own string predicate.
+    #[allow(dead_code)]
+    pub(crate) fn is_transient(&self) -> bool {
+        match self {
+            AppError::Network(_) => true,
+            AppError::Dropbox { status, .. } => *status == 429 || (*status >= 500 && *status < 600),
+            AppError::Sync(m) | AppError::Other(m) => {
+                m.contains("request failed")
+                    || m.contains("timed out")
+                    || m.contains("timeout")
+                    || m.contains("too_many_write_operations")
+                    || m.contains("too_many_requests")
+                    || m.contains("status error: 429")
+                    || m.contains("status error: 5")
+            }
+            _ => false,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn display_formats_each_variant() {
+        assert_eq!(
+            AppError::Network("boom".into()).to_string(),
+            "network error: boom"
+        );
+        assert_eq!(
+            AppError::Auth("denied".into()).to_string(),
+            "auth error: denied"
+        );
+        assert_eq!(
+            AppError::Dropbox {
+                status: 404,
+                message: "not_found".into()
+            }
+            .to_string(),
+            "dropbox API error (status 404): not_found"
+        );
+        assert_eq!(
+            AppError::Storage("locked".into()).to_string(),
+            "storage error: locked"
+        );
+        assert_eq!(
+            AppError::Sync("conflict".into()).to_string(),
+            "sync error: conflict"
+        );
+        assert_eq!(
+            AppError::Io("missing".into()).to_string(),
+            "io error: missing"
+        );
+        assert_eq!(AppError::Other("oops".into()).to_string(), "oops");
+    }
+
+    #[test]
+    fn io_error_converts_to_io_variant() {
+        let io_err = std::io::Error::new(std::io::ErrorKind::NotFound, "file missing");
+        let app_err: AppError = io_err.into();
+        assert!(matches!(app_err, AppError::Io(_)));
+    }
+
+    #[test]
+    fn rusqlite_error_converts_to_storage_variant() {
+        let sqlite_err = rusqlite::Error::InvalidQuery;
+        let app_err: AppError = sqlite_err.into();
+        assert!(matches!(app_err, AppError::Storage(_)));
+    }
+
+    #[test]
+    fn is_transient_true_for_network_and_retryable_dropbox_statuses() {
+        assert!(AppError::Network("connection reset".into()).is_transient());
+        assert!(AppError::Dropbox {
+            status: 429,
+            message: "rate limited".into()
+        }
+        .is_transient());
+        assert!(AppError::Dropbox {
+            status: 503,
+            message: "unavailable".into()
+        }
+        .is_transient());
+        assert!(AppError::Other("request failed: connection reset".into()).is_transient());
+    }
+
+    #[test]
+    fn is_transient_false_for_non_retryable_errors() {
+        assert!(!AppError::Auth("bad token".into()).is_transient());
+        assert!(!AppError::Dropbox {
+            status: 404,
+            message: "not_found".into()
+        }
+        .is_transient());
+        assert!(!AppError::Other("bad path".into()).is_transient());
+    }
+}

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -4,6 +4,7 @@ mod cloudsc;
 mod cloudsc_ops;
 mod commands;
 mod dropbox_transfer;
+mod error;
 mod logging;
 mod models;
 mod oauth_listener;

--- a/apps/desktop/src-tauri/src/overlay_state.rs
+++ b/apps/desktop/src-tauri/src/overlay_state.rs
@@ -7,6 +7,7 @@ use std::path::PathBuf;
 
 use serde::Serialize;
 
+use crate::error::AppResult;
 use crate::state::AppState;
 use crate::storage::db;
 
@@ -29,7 +30,7 @@ struct OverlayStateFile {
     paths: HashMap<String, OverlayTier>,
 }
 
-fn active_job_paths(db: &db::Db) -> Result<HashSet<String>, String> {
+fn active_job_paths(db: &db::Db) -> AppResult<HashSet<String>> {
     let jobs = db.list_recent_jobs(10_000)?;
     let mut set = HashSet::new();
     for j in jobs {
@@ -50,7 +51,7 @@ fn active_job_paths(db: &db::Db) -> Result<HashSet<String>, String> {
     Ok(set)
 }
 
-fn unresolved_conflict_paths(db: &db::Db) -> Result<HashSet<String>, String> {
+fn unresolved_conflict_paths(db: &db::Db) -> AppResult<HashSet<String>> {
     Ok(db.list_unresolved_conflict_local_paths()?.into_iter().collect())
 }
 
@@ -61,7 +62,7 @@ pub(crate) fn refresh_overlay_state_internal(state: &AppState) {
     }
 }
 
-fn refresh_overlay_state_inner(state: &AppState) -> Result<(), String> {
+fn refresh_overlay_state_inner(state: &AppState) -> AppResult<()> {
     let sync_folder = state.db.get_sync_folder()?;
     let job_paths = active_job_paths(&state.db)?;
     let conflict_paths = unresolved_conflict_paths(&state.db)?;
@@ -102,11 +103,11 @@ fn refresh_overlay_state_inner(state: &AppState) -> Result<(), String> {
 
     let dir = db::app_data_dir()?;
     let dest = overlay_state_path(&dir);
-    let json = serde_json::to_string_pretty(&payload).map_err(|e| e.to_string())?;
+    let json = serde_json::to_string_pretty(&payload)?;
 
     let tmp = dest.with_extension("json.tmp");
-    fs::write(&tmp, json.as_bytes()).map_err(|e| e.to_string())?;
-    fs::rename(&tmp, &dest).map_err(|e| e.to_string())?;
+    fs::write(&tmp, json.as_bytes())?;
+    fs::rename(&tmp, &dest)?;
     Ok(())
 }
 

--- a/apps/desktop/src-tauri/src/path_util.rs
+++ b/apps/desktop/src-tauri/src/path_util.rs
@@ -5,15 +5,17 @@ use std::path::{Path, PathBuf};
 use chrono::Utc;
 use sha2::{Digest, Sha256};
 
+use crate::error::{AppError, AppResult};
+
 pub(crate) fn should_ignore_local_path(relative: &str) -> bool {
     let p = relative.replace('\\', "/");
     p == ".DS_Store" || p.ends_with("/.DS_Store") || p.starts_with("._") || p.contains("/._")
 }
 
-pub(crate) fn relpath_under(sync_folder: &Path, absolute: &Path) -> Result<String, String> {
+pub(crate) fn relpath_under(sync_folder: &Path, absolute: &Path) -> AppResult<String> {
     Ok(absolute
         .strip_prefix(sync_folder)
-        .map_err(|e| format!("failed to compute relative path: {e}"))?
+        .map_err(|e| AppError::Other(format!("failed to compute relative path: {e}")))?
         .to_string_lossy()
         .to_string())
 }
@@ -83,8 +85,9 @@ const DROPBOX_BLOCK_SIZE: usize = 4 * 1024 * 1024;
 /// # Errors
 ///
 /// Returns an error string if the file cannot be opened, read, or stat-ed.
-pub(crate) fn hash_file(path: &Path) -> Result<(String, i64, i64), String> {
-    let mut file = File::open(path).map_err(|e| format!("cannot open file for hash: {e}"))?;
+pub(crate) fn hash_file(path: &Path) -> AppResult<(String, i64, i64)> {
+    let mut file =
+        File::open(path).map_err(|e| AppError::Io(format!("cannot open file for hash: {e}")))?;
     let mut buffer = [0_u8; 8192];
 
     // Accumulates the raw 32-byte SHA-256 digest of each 4 MiB block.
@@ -93,7 +96,7 @@ pub(crate) fn hash_file(path: &Path) -> Result<(String, i64, i64), String> {
     let mut bytes_in_block: usize = 0;
 
     loop {
-        let read = file.read(&mut buffer).map_err(|e| e.to_string())?;
+        let read = file.read(&mut buffer)?;
         if read == 0 {
             break;
         }
@@ -127,7 +130,7 @@ pub(crate) fn hash_file(path: &Path) -> Result<(String, i64, i64), String> {
     // SHA-256 the concatenation of all block digests.
     let content_hash = Sha256::digest(&block_digests);
 
-    let metadata = file.metadata().map_err(|e| e.to_string())?;
+    let metadata = file.metadata()?;
     let size = metadata.len() as i64;
     let modified = metadata
         .modified()
@@ -139,13 +142,13 @@ pub(crate) fn hash_file(path: &Path) -> Result<(String, i64, i64), String> {
     Ok((format!("{:x}", content_hash), size, modified))
 }
 
-pub(crate) fn create_conflicted_copy(path: &Path) -> Result<PathBuf, String> {
+pub(crate) fn create_conflicted_copy(path: &Path) -> AppResult<PathBuf> {
     let parent = path
         .parent()
-        .ok_or_else(|| "file has no parent for conflict copy".to_string())?;
+        .ok_or_else(|| AppError::Other("file has no parent for conflict copy".to_string()))?;
     let stem = path
         .file_stem()
-        .ok_or_else(|| "missing file stem".to_string())?
+        .ok_or_else(|| AppError::Other("missing file stem".to_string()))?
         .to_string_lossy();
     let ext = path.extension().map(|e| e.to_string_lossy().to_string());
     let ts = Utc::now().format("%Y%m%d%H%M%S");
@@ -156,7 +159,8 @@ pub(crate) fn create_conflicted_copy(path: &Path) -> Result<PathBuf, String> {
     };
 
     let dest = parent.join(name);
-    fs::copy(path, &dest).map_err(|e| format!("failed to create conflicted copy: {e}"))?;
+    fs::copy(path, &dest)
+        .map_err(|e| AppError::Io(format!("failed to create conflicted copy: {e}")))?;
     Ok(dest)
 }
 


### PR DESCRIPTION
## Summary — Phase A of the incremental DBSYNC-17 migration
First of several small PRs replacing `Result<_, String>` with a typed error (122 signatures across 14 files; done module-by-module to keep each PR green + reviewable).

- Adds `thiserror`; new **`error.rs`** with `AppError { Network, Auth, Dropbox{status,message}, Storage, Sync, Io, Other }`, `AppResult<T>` alias, `From` impls (io / rusqlite / serde_json), and an `is_transient()` classifier that **mirrors the current `retry_transient` string predicate** (so later phases can swap the string matcher for variant matching without semantic change).
- **Temporary migration bridges** `From<AppError> for String` + `From<String>/<&str> for AppError` (tagged `TODO(DBSYNC-17)`, removed in the final phase) let migrated and not-yet-migrated modules interoperate via `?`.
- Migrates the self-contained leaf modules **`path_util`, `cloudsc`, `overlay_state`** to `AppResult` as the tracer. All not-yet-migrated callers keep compiling via the `AppError→String` bridge (verified; no call-site wraps needed).
- Existing string classifiers (`retry_transient`, `is_hard_auth_failure`, `is_session_invalid_error`) unchanged — migrated in later phases.

## Stack
desktop-tauri (Rust backend) · Jira: #DBSYNC-17 (stays In Progress — incremental)

## Test Plan
- [x] `cargo test --lib` — **59 passed** (54 + 5 new error.rs tests: display, io/rusqlite From, is_transient true/false).
- [x] `cargo build --lib` — 0 warnings.
- [x] `cargo clippy --lib` — 0 warnings.

## Notes
- Unused-until-later variants (`Auth`/`Network`/`Dropbox`/`Sync`) + `is_transient` carry `#[allow(dead_code)]` + TODO to avoid warnings until their module phases land.

🤖 Generated with Claude Code