### PR TITLE
refactor(#DBSYNC-17): auth modules + typed is_hard_auth (phase D)

### DIFF
--- a/apps/desktop/src-tauri/src/auth/oauth.rs
+++ b/apps/desktop/src-tauri/src/auth/oauth.rs
@@ -4,6 +4,8 @@ use reqwest::Client;
 use serde::Deserialize;
 use sha2::{Digest, Sha256};
 
+use crate::error::{AppError, AppResult};
+
 /// Dropbox App Console → your app → **Settings** → **App key** (OAuth2 `client_id`).
 /// Prefer providing this value via `DROPBOX_APP_KEY` in `.env` for dev/build.
 /// The build command embeds it at compile time via `option_env!`.
@@ -26,13 +28,13 @@ pub struct TokenResponse {
     pub expires_in: Option<i64>,
 }
 
-fn resolve_app_key() -> Result<String, String> {
+fn resolve_app_key() -> AppResult<String> {
     let v = std::env::var("DROPBOX_APP_KEY").unwrap_or_else(|_| DROPBOX_APP_KEY.to_string());
     if v.is_empty() {
-        return Err(
+        return Err(AppError::Auth(
             "DROPBOX_APP_KEY is empty: set it in apps/desktop/.env (and run build again) or export it in the environment."
                 .to_string(),
-        );
+        ));
     }
     Ok(v)
 }
@@ -68,7 +70,7 @@ fn random_state() -> String {
         .collect()
 }
 
-pub fn start_oauth() -> Result<(String, String, String), String> {
+pub fn start_oauth() -> AppResult<(String, String, String)> {
     let app_key = resolve_app_key()?;
     let redirect_uri = resolve_redirect_uri();
     let verifier = pkce_verifier();
@@ -87,13 +89,13 @@ pub fn start_oauth() -> Result<(String, String, String), String> {
     Ok((auth_url, state, verifier))
 }
 
-pub async fn complete_oauth(code: String, verifier: String) -> Result<TokenResponse, String> {
+pub async fn complete_oauth(code: String, verifier: String) -> AppResult<TokenResponse> {
     let app_key = resolve_app_key()?;
     let redirect_uri = resolve_redirect_uri();
     let client = Client::builder()
         .timeout(std::time::Duration::from_secs(30))
         .build()
-        .map_err(|e| format!("failed to build oauth http client: {e}"))?;
+        .map_err(|e| AppError::Network(format!("failed to build oauth http client: {e}")))?;
     let response = client
         .post("https://api.dropboxapi.com/oauth2/token")
         .form(&[
@@ -105,21 +107,27 @@ pub async fn complete_oauth(code: String, verifier: String) -> Result<TokenRespo
         ])
         .send()
         .await
-        .map_err(|e| format!("token request failed: {e}"))?;
+        .map_err(|e| AppError::Network(format!("token request failed: {e}")))?;
 
     let status = response.status();
     let body = response
         .bytes()
         .await
-        .map_err(|e| format!("token response body failed: {e}"))?;
+        .map_err(|e| AppError::Network(format!("token response body failed: {e}")))?;
 
     if !status.is_success() {
         let text = String::from_utf8_lossy(&body);
-        return Err(format!("dropbox token exchange failed ({status}): {text}"));
+        return Err(AppError::Auth(format!(
+            "dropbox token exchange failed ({status}): {text}"
+        )));
     }
 
-    let token = serde_json::from_slice::<TokenResponse>(&body)
-        .map_err(|e| format!("token parse failed: {e}; body: {}", String::from_utf8_lossy(&body)))?;
+    let token = serde_json::from_slice::<TokenResponse>(&body).map_err(|e| {
+        AppError::Auth(format!(
+            "token parse failed: {e}; body: {}",
+            String::from_utf8_lossy(&body)
+        ))
+    })?;
 
     Ok(token)
 }
@@ -127,7 +135,7 @@ pub async fn complete_oauth(code: String, verifier: String) -> Result<TokenRespo
 pub fn refresh_access_token_blocking(
     client: &reqwest::blocking::Client,
     refresh_token: &str,
-) -> Result<TokenResponse, String> {
+) -> AppResult<TokenResponse> {
     let app_key = resolve_app_key()?;
     let redirect_uri = resolve_redirect_uri();
 
@@ -140,17 +148,19 @@ pub fn refresh_access_token_blocking(
             ("redirect_uri", redirect_uri),
         ])
         .send()
-        .map_err(|e| format!("refresh token request failed: {e}"))?;
+        .map_err(|e| AppError::Network(format!("refresh token request failed: {e}")))?;
 
     if !response.status().is_success() {
         let status = response.status();
-        let body = response.text().unwrap_or_else(|_| "<unreadable body>".to_string());
-        return Err(format!(
+        let body = response
+            .text()
+            .unwrap_or_else(|_| "<unreadable body>".to_string());
+        return Err(AppError::Auth(format!(
             "dropbox refresh token exchange failed with status {status}; body: {body}"
-        ));
+        )));
     }
 
     response
         .json::<TokenResponse>()
-        .map_err(|e| format!("refresh token parse failed: {e}"))
+        .map_err(|e| AppError::Auth(format!("refresh token parse failed: {e}")))
 }

--- a/apps/desktop/src-tauri/src/auth/oauth_complete.rs
+++ b/apps/desktop/src-tauri/src/auth/oauth_complete.rs
@@ -1,6 +1,7 @@
 use chrono::{Duration, Utc};
 
 use crate::auth::oauth::complete_oauth;
+use crate::error::{AppError, AppResult};
 use crate::state::AppState;
 use crate::storage;
 
@@ -9,32 +10,36 @@ pub(crate) async fn complete_oauth_internal(
     app_state: &AppState,
     code: String,
     state: String,
-) -> Result<(), String> {
+) -> AppResult<()> {
     let state = state.trim().to_string();
     let (expected_state, verifier) = {
         let engine = app_state
             .sync_engine
             .lock()
-            .map_err(|_| "sync engine lock poisoned".to_string())?;
+            .map_err(|_| AppError::Auth("sync engine lock poisoned".to_string()))?;
         (
-            engine.pending_oauth_state().unwrap_or_default().trim().to_string(),
+            engine
+                .pending_oauth_state()
+                .unwrap_or_default()
+                .trim()
+                .to_string(),
             engine.pending_pkce_verifier().unwrap_or_default(),
         )
     };
 
     if expected_state.is_empty() {
-        return Err(
+        return Err(AppError::Auth(
             "OAuth session was reset (e.g. login restarted). Close the browser tab and click Start Dropbox login again."
                 .to_string(),
-        );
+        ));
     }
 
     if expected_state != state {
-        return Err(format!(
+        return Err(AppError::Auth(format!(
             "invalid oauth state (length {} vs {}); try logging in again from the app without opening a second login tab",
             expected_state.len(),
             state.len()
-        ));
+        )));
     }
 
     let token = complete_oauth(code, verifier).await?;
@@ -51,13 +56,13 @@ pub(crate) async fn complete_oauth_internal(
     app_state
         .secure_store
         .store_session(&session)
-        .map_err(|e| format!("failed to store token session: {e}"))?;
+        .map_err(|e| AppError::Auth(format!("failed to store token session: {e}")))?;
 
     {
         let mut cache = app_state
             .token_cache
             .lock()
-            .map_err(|_| "token cache mutex poisoned".to_string())?;
+            .map_err(|_| AppError::Auth("token cache mutex poisoned".to_string()))?;
         *cache = Some(session);
     }
 

--- a/apps/desktop/src-tauri/src/auth_session.rs
+++ b/apps/desktop/src-tauri/src/auth_session.rs
@@ -4,20 +4,12 @@ use std::sync::{Arc, Mutex};
 use chrono::{Duration, Utc};
 
 use crate::auth::oauth::refresh_access_token_blocking;
+use crate::error::{AppError, AppResult};
 use crate::state::AppState;
 use crate::storage::secure_store::TokenSession;
 
 pub(crate) fn has_stored_credentials(state: &AppState) -> bool {
     state.secure_store.get_session().is_ok() || state.secure_store.get_token().is_ok()
-}
-
-pub(crate) fn is_hard_auth_failure(err: &str) -> bool {
-    let lower = err.to_ascii_lowercase();
-    err.contains("dropbox token expired and no refresh_token available")
-        || err.contains("missing dropbox token session")
-        // Only treat refresh failures as hard when Dropbox explicitly rejects the grant.
-        || (err.contains("dropbox refresh token exchange failed with status")
-            && (lower.contains("invalid_grant") || lower.contains("invalid_client")))
 }
 
 /// Returns true when we should exchange the refresh token for a new access token.
@@ -50,8 +42,8 @@ fn refresh_token_guarded(
     token_cache: &Arc<Mutex<Option<TokenSession>>>,
     token_refresh_lock: &Arc<Mutex<()>>,
     force: bool,
-    refresher: impl FnOnce() -> Result<TokenSession, String>,
-) -> Result<TokenSession, String> {
+    refresher: impl FnOnce() -> AppResult<TokenSession>,
+) -> AppResult<TokenSession> {
     // A `Mutex<()>` guards no invariant, so a prior panic while holding it cannot
     // corrupt anything — recover from poison rather than permanently wedging every
     // future refresh with "lock poisoned".
@@ -81,7 +73,7 @@ fn refresh_token_guarded(
 }
 
 /// Clears the in-memory cache and performs a refresh using the session from the keychain.
-pub(crate) fn force_refresh_session(state: &AppState) -> Result<TokenSession, String> {
+pub(crate) fn force_refresh_session(state: &AppState) -> AppResult<TokenSession> {
     if let Ok(mut c) = state.token_cache.lock() {
         *c = None;
     }
@@ -89,10 +81,12 @@ pub(crate) fn force_refresh_session(state: &AppState) -> Result<TokenSession, St
     let session = state
         .secure_store
         .get_session()
-        .map_err(|_| "missing dropbox token session".to_string())?;
+        .map_err(|_| AppError::Auth("missing dropbox token session".to_string()))?;
 
     let Some(refresh_token) = session.refresh_token.clone() else {
-        return Err("dropbox token expired and no refresh_token available".to_string());
+        return Err(AppError::Auth(
+            "dropbox token expired and no refresh_token available".to_string(),
+        ));
     };
 
     refresh_token_guarded(&state.token_cache, &state.token_refresh_lock, true, || {
@@ -116,13 +110,13 @@ pub(crate) fn force_refresh_session(state: &AppState) -> Result<TokenSession, St
         state
             .secure_store
             .store_session(&new_session)
-            .map_err(|e| format!("failed storing refreshed token session: {e}"))?;
+            .map_err(|e| AppError::Auth(format!("failed storing refreshed token session: {e}")))?;
 
         Ok(new_session)
     })
 }
 
-pub(crate) fn get_access_token(state: &AppState) -> Result<String, String> {
+pub(crate) fn get_access_token(state: &AppState) -> AppResult<String> {
     if let Ok(cache) = state.token_cache.lock() {
         if let Some(session) = cache.as_ref() {
             if !session_needs_refresh(session) {
@@ -137,7 +131,7 @@ pub(crate) fn get_access_token(state: &AppState) -> Result<String, String> {
             let legacy_token = state
                 .secure_store
                 .get_token()
-                .map_err(|e| format!("missing dropbox token session: {e}"))?;
+                .map_err(|e| AppError::Auth(format!("missing dropbox token session: {e}")))?;
             let migrated = TokenSession {
                 access_token: legacy_token,
                 refresh_token: None,
@@ -156,7 +150,9 @@ pub(crate) fn get_access_token(state: &AppState) -> Result<String, String> {
     }
 
     let Some(refresh_token) = session.refresh_token.clone() else {
-        return Err("dropbox token expired and no refresh_token available".to_string());
+        return Err(AppError::Auth(
+            "dropbox token expired and no refresh_token available".to_string(),
+        ));
     };
 
     let refreshed_session =
@@ -181,7 +177,9 @@ pub(crate) fn get_access_token(state: &AppState) -> Result<String, String> {
             state
                 .secure_store
                 .store_session(&new_session)
-                .map_err(|e| format!("failed storing refreshed token session: {e}"))?;
+                .map_err(|e| {
+                    AppError::Auth(format!("failed storing refreshed token session: {e}"))
+                })?;
 
             Ok(new_session)
         })?;
@@ -189,8 +187,11 @@ pub(crate) fn get_access_token(state: &AppState) -> Result<String, String> {
     Ok(refreshed_session.access_token)
 }
 
-pub(crate) fn verify_dropbox_token_internal(state: &AppState) -> Result<bool, String> {
-    fn probe(client: &reqwest::blocking::Client, token: &str) -> Result<reqwest::blocking::Response, ()> {
+pub(crate) fn verify_dropbox_token_internal(state: &AppState) -> AppResult<bool> {
+    fn probe(
+        client: &reqwest::blocking::Client,
+        token: &str,
+    ) -> Result<reqwest::blocking::Response, ()> {
         client
             .post("https://api.dropboxapi.com/2/users/get_current_account")
             .bearer_auth(token)
@@ -224,7 +225,7 @@ pub(crate) fn verify_dropbox_token_internal(state: &AppState) -> Result<bool, St
                 }
             }
             Err(e) => {
-                if is_hard_auth_failure(&e) {
+                if e.is_hard_auth() {
                     Ok(false)
                 } else {
                     Ok(true)

--- a/apps/desktop/src-tauri/src/commands.rs
+++ b/apps/desktop/src-tauri/src/commands.rs
@@ -8,8 +8,8 @@ use tauri::{AppHandle, Manager};
 use crate::auth::oauth::start_oauth;
 use crate::auth::oauth_complete::complete_oauth_internal;
 use crate::auth_session::{
-    current_tray_status_label, has_stored_credentials, is_hard_auth_failure,
-    update_tray_tooltip, verify_dropbox_token_internal,
+    current_tray_status_label, has_stored_credentials, update_tray_tooltip,
+    verify_dropbox_token_internal,
 };
 use crate::cloudsc_ops::{
     hydrate_cloudsc_placeholder_internal,
@@ -29,14 +29,8 @@ use crate::sync_pipeline::{
 pub fn get_selective_sync_filters(
     state: tauri::State<AppState>,
 ) -> Result<SelectiveSyncFilters, String> {
-    let include_csv = state
-        .db
-        .get_include_prefixes_csv()?
-        .unwrap_or_default();
-    let exclude_csv = state
-        .db
-        .get_exclude_prefixes_csv()?
-        .unwrap_or_default();
+    let include_csv = state.db.get_include_prefixes_csv()?.unwrap_or_default();
+    let exclude_csv = state.db.get_exclude_prefixes_csv()?.unwrap_or_default();
     Ok(SelectiveSyncFilters {
         include_csv,
         exclude_csv,
@@ -67,11 +61,7 @@ pub fn start_oauth_flow(
             .map_err(|_| "sync engine lock poisoned".to_string())?;
         engine.set_oauth_context(oauth_state.clone(), verifier);
     }
-    start_oauth_callback_listener(
-        app,
-        state.inner().clone(),
-        state.oauth_listener.clone(),
-    )?;
+    start_oauth_callback_listener(app, state.inner().clone(), state.oauth_listener.clone())?;
 
     Ok(OauthStartResponse {
         auth_url,
@@ -85,7 +75,9 @@ pub async fn complete_oauth_flow(
     code: String,
     state: String,
 ) -> Result<(), String> {
-    complete_oauth_internal(app_state.inner(), code, state).await
+    complete_oauth_internal(app_state.inner(), code, state)
+        .await
+        .map_err(String::from)
 }
 
 #[tauri::command]
@@ -122,7 +114,9 @@ pub fn pick_sync_folder_dialog() -> Result<Option<String>, String> {
 }
 
 /// Same logic as [`get_startup_requirements`] for use from Rust (e.g. window visibility).
-pub(crate) fn compute_startup_requirements(state: &AppState) -> Result<StartupRequirementsResponse, String> {
+pub(crate) fn compute_startup_requirements(
+    state: &AppState,
+) -> Result<StartupRequirementsResponse, String> {
     let sync_folder = state.db.get_sync_folder()?;
     let sync_folder_ok = sync_folder
         .as_ref()
@@ -147,7 +141,7 @@ pub(crate) fn compute_startup_requirements(state: &AppState) -> Result<StartupRe
     } else {
         match verify_dropbox_token_internal(state) {
             Ok(v) => v,
-            Err(e) => !is_hard_auth_failure(&e),
+            Err(e) => !e.is_hard_auth(),
         }
     };
 

--- a/apps/desktop/src-tauri/src/error.rs
+++ b/apps/desktop/src-tauri/src/error.rs
@@ -12,19 +12,10 @@ use thiserror::Error;
 
 /// Application-wide typed error. Internal functions return `AppResult<T>`;
 /// the Tauri command boundary converts to `String` for IPC serialization.
-// TODO(DBSYNC-17): remove `allow(dead_code)` once every module producing these
-// variants (auth) is migrated off `Result<_, String>`. `Network`, `Dropbox`,
-// `Storage`, `Sync`, `Io` and `Other` are all constructed by now-migrated
-// modules (dropbox_transfer, cloudsc, path_util, storage::db); `Auth` is
-// still only produced by `auth`/`auth_session`, not yet migrated.
 #[derive(Debug, Error)]
 pub(crate) enum AppError {
     #[error("network error: {0}")]
     Network(String),
-    #[allow(
-        dead_code,
-        reason = "constructed once auth/auth_session (DBSYNC-17 later phase) migrates off Result<_, String>"
-    )]
     #[error("auth error: {0}")]
     Auth(String),
     #[error("dropbox API error (status {status}): {message}")]
@@ -136,6 +127,26 @@ impl AppError {
             || message.contains("closed")
             || message.contains("not_closed")
     }
+
+    /// Does this error indicate a session that cannot be recovered by retrying
+    /// (missing session, no refresh token, or Dropbox explicitly rejecting the
+    /// refresh grant), as opposed to a transient refresh failure that is worth
+    /// retrying later? Used by `auth_session::verify_dropbox_token_internal`
+    /// (and the not-yet-migrated `commands::compute_startup_requirements`) to
+    /// decide whether to surface the user as logged-out.
+    ///
+    /// Uses `Display` (`self.to_string()`) to inspect the message: the `Auth`
+    /// variant's `"auth error: "` prefix does not interfere with any of the
+    /// `contains` markers below.
+    pub(crate) fn is_hard_auth(&self) -> bool {
+        let text = self.to_string();
+        let lower = text.to_ascii_lowercase();
+        text.contains("dropbox token expired and no refresh_token available")
+            || text.contains("missing dropbox token session")
+            // Only treat refresh failures as hard when Dropbox explicitly rejects the grant.
+            || (text.contains("dropbox refresh token exchange failed with status")
+                && (lower.contains("invalid_grant") || lower.contains("invalid_client")))
+    }
 }
 
 #[cfg(test)]
@@ -232,8 +243,10 @@ mod tests {
 
     #[test]
     fn is_session_invalid_false_for_transient_or_unrelated_errors() {
-        assert!(!AppError::Network("upload_session/append_v2 request failed: connection reset".into())
-            .is_session_invalid());
+        assert!(!AppError::Network(
+            "upload_session/append_v2 request failed: connection reset".into()
+        )
+        .is_session_invalid());
         assert!(!AppError::Dropbox {
             status: 400,
             message: "Bad Request".into()
@@ -245,5 +258,39 @@ mod tests {
             message: "upload_session/finish: too_many_write_operations/...".into()
         }
         .is_session_invalid());
+    }
+
+    #[test]
+    fn is_hard_auth_true_for_missing_session_or_refresh_token() {
+        assert!(AppError::Auth("missing dropbox token session".into()).is_hard_auth());
+        assert!(
+            AppError::Auth("dropbox token expired and no refresh_token available".into())
+                .is_hard_auth()
+        );
+    }
+
+    #[test]
+    fn is_hard_auth_true_for_rejected_refresh_grant() {
+        assert!(AppError::Auth(
+            "dropbox refresh token exchange failed with status 400; body: {\"error\": \"invalid_grant\"}"
+                .into()
+        )
+        .is_hard_auth());
+        assert!(AppError::Auth(
+            "dropbox refresh token exchange failed with status 401; body: {\"error\": \"INVALID_CLIENT\"}"
+                .into()
+        )
+        .is_hard_auth());
+    }
+
+    #[test]
+    fn is_hard_auth_false_for_transient_refresh_failures_and_unrelated_errors() {
+        // Refresh failed, but not because Dropbox rejected the grant (e.g. a transient 503).
+        assert!(!AppError::Auth(
+            "dropbox refresh token exchange failed with status 503; body: server busy".into()
+        )
+        .is_hard_auth());
+        assert!(!AppError::Network("connection reset".into()).is_hard_auth());
+        assert!(!AppError::Auth("some other auth hiccup".into()).is_hard_auth());
     }
 }

--- a/apps/desktop/src-tauri/src/oauth_listener.rs
+++ b/apps/desktop/src-tauri/src/oauth_listener.rs
@@ -10,6 +10,7 @@ use url::Url;
 
 use crate::auth::oauth::dropbox_redirect_uri;
 use crate::auth::oauth_complete::complete_oauth_internal;
+use crate::error::{AppError, AppResult};
 use crate::models::DropboxOauthFinishedEvent;
 use crate::state::{AppState, OauthListenerControl};
 
@@ -31,8 +32,13 @@ fn normalize_path(path: &str) -> String {
 /// Result of parsing the HTTP request-target for an OAuth redirect (RFC 7230 origin-form or
 /// absolute-form `http://host/...`).
 enum OauthRedirectParse {
-    Success { code: String, state: String },
-    OAuthDenied { message: String },
+    Success {
+        code: String,
+        state: String,
+    },
+    OAuthDenied {
+        message: String,
+    },
     /// Callback path matched but query is incomplete (or favicon noise on another path).
     Incomplete,
     /// Not our OAuth callback path (e.g. `/favicon.ico`).
@@ -103,10 +109,10 @@ fn emit_oauth_finished(app: &AppHandle, event: DropboxOauthFinishedEvent) {
 /// Stops any running localhost OAuth listener and joins its thread so the TCP port is released.
 pub(crate) fn stop_oauth_listener(
     oauth_listener: &Arc<Mutex<Option<OauthListenerControl>>>,
-) -> Result<(), String> {
+) -> AppResult<()> {
     let mut guard = oauth_listener
         .lock()
-        .map_err(|_| "oauth listener mutex poisoned".to_string())?;
+        .map_err(|_| AppError::Auth("oauth listener mutex poisoned".to_string()))?;
     if let Some(ctrl) = guard.take() {
         ctrl.cancel.store(true, Ordering::SeqCst);
         let _ = ctrl.handle.join();
@@ -118,44 +124,41 @@ pub(crate) fn start_oauth_callback_listener(
     app: AppHandle,
     app_state: AppState,
     oauth_listener: Arc<Mutex<Option<OauthListenerControl>>>,
-) -> Result<(), String> {
+) -> AppResult<()> {
     stop_oauth_listener(&oauth_listener)?;
 
     let redirect_uri = dropbox_redirect_uri();
-    let url = Url::parse(&redirect_uri).map_err(|e| format!("invalid redirect uri: {e}"))?;
+    let url = Url::parse(&redirect_uri)
+        .map_err(|e| AppError::Auth(format!("invalid redirect uri: {e}")))?;
     let host = url
         .host_str()
-        .ok_or_else(|| "redirect uri must contain host".to_string())?;
+        .ok_or_else(|| AppError::Auth("redirect uri must contain host".to_string()))?;
     let port = url
         .port_or_known_default()
-        .ok_or_else(|| "redirect uri must contain port".to_string())?;
+        .ok_or_else(|| AppError::Auth("redirect uri must contain port".to_string()))?;
     let callback_path = url.path().to_string();
     let bind_addr = loopback_bind_address(host, port);
 
     let listener = TcpListener::bind(&bind_addr).map_err(|e| {
-        format!("cannot bind OAuth callback listener on {bind_addr}: {e}. Close other apps using this port or cancel OAuth and retry.")
+        AppError::Network(format!(
+            "cannot bind OAuth callback listener on {bind_addr}: {e}. Close other apps using this port or cancel OAuth and retry."
+        ))
     })?;
     listener
         .set_nonblocking(true)
-        .map_err(|e| format!("set_nonblocking: {e}"))?;
+        .map_err(|e| AppError::Network(format!("set_nonblocking: {e}")))?;
 
     let cancel = Arc::new(AtomicBool::new(false));
     let cancel_for_thread = cancel.clone();
 
     let handle = thread::spawn(move || {
-        run_oauth_listener_loop(
-            listener,
-            cancel_for_thread,
-            app,
-            app_state,
-            callback_path,
-        );
+        run_oauth_listener_loop(listener, cancel_for_thread, app, app_state, callback_path);
     });
 
     {
         let mut guard = oauth_listener
             .lock()
-            .map_err(|_| "oauth listener mutex poisoned".to_string())?;
+            .map_err(|_| AppError::Auth("oauth listener mutex poisoned".to_string()))?;
         *guard = Some(OauthListenerControl { cancel, handle });
     }
 
@@ -238,7 +241,7 @@ fn run_oauth_listener_loop(
                         }
                         let event = DropboxOauthFinishedEvent {
                             ok: result.is_ok(),
-                            message: result.err(),
+                            message: result.err().map(String::from),
                         };
                         emit_oauth_finished(&app, event);
                     }


### PR DESCRIPTION
## Summary — Phase D of DBSYNC-17
Migrates the auth modules to `AppResult` and converts the last string classifier (`is_hard_auth_failure`) to a typed method.
- `oauth.rs`, `auth_session.rs`, `oauth_complete.rs`, `oauth_listener.rs` → `AppResult`.
- OAuth/token failures → `AppError::Auth` (message text preserved, incl. `dropbox refresh token exchange failed with status …` so `invalid_grant`/`invalid_client` detection still works); transport/bind → `Network`.
- `is_hard_auth_failure` removed → **`AppError::is_hard_auth()`** (same predicate via Display). Call sites updated in `verify_dropbox_token_internal` + `commands::compute_startup_requirements`.
- Removed the `Auth` `#[allow(dead_code)]` (now constructed). +3 `is_hard_auth` tests.
- 2 minimal bridge wraps at not-yet-migrated sites (`complete_oauth_flow` tail return; oauth-listener event `Option<String>` field).

## Stack
desktop-tauri (Rust) · Jira #DBSYNC-17 (stays In Progress)

## Test Plan
- [x] `cargo test --lib` — **64 passed** (+3).
- [x] `cargo build --lib` — 0 warnings.
- [x] `cargo clippy --lib -- -D warnings` — clean.

🤖 Generated with Claude Code