### PR TITLE
feat(#DBSYNC-34): live sync progress UI (per-file bar, speed, X-of-Y)

### DIFF
--- a/apps/desktop/src-tauri/src/dropbox_transfer.rs
+++ b/apps/desktop/src-tauri/src/dropbox_transfer.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 use std::fs::{self, File};
 use std::io;
-use std::io::{Read, Seek, SeekFrom};
+use std::io::{Read, Seek, SeekFrom, Write};
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 
@@ -186,12 +186,41 @@ fn fetch_and_write_file(
         });
     }
 
-    let write_result = File::create(&temp)
-        .map_err(|e| AppError::Io(format!("failed creating temp file: {e}")))
-        .and_then(|mut tmp_file| {
-            io::copy(&mut download_resp, &mut tmp_file)
-                .map_err(|e| AppError::Io(format!("failed writing local file: {e}")))
-        });
+    // Stream the body to disk in chunks (instead of io::copy) so we can emit
+    // throttled `download-progress` events for the sync-progress UI (DBSYNC-34).
+    let total = download_resp.content_length().unwrap_or(0);
+    let write_result: AppResult<()> = (|| {
+        let mut tmp_file = File::create(&temp)
+            .map_err(|e| AppError::Io(format!("failed creating temp file: {e}")))?;
+        let mut buf = vec![0u8; 64 * 1024];
+        let mut transferred: u64 = 0;
+        let mut last_emit = std::time::Instant::now();
+        let mut last_emit_bytes: u64 = 0;
+        emit_download_progress(path_display, 0, total);
+        loop {
+            let n = download_resp
+                .read(&mut buf)
+                .map_err(|e| AppError::Io(format!("failed reading download stream: {e}")))?;
+            if n == 0 {
+                break;
+            }
+            tmp_file
+                .write_all(&buf[..n])
+                .map_err(|e| AppError::Io(format!("failed writing local file: {e}")))?;
+            transferred += n as u64;
+            // Throttle: emit at most every ~256 KiB or ~100ms.
+            if transferred - last_emit_bytes >= 256 * 1024
+                || last_emit.elapsed() >= Duration::from_millis(100)
+            {
+                emit_download_progress(path_display, transferred, total);
+                last_emit = std::time::Instant::now();
+                last_emit_bytes = transferred;
+            }
+        }
+        // Final 100% tick (total may be 0/unknown; report the actual byte count).
+        emit_download_progress(path_display, transferred, transferred.max(total));
+        Ok(())
+    })();
 
     if let Err(e) = write_result {
         let _ = fs::remove_file(&temp);
@@ -491,6 +520,20 @@ fn conflict_copy_with_content_exists(target: &Path, content_hash: &str) -> AppRe
 /// on `state::APP_HANDLE` (see its doc comment). No-ops silently when no handle is set
 /// yet, which keeps offline unit tests (which never call `setup()`) window/handle-free.
 fn emit_upload_progress(path: &str, transferred: u64, total: u64) {
+    emit_transfer_progress("upload-progress", path, transferred, total);
+}
+
+/// Emits a `download-progress` event with the same payload shape as
+/// `upload-progress`, so the flyout can show live download progress. The caller
+/// throttles emits (bytes/time) to avoid flooding the event bus.
+fn emit_download_progress(path: &str, transferred: u64, total: u64) {
+    emit_transfer_progress("download-progress", path, transferred, total);
+}
+
+/// Shared emitter for `upload-progress` / `download-progress` events. No-ops
+/// silently when no `AppHandle` is set on `state::APP_HANDLE` yet (keeps offline
+/// unit tests, which never call `setup()`, handle-free).
+fn emit_transfer_progress(event_name: &'static str, path: &str, transferred: u64, total: u64) {
     let Some(handle) = crate::state::APP_HANDLE.get() else {
         return;
     };
@@ -501,12 +544,12 @@ fn emit_upload_progress(path: &str, transferred: u64, total: u64) {
         total,
     };
 
-    match handle.emit_to(EventTarget::webview_window("main"), "upload-progress", event.clone()) {
+    match handle.emit_to(EventTarget::webview_window("main"), event_name, event.clone()) {
         Ok(()) => {}
         Err(e) => {
-            tracing::error!(error = %e, "emit_to webview_window(main) failed");
-            if let Err(e2) = handle.emit("upload-progress", event) {
-                tracing::error!(error = %e2, "emit global upload-progress failed");
+            tracing::error!(error = %e, event = event_name, "emit_to webview_window(main) failed");
+            if let Err(e2) = handle.emit(event_name, event) {
+                tracing::error!(error = %e2, event = event_name, "emit global progress failed");
             }
         }
     }

--- a/apps/desktop/src/components/FlyoutApp.css
+++ b/apps/desktop/src/components/FlyoutApp.css
@@ -384,6 +384,89 @@ html, body, #root {
   white-space: nowrap;
 }
 
+/* --- Accueil: current-transfer card (upload/download in progress) --- */
+
+.current-transfer-card {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  background: var(--flyout-panel);
+  border: 1px solid var(--flyout-border);
+  border-radius: 8px;
+  padding: 8px 10px;
+  margin-bottom: 8px;
+}
+
+.current-transfer-head {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+}
+
+.current-transfer-name {
+  flex: 1 1 auto;
+  min-width: 0;
+  font-size: 12px;
+  font-weight: 600;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.current-transfer-bar {
+  position: relative;
+  height: 5px;
+  border-radius: 3px;
+  background: var(--flyout-muted-soft);
+  overflow: hidden;
+}
+
+.current-transfer-bar-fill {
+  height: 100%;
+  border-radius: 3px;
+  background: var(--flyout-accent);
+  transition: width 0.15s ease;
+}
+
+.current-transfer-bar.indeterminate .current-transfer-bar-fill {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  width: 40%;
+  background: repeating-linear-gradient(
+    45deg,
+    var(--flyout-accent) 0,
+    var(--flyout-accent) 6px,
+    transparent 6px,
+    transparent 12px
+  );
+  animation: current-transfer-indeterminate 1.1s linear infinite;
+}
+
+@keyframes current-transfer-indeterminate {
+  0% {
+    left: -40%;
+  }
+  100% {
+    left: 100%;
+  }
+}
+
+.current-transfer-meta {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  font-size: 10.5px;
+  color: var(--flyout-muted);
+}
+
+.current-transfer-run-label {
+  font-size: 10.5px;
+  color: var(--flyout-muted);
+  margin: -2px 0 8px;
+}
+
 /* --- Activité: icon-badge feed rows --- */
 
 .activity-list .activity-row,

--- a/apps/desktop/src/components/FlyoutApp.tsx
+++ b/apps/desktop/src/components/FlyoutApp.tsx
@@ -3,7 +3,9 @@ import { invoke } from "@tauri-apps/api/core";
 import { useActivityLog } from "../hooks/useActivityLog";
 import { useStartupRequirements } from "../hooks/useStartupRequirements";
 import { useSyncDashboard } from "../hooks/useSyncDashboard";
-import type { ActivityEntry, SyncJob } from "../types";
+import { useTransferProgress } from "../hooks/useTransferProgress";
+import { formatBytes, formatSpeed } from "../format";
+import type { ActiveTransfer, ActivityEntry, SyncJob } from "../types";
 import "./FlyoutApp.css";
 
 type Section = "home" | "folders" | "activity";
@@ -153,6 +155,38 @@ function openSettings() {
   invoke("show_setup_window").catch(() => {});
 }
 
+type CurrentTransferCardProps = { transfer: ActiveTransfer };
+
+/** Compact "in-flight" card shown above the recent-transfers list while a
+ * transfer is streaming. Falls back to an indeterminate/striped bar when the
+ * total size is unknown (`total === 0`, e.g. a fresh resumable-upload session). */
+function CurrentTransferCard({ transfer }: CurrentTransferCardProps) {
+  const { path, transferred, total, direction, speedBytesPerSec } = transfer;
+  const knownTotal = total > 0;
+  const pct = knownTotal ? Math.min(100, Math.max(0, (transferred / total) * 100)) : 0;
+
+  return (
+    <div className="current-transfer-card">
+      <div className="current-transfer-head">
+        <EventIcon kind={direction} />
+        <div className="current-transfer-name" title={path}>
+          {basename(path)}
+        </div>
+      </div>
+      <div className={`current-transfer-bar${knownTotal ? "" : " indeterminate"}`}>
+        <div className="current-transfer-bar-fill" style={knownTotal ? { width: `${pct}%` } : undefined} />
+      </div>
+      <div className="current-transfer-meta">
+        <span>
+          {formatBytes(transferred)}
+          {knownTotal ? ` / ${formatBytes(total)}` : ""}
+        </span>
+        <span>{formatSpeed(speedBytesPerSec)}</span>
+      </div>
+    </div>
+  );
+}
+
 type RecentRowProps = { job: SyncJob };
 
 function RecentTransferRow({ job }: RecentRowProps) {
@@ -196,6 +230,7 @@ function FlyoutApp() {
   const { activity, pushLog } = useActivityLog();
   const { startupLoading, authOk, syncFolderOk, syncFolder } = useStartupRequirements(pushLog);
   const { status, jobs, conflicts, retryFailedJobs } = useSyncDashboard(pushLog);
+  const { activeTransfer } = useTransferProgress();
 
   const [section, setSection] = useState<Section>("home");
   const schedulerStartedRef = useRef(false);
@@ -259,6 +294,18 @@ function FlyoutApp() {
   const recentJobs: SyncJob[] = jobs.slice(0, 8);
   const hasFailedJobs = jobs.some((job) => job.status === "failed");
 
+  // "X of Y files": Y = jobs still pending or completed in the current run
+  // (queued/running/retry_wait + done), X = the completed (done) count. Only
+  // shown while a sync is actually running/pending, so a completed run's
+  // "done" jobs don't linger in the indicator once the run is over.
+  const pendingJobCount = jobs.filter(
+    (job) => job.status === "queued" || job.status === "running" || job.status === "retry_wait",
+  ).length;
+  const doneJobCount = jobs.filter((job) => job.status === "done").length;
+  const runTotal = pendingJobCount + doneJobCount;
+  const runProgressLabel =
+    (status.syncRunning || pendingJobCount > 0) && runTotal > 0 ? `${doneJobCount} sur ${runTotal} fichiers` : null;
+
   return (
     <div className="flyout">
       <nav className="flyout-nav">
@@ -293,6 +340,9 @@ function FlyoutApp() {
 
         {section === "home" && (
           <section className="flyout-section">
+            {activeTransfer && <CurrentTransferCard transfer={activeTransfer} />}
+            {runProgressLabel && <div className="current-transfer-run-label">{runProgressLabel}</div>}
+
             <button type="button" className="flyout-btn flyout-logs-btn" onClick={() => void openLogs()}>
               Ouvrir les journaux
             </button>

--- a/apps/desktop/src/components/FlyoutApp.tsx
+++ b/apps/desktop/src/components/FlyoutApp.tsx
@@ -25,7 +25,9 @@ function queueActionLabel(jobType: string): string {
     case "download":
       return "Download (Dropbox -> local)";
     case "delete":
-      return "Delete (Dropbox)";
+      return "Supprimé sur Dropbox";
+    case "local_delete":
+      return "Supprimé (retiré du remote)";
     case "hydrate_cloudsc":
       return "Hydrate (.cloudsc)";
     default:
@@ -43,6 +45,7 @@ function jobEventKind(job: SyncJob): EventKind {
     case "hydrate_cloudsc":
       return "download";
     case "delete":
+    case "local_delete":
       return "delete";
     default:
       return "sync";
@@ -223,6 +226,57 @@ function ActivityRow({ entry }: ActivityRowProps) {
   );
 }
 
+type JobActivityRowProps = { job: SyncJob };
+
+/** Renders a background sync job (upload/download/delete/local_delete/hydrate) as
+ * an Activité row, so events driven by the scheduler (not pushLog) are visible too. */
+function JobActivityRow({ job }: JobActivityRowProps) {
+  const kind = jobEventKind(job);
+  const name = basename(job.targetPath);
+  const main = name ? `${queueActionLabel(job.jobType)} — ${name}` : queueActionLabel(job.jobType);
+  return (
+    <li className="activity-row">
+      <EventIcon kind={kind} />
+      <div className="activity-row-body">
+        <div className="row-main">{main}</div>
+        <div className={`row-sub ${job.status === "failed" ? "error" : ""}`}>
+          {job.status === "failed" ? job.lastError ?? "Échec" : `${job.status} · ${formatRelativeTime(job.updatedAt)}`}
+        </div>
+      </div>
+    </li>
+  );
+}
+
+type ActivityFeedItem =
+  | { kind: "job"; key: string; time: number; job: SyncJob }
+  | { kind: "log"; key: string; time: number; entry: ActivityEntry };
+
+/** Merges background sync `jobs` with the pushLog `activity` entries into a single
+ * time-sorted (descending) feed for the Activité section, so events that only exist
+ * as jobs (e.g. a scheduler-driven `local_delete`) show up alongside logged lines. */
+function buildActivityFeed(jobs: SyncJob[], activity: ActivityEntry[]): ActivityFeedItem[] {
+  const jobItems: ActivityFeedItem[] = jobs
+    .filter((job) => job.updatedAt !== undefined)
+    .map((job) => ({
+      kind: "job",
+      key: `job-${job.id}`,
+      time: new Date(job.updatedAt as string).getTime(),
+      job,
+    }));
+
+  const logItems: ActivityFeedItem[] = activity.map((entry) => ({
+    kind: "log",
+    key: `log-${entry.id}`,
+    time: entry.timestamp,
+    entry,
+  }));
+
+  return [...jobItems, ...logItems]
+    .filter((item) => !Number.isNaN(item.time))
+    .sort((a, b) => b.time - a.time)
+    .slice(0, 40);
+}
+
 /** Compact Dropbox-style flyout: nav rail + status footer over three read-mostly
  * sections. No hydrate/download actions here — hydration happens by double-clicking
  * the `.cloudsc` placeholder in the OS file manager. */
@@ -293,6 +347,7 @@ function FlyoutApp() {
 
   const recentJobs: SyncJob[] = jobs.slice(0, 8);
   const hasFailedJobs = jobs.some((job) => job.status === "failed");
+  const activityFeed = buildActivityFeed(jobs, activity);
 
   // "X of Y files": Y = jobs still pending or completed in the current run
   // (queued/running/retry_wait + done), X = the completed (done) count. Only
@@ -347,14 +402,14 @@ function FlyoutApp() {
               Ouvrir les journaux
             </button>
 
-            <h2>Recent transfers</h2>
+            <h2>Activité récente</h2>
             {hasFailedJobs && (
               <button type="button" className="flyout-btn flyout-retry" onClick={() => void retryFailedJobs()}>
                 Retry failed jobs
               </button>
             )}
             <ul className="flyout-list recent-list">
-              {recentJobs.length === 0 && <li className="muted">No recent activity.</li>}
+              {recentJobs.length === 0 && <li className="muted">Aucune activité récente.</li>}
               {recentJobs.map((job) => (
                 <RecentTransferRow key={job.id} job={job} />
               ))}
@@ -392,10 +447,14 @@ function FlyoutApp() {
 
             <h2>Activity log</h2>
             <ul className="flyout-list activity-list">
-              {activity.length === 0 && <li className="muted">No entries yet.</li>}
-              {activity.map((entry) => (
-                <ActivityRow key={entry.id} entry={entry} />
-              ))}
+              {activityFeed.length === 0 && <li className="muted">No entries yet.</li>}
+              {activityFeed.map((item) =>
+                item.kind === "job" ? (
+                  <JobActivityRow key={item.key} job={item.job} />
+                ) : (
+                  <ActivityRow key={item.key} entry={item.entry} />
+                ),
+              )}
             </ul>
           </section>
         )}

--- a/apps/desktop/src/format.ts
+++ b/apps/desktop/src/format.ts
@@ -1,0 +1,15 @@
+const BYTE_UNITS = ["B", "KB", "MB", "GB", "TB"];
+
+/** Binary (1024-based) byte formatting, 1 decimal place ("1.2 MB", "640 KB"). */
+export function formatBytes(bytes: number): string {
+  if (!Number.isFinite(bytes) || bytes <= 0) return "0 B";
+  const exponent = Math.min(Math.floor(Math.log(bytes) / Math.log(1024)), BYTE_UNITS.length - 1);
+  const value = bytes / 1024 ** exponent;
+  return `${exponent === 0 ? Math.round(value) : value.toFixed(1)} ${BYTE_UNITS[exponent]}`;
+}
+
+/** Throughput formatting built on top of `formatBytes` ("1.2 MB/s", "640 KB/s"). */
+export function formatSpeed(bytesPerSec: number): string {
+  if (!Number.isFinite(bytesPerSec) || bytesPerSec <= 0) return "0 B/s";
+  return `${formatBytes(bytesPerSec)}/s`;
+}

--- a/apps/desktop/src/hooks/useTransferProgress.ts
+++ b/apps/desktop/src/hooks/useTransferProgress.ts
@@ -1,0 +1,91 @@
+import { useEffect, useRef, useState } from "react";
+import { listen } from "@tauri-apps/api/event";
+import type { ActiveTransfer, TransferDirection, TransferProgressEvent } from "../types";
+
+/** Clear the active transfer if no further progress event arrives within this
+ * window, so a stalled/finished transfer doesn't linger in the UI. */
+const IDLE_CLEAR_MS = 1500;
+
+type SpeedSample = { path: string; prevTransferred: number; prevTime: number };
+
+/** Live sync progress derived from the Rust-emitted `upload-progress` /
+ * `download-progress` events. Tracks a single active transfer (v1: no
+ * multi-row concurrent progress) and its instantaneous speed, clearing once
+ * the transfer completes or goes idle. */
+export function useTransferProgress() {
+  const [activeTransfer, setActiveTransfer] = useState<ActiveTransfer | null>(null);
+  const speedSampleRef = useRef<SpeedSample | null>(null);
+  const idleTimerRef = useRef<number | undefined>(undefined);
+
+  useEffect(() => {
+    let active = true;
+    const unlistenFns: Array<() => void> = [];
+
+    const clearIdleTimer = () => {
+      if (idleTimerRef.current !== undefined) {
+        window.clearTimeout(idleTimerRef.current);
+        idleTimerRef.current = undefined;
+      }
+    };
+
+    const clearActive = () => {
+      clearIdleTimer();
+      speedSampleRef.current = null;
+      setActiveTransfer(null);
+    };
+
+    const scheduleIdleClear = () => {
+      clearIdleTimer();
+      idleTimerRef.current = window.setTimeout(clearActive, IDLE_CLEAR_MS);
+    };
+
+    const handleProgress = (direction: TransferDirection) => (event: { payload: TransferProgressEvent }) => {
+      if (!active) return;
+      const { path, transferred, total } = event.payload;
+
+      const completed = total > 0 && transferred >= total;
+      if (completed) {
+        clearActive();
+        return;
+      }
+
+      const now = Date.now();
+      const prev = speedSampleRef.current;
+      let speedBytesPerSec = 0;
+      if (prev && prev.path === path) {
+        const deltaSec = (now - prev.prevTime) / 1000;
+        const deltaBytes = transferred - prev.prevTransferred;
+        speedBytesPerSec = deltaSec > 0 ? Math.max(0, deltaBytes / deltaSec) : 0;
+      }
+      speedSampleRef.current = { path, prevTransferred: transferred, prevTime: now };
+
+      setActiveTransfer({ path, transferred, total, direction, speedBytesPerSec });
+      scheduleIdleClear();
+    };
+
+    void listen<TransferProgressEvent>("upload-progress", handleProgress("upload")).then((fn) => {
+      if (!active) {
+        fn();
+      } else {
+        unlistenFns.push(fn);
+      }
+    });
+
+    void listen<TransferProgressEvent>("download-progress", handleProgress("download")).then((fn) => {
+      if (!active) {
+        fn();
+      } else {
+        unlistenFns.push(fn);
+      }
+    });
+
+    return () => {
+      active = false;
+      clearIdleTimer();
+      unlistenFns.forEach((fn) => fn());
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  return { activeTransfer };
+}

--- a/apps/desktop/src/types.ts
+++ b/apps/desktop/src/types.ts
@@ -75,3 +75,20 @@ export type ActivityEntry = {
   /** Epoch ms captured when the entry was logged, used for relative-time display. */
   timestamp: number;
 };
+
+export type TransferDirection = "upload" | "download";
+
+/** Payload shared by the `upload-progress` / `download-progress` Tauri events. */
+export type TransferProgressEvent = {
+  path: string;
+  transferred: number;
+  total: number;
+};
+
+export type ActiveTransfer = {
+  path: string;
+  transferred: number;
+  total: number;
+  direction: TransferDirection;
+  speedBytesPerSec: number;
+};


### PR DESCRIPTION
## Summary
**Rust:** `fetch_and_write_file` now streams the download body in 64 KiB chunks (instead of `io::copy`) and emits a **throttled `download-progress`** event `{path,transferred,total}` (~256 KiB / 100 ms), mirroring the existing `upload-progress` via a shared `emit_transfer_progress` helper. `total` from `Content-Length`.

**Frontend:** new `useTransferProgress` hook listens to `upload-progress` + `download-progress`, tracks the active transfer and computes **per-file speed** from consecutive event byte-deltas, clearing on completion or ~1.5 s idle. Accueil shows a **CurrentTransferCard** (up/down icon + basename + progress bar — indeterminate when `total` unknown — + bytes + formatted speed) and an **"X sur Y fichiers"** indicator from the dashboard job statuses (`done` / `done+queued+running`), shown only while a run is active. New `format.ts` (`formatBytes`/`formatSpeed`).

## Stack
desktop-tauri · Jira #DBSYNC-34

## Test Plan
- [x] `cargo build` + `cargo clippy -- -D warnings` clean; `cargo test --lib` **64 pass**.
- [x] `npm --workspace apps/desktop run build` (tsc + vite, `noUnusedLocals`) — 0 TS errors.
- [ ] **Manual spot-check (`npm run dev:win`)** — trigger a real upload and a real download; Accueil shows the file, moving progress bar, speed, and the X-of-Y counter; verify it clears when idle.

## Notes
- Events only — no new IPC commands. v1 = single active-transfer view (no concurrent multi-row progress).
- Download timeout stays 300 s (DBSYNC-14); the chunked read doesn't change the request timeout.

🤖 Generated with Claude Code