### PR TITLE
fix(security): enable CSP and reject path traversal (#DBSYNC-27)

### DIFF
--- a/apps/desktop/src-tauri/src/cloudsc_ops.rs
+++ b/apps/desktop/src-tauri/src/cloudsc_ops.rs
@@ -14,7 +14,9 @@ use crate::error::{AppError, AppResult};
 use crate::models::{
     CloudscMeta, CloudscPlaceholderInfo, DropboxListFolderResponse,
 };
-use crate::path_util::{is_path_allowed, normalize_dropbox_path, parse_prefix_csv, relpath_under};
+use crate::path_util::{
+    is_path_allowed, normalize_dropbox_path, parse_prefix_csv, relpath_under, safe_join,
+};
 use crate::state::AppState;
 
 pub(crate) fn index_remote_folder_children_as_cloudsc_placeholders_internal(
@@ -95,7 +97,16 @@ pub(crate) fn index_remote_folder_children_as_cloudsc_placeholders_internal(
                 continue;
             }
 
-            let placeholder_path = local_dir.join(format!("{child_name}.cloudsc"));
+            // `child_name` is the last segment of a remote path_display: refuse a
+            // name that carries embedded separators / traversal before writing it
+            // to local disk (skip the poisoned entry, don't abort the sweep).
+            let placeholder_path = match safe_join(local_dir, &format!("{child_name}.cloudsc")) {
+                Ok(p) => p,
+                Err(e) => {
+                    tracing::warn!(name = %child_name, error = %e, "skipping unsafe placeholder name");
+                    continue;
+                }
+            };
             let target_path = cloudsc_target_path(&placeholder_path);
             // Skip if already represented locally: as a placeholder, or as a real
             // file/dir (a hydrated folder is a real dir, so we never shadow it with
@@ -281,7 +292,9 @@ pub(crate) fn hydrate_cloudsc_placeholder_internal(
         .get_sync_folder()?
         .ok_or_else(|| AppError::Sync("sync folder not configured".to_string()))?;
 
-    let placeholder_path = PathBuf::from(&sync_folder).join(placeholder_local_rel_path);
+    // `placeholder_local_rel_path` is frontend/IPC-supplied — validate it can't
+    // escape the sync root before touching the filesystem.
+    let placeholder_path = safe_join(Path::new(&sync_folder), placeholder_local_rel_path)?;
     if !placeholder_path.exists() {
         return Err(AppError::Sync(format!(
             "placeholder not found: {placeholder_local_rel_path}"

--- a/apps/desktop/src-tauri/src/cloudsc_ops.rs
+++ b/apps/desktop/src-tauri/src/cloudsc_ops.rs
@@ -218,7 +218,14 @@ pub(crate) fn index_materialized_folders_as_cloudsc_placeholders_internal(
         }
         let dir = entry.path();
         let rel = relpath_under(&sync_folder, dir)?; // "" for the sync root itself
-        let remote_path = normalize_dropbox_path(&rel); // "" for root, "/Cocina", ...
+        // "" for root, "/Cocina", ...; a malformed path skips this folder only.
+        let remote_path = match normalize_dropbox_path(&rel) {
+            Ok(p) => p,
+            Err(e) => {
+                tracing::error!(rel = %rel, error = %e, "skipping folder with unsafe path");
+                continue;
+            }
+        };
         match index_remote_folder_children_as_cloudsc_placeholders_internal(state, &remote_path, dir)
         {
             Ok(n) => created += n,
@@ -315,7 +322,7 @@ mod tests {
     fn root_dir_maps_to_empty_dropbox_path() {
         let root = PathBuf::from("/sync/root");
         let rel = relpath_under(&root, &root).expect("relpath");
-        assert_eq!(normalize_dropbox_path(&rel), "");
+        assert_eq!(normalize_dropbox_path(&rel).unwrap(), "");
     }
 
     #[test]
@@ -324,6 +331,6 @@ mod tests {
         let dir = root.join("Cocina").join("Pizza");
         let rel = relpath_under(&root, &dir).expect("relpath");
         // `normalize_dropbox_path` itself converts OS separators to '/'.
-        assert_eq!(normalize_dropbox_path(&rel), "/Cocina/Pizza");
+        assert_eq!(normalize_dropbox_path(&rel).unwrap(), "/Cocina/Pizza");
     }
 }

--- a/apps/desktop/src-tauri/src/dropbox_transfer.rs
+++ b/apps/desktop/src-tauri/src/dropbox_transfer.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 use std::fs::{self, File};
 use std::io;
 use std::io::{Read, Seek, SeekFrom, Write};
-use std::path::{Path, PathBuf};
+use std::path::Path;
 use std::time::Duration;
 
 use reqwest::blocking::{Body, Client};
@@ -16,7 +16,7 @@ use crate::models::{
 };
 use crate::path_util::{
     create_conflicted_copy, hash_file, is_path_allowed, normalize_dropbox_path, parse_prefix_csv,
-    relpath_under,
+    relpath_under, safe_join,
 };
 use crate::state::AppState;
 use crate::storage::db::FileIndexRow;
@@ -249,7 +249,7 @@ pub(crate) fn list_remote_folder(
     let include_prefixes = parse_prefix_csv(state.db.get_include_prefixes_csv()?);
     let exclude_prefixes = parse_prefix_csv(state.db.get_exclude_prefixes_csv()?);
 
-    let dropbox_path = normalize_dropbox_path(&path);
+    let dropbox_path = normalize_dropbox_path(&path)?;
 
     let client = &state.http_client;
     let response = client
@@ -287,8 +287,11 @@ pub(crate) fn list_remote_folder(
             continue;
         };
         let relative = path_display.trim_start_matches('/').to_string();
-        let local_target = PathBuf::from(&folder).join(&relative);
-        let is_synced = local_target.exists();
+        // A poisoned remote entry that tries to traverse out of the sync root is
+        // never "synced"; refuse the join and treat it as not present locally.
+        let is_synced = safe_join(Path::new(&folder), &relative)
+            .map(|p| p.exists())
+            .unwrap_or(false);
         let is_excluded = !is_path_allowed(&relative, &include_prefixes, &exclude_prefixes);
 
         entries.push(RemoteEntry {
@@ -804,7 +807,7 @@ pub(crate) fn upload_local_file_internal(
         .get_sync_folder()?
         .ok_or_else(|| AppError::Sync("sync folder not configured".to_string()))?;
 
-    let local_path = PathBuf::from(&folder).join(relative);
+    let local_path = safe_join(Path::new(&folder), relative)?;
     if !local_path.exists() {
         return Err(AppError::Sync(format!("local file missing for upload: {relative}")));
     }
@@ -833,7 +836,7 @@ pub(crate) fn upload_local_file_internal(
         .map_err(|e| AppError::Io(format!("failed reading local file metadata: {e}")))?
         .len();
 
-    let dropbox_path = normalize_dropbox_path(relative);
+    let dropbox_path = normalize_dropbox_path(relative)?;
 
     match choose_upload_strategy(len) {
         UploadStrategy::SingleShot => {
@@ -887,7 +890,7 @@ pub(crate) fn delete_remote_file_internal(state: &AppState, relative: &str) -> A
     }
 
     let token = get_access_token(state)?;
-    let dropbox_path = normalize_dropbox_path(relative);
+    let dropbox_path = normalize_dropbox_path(relative)?;
     let client = &state.http_client;
     let resp = client
         .post("https://api.dropboxapi.com/2/files/delete_v2")
@@ -930,7 +933,7 @@ pub(crate) fn delete_local_file_internal(state: &AppState, relative: &str) -> Ap
         .get_sync_folder()?
         .ok_or_else(|| AppError::Sync("sync folder not configured".to_string()))?;
 
-    let local_path = PathBuf::from(&folder).join(relative);
+    let local_path = safe_join(Path::new(&folder), relative)?;
     if local_path.exists() {
         fs::remove_file(&local_path)
             .map_err(|e| AppError::Io(format!("failed to delete local file {relative}: {e}")))?;
@@ -955,7 +958,8 @@ pub(crate) fn download_remote_file_internal(state: &AppState, path_display: &str
         return Ok(());
     }
 
-    let target = PathBuf::from(&folder).join(&relative);
+    // Refuse a remote path that would escape the sync root before writing.
+    let target = safe_join(Path::new(&folder), &relative)?;
 
     // Remote-wins conflict guard: preserve unsynced local edits before the atomic
     // overwrite below. (There is an inherent, benign TOCTOU window — an edit made
@@ -1068,7 +1072,14 @@ pub(crate) fn hydrate_remote_folder_internal(
                 continue;
             }
 
-            let target = PathBuf::from(&folder).join(&relative);
+            // Skip (don't abort the whole sweep on) a single traversing entry.
+            let target = match safe_join(Path::new(&folder), &relative) {
+                Ok(t) => t,
+                Err(e) => {
+                    tracing::warn!(path = %relative, error = %e, "skipping unsafe remote path");
+                    continue;
+                }
+            };
             fetch_and_write_file(client, &token, path_display, &target)?;
 
             let (hash, size_bytes, modified_ts) = hash_file(&target)?;
@@ -1161,7 +1172,13 @@ pub(crate) fn pull_remote_snapshot_internal(state: &AppState) -> AppResult<usize
             };
 
             let relative = path_display.trim_start_matches('/').to_string();
-            let target = PathBuf::from(&folder).join(&relative);
+            let target = match safe_join(Path::new(&folder), &relative) {
+                Ok(t) => t,
+                Err(e) => {
+                    tracing::warn!(path = %relative, error = %e, "skipping unsafe remote path");
+                    continue;
+                }
+            };
 
             if known_map.contains_key(&relative) && target.exists() {
                 continue;

--- a/apps/desktop/src-tauri/src/path_util.rs
+++ b/apps/desktop/src-tauri/src/path_util.rs
@@ -23,17 +23,72 @@ pub(crate) fn relpath_under(sync_folder: &Path, absolute: &Path) -> AppResult<St
         .replace('\\', "/"))
 }
 
-pub(crate) fn normalize_dropbox_path(input: &str) -> String {
+/// True if `input` contains a path-traversal component (`..`) — checked against
+/// both `/` and `\` separators — or an embedded NUL byte. Such inputs must never
+/// be used to build a Dropbox path or a local filesystem path (DBSYNC-27).
+fn has_traversal(input: &str) -> bool {
+    input.contains('\0') || input.split(['/', '\\']).any(|c| c == "..")
+}
+
+/// True if `input` is an OS-absolute path that has no business appearing as a
+/// path relative to the sync root: a Windows drive prefix (`C:\`, `C:/`) or a
+/// UNC path (`\\server`). A single leading `/` is intentionally NOT treated as
+/// absolute here — it is the legitimate Dropbox root convention.
+fn is_os_absolute(input: &str) -> bool {
+    let bytes = input.as_bytes();
+    if bytes.len() >= 2 && bytes[0].is_ascii_alphabetic() && bytes[1] == b':' {
+        return true; // Windows drive-absolute, e.g. `C:\Users` or `C:/Users`
+    }
+    input.starts_with("\\\\") // UNC path, e.g. `\\server\share`
+}
+
+/// Turn a relative path into a Dropbox API path (`/`-prefixed), rejecting any
+/// input that could escape the intended tree. Returns an error for paths that
+/// contain `..`, NUL bytes, or an OS-absolute prefix instead of silently
+/// building a traversing path (DBSYNC-27). A leading `/` is preserved.
+pub(crate) fn normalize_dropbox_path(input: &str) -> AppResult<String> {
+    if has_traversal(input) || is_os_absolute(input) {
+        return Err(AppError::Sync(format!("rejected unsafe path: {input:?}")));
+    }
     if input.is_empty() {
-        return "".to_string();
+        return Ok(String::new());
     }
     // Windows relative paths use `\` separators; Dropbox requires `/`.
     let forward = input.replace('\\', "/");
-    if forward.starts_with('/') {
+    Ok(if forward.starts_with('/') {
         forward
     } else {
-        format!("/{}", forward)
+        format!("/{forward}")
+    })
+}
+
+/// Validate that `rel` is a safe path *relative* to the sync root: no `..`, no
+/// NUL byte, and not absolute (no leading `/` or `\`, no drive/UNC prefix).
+/// Used before joining any remote-derived path onto the local sync folder.
+pub(crate) fn validate_relative(rel: &str) -> AppResult<()> {
+    if has_traversal(rel)
+        || is_os_absolute(rel)
+        || rel.starts_with('/')
+        || rel.starts_with('\\')
+    {
+        return Err(AppError::Sync(format!(
+            "rejected unsafe relative path: {rel:?}"
+        )));
     }
+    Ok(())
+}
+
+/// Join an untrusted relative path onto `root`, refusing to escape it. Validates
+/// `rel` with [`validate_relative`], then verifies (lexically, without touching
+/// the filesystem — the target may not exist yet) that the result stays under
+/// `root`. This is the single choke point for every remote→local write sink.
+pub(crate) fn safe_join(root: &Path, rel: &str) -> AppResult<PathBuf> {
+    validate_relative(rel)?;
+    let joined = root.join(rel);
+    if !joined.starts_with(root) {
+        return Err(AppError::Sync(format!("path escapes sync root: {rel:?}")));
+    }
+    Ok(joined)
 }
 
 pub(crate) fn parse_prefix_csv(csv: Option<String>) -> Vec<String> {
@@ -179,7 +234,12 @@ mod tests {
     use sha2::{Digest, Sha256};
     use tempfile::NamedTempFile;
 
-    use super::{backoff_seconds, hash_file, DROPBOX_BLOCK_SIZE};
+    use std::path::Path;
+
+    use super::{
+        backoff_seconds, hash_file, normalize_dropbox_path, safe_join, validate_relative,
+        DROPBOX_BLOCK_SIZE,
+    };
 
     // ---------------------------------------------------------------------------
     // Helper: compute the Dropbox content_hash for an in-memory byte slice so
@@ -304,6 +364,77 @@ mod tests {
 
         let (hash, _, _) = hash_file(tmp.path()).expect("hash_file");
         assert_eq!(hash, expected);
+    }
+
+    // ---------------------------------------------------------------------------
+    // Path-traversal hardening (DBSYNC-27)
+    // ---------------------------------------------------------------------------
+
+    #[test]
+    fn normalize_accepts_legit_paths() {
+        assert_eq!(normalize_dropbox_path("").unwrap(), "");
+        assert_eq!(normalize_dropbox_path("Cocina/Pizza").unwrap(), "/Cocina/Pizza");
+        // A leading '/' is the Dropbox root convention and must be preserved.
+        assert_eq!(normalize_dropbox_path("/Cocina").unwrap(), "/Cocina");
+        // Windows separators are canonicalised to '/'.
+        assert_eq!(normalize_dropbox_path("Cocina\\Pizza").unwrap(), "/Cocina/Pizza");
+    }
+
+    #[test]
+    fn normalize_rejects_traversal_payloads() {
+        for bad in [
+            "../etc/passwd",
+            "Cocina/../../secret",
+            "..\\Windows\\System32",
+            "a/../../b",
+            "C:\\Windows",
+            "C:/Windows",
+            "\\\\server\\share",
+            "with\0null",
+        ] {
+            assert!(
+                normalize_dropbox_path(bad).is_err(),
+                "expected rejection for {bad:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn validate_relative_rejects_absolute_and_traversal() {
+        assert!(validate_relative("Cocina/Pizza").is_ok());
+        assert!(validate_relative("a/b/c.txt").is_ok());
+
+        for bad in [
+            "..",
+            "../x",
+            "a/../../b",
+            "/etc/passwd",
+            "\\Windows",
+            "C:\\x",
+            "\\\\unc\\x",
+            "x\0y",
+        ] {
+            assert!(validate_relative(bad).is_err(), "expected rejection for {bad:?}");
+        }
+    }
+
+    #[test]
+    fn safe_join_stays_under_root() {
+        let root = Path::new("/sync/root");
+        let joined = safe_join(root, "Cocina/Pizza.txt").expect("legit join");
+        assert!(joined.starts_with(root));
+        assert_eq!(joined, Path::new("/sync/root/Cocina/Pizza.txt"));
+    }
+
+    #[test]
+    fn safe_join_refuses_to_escape_root() {
+        let root = Path::new("/sync/root");
+        for bad in ["../outside", "a/../../b", "/abs/path", "..", "x\0y"] {
+            assert!(
+                safe_join(root, bad).is_err(),
+                "safe_join must refuse {bad:?}"
+            );
+        }
     }
 
     #[test]

--- a/apps/desktop/src-tauri/src/path_util.rs
+++ b/apps/desktop/src-tauri/src/path_util.rs
@@ -429,7 +429,17 @@ mod tests {
     #[test]
     fn safe_join_refuses_to_escape_root() {
         let root = Path::new("/sync/root");
-        for bad in ["../outside", "a/../../b", "/abs/path", "..", "x\0y"] {
+        for bad in [
+            "../outside",
+            "a/../../b",
+            "/abs/path",
+            "..",
+            "x\0y",
+            // A remote-derived child name carrying embedded separators (DBSYNC-27
+            // review finding #1: the `.cloudsc` placeholder write sink).
+            "..\\..\\evil.cloudsc",
+            "sub\\..\\..\\evil",
+        ] {
             assert!(
                 safe_join(root, bad).is_err(),
                 "safe_join must refuse {bad:?}"

--- a/apps/desktop/src-tauri/src/remote_index.rs
+++ b/apps/desktop/src-tauri/src/remote_index.rs
@@ -27,7 +27,7 @@ pub(crate) fn fetch_remote_file_metadata(
 ) -> AppResult<Option<RemoteFileMeta>> {
     let token = get_access_token(state)?;
     let client = &state.http_client;
-    let dropbox_path = normalize_dropbox_path(relative);
+    let dropbox_path = normalize_dropbox_path(relative)?;
 
     let response = client
         .post("https://api.dropboxapi.com/2/files/get_metadata")
@@ -209,7 +209,7 @@ pub(crate) fn refresh_remote_index_and_enqueue_downloads_internal(
 
         let prev_remote = state.db.get_remote_file(&rel)?;
         let remote_meta = remote_by_path
-            .get(&normalize_dropbox_path(&rel).to_lowercase())
+            .get(&normalize_dropbox_path(&rel)?.to_lowercase())
             .cloned();
         let Some(remote_meta) = remote_meta else {
             // Remote copy is gone. Only propagate the deletion when we had

--- a/apps/desktop/src-tauri/src/sync_pipeline.rs
+++ b/apps/desktop/src-tauri/src/sync_pipeline.rs
@@ -306,7 +306,9 @@ pub(crate) fn process_sync_queue_internal(state: &AppState) -> AppResult<bool> {
             .as_deref()
             .or(job.source_path.as_deref())
             .ok_or_else(|| AppError::Sync("download job missing target_path/source_path".to_string()))
-            .and_then(|rel| download_remote_file_internal(state, &normalize_dropbox_path(rel))),
+            .and_then(|rel| {
+                download_remote_file_internal(state, &normalize_dropbox_path(rel)?)
+            }),
         "hydrate_cloudsc" => job
             .source_path
             .as_deref()

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -37,7 +37,7 @@
       }
     ],
     "security": {
-      "csp": "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self' data:; connect-src 'self' ipc: http://ipc.localhost"
+      "csp": "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self' data:; connect-src 'self' ipc: http://ipc.localhost; object-src 'none'"
     }
   },
   "bundle": {

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -37,7 +37,7 @@
       }
     ],
     "security": {
-      "csp": null
+      "csp": "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self' data:; connect-src 'self' ipc: http://ipc.localhost"
     }
   },
   "bundle": {


### PR DESCRIPTION
## Summary
Closes the two security holes in **DBSYNC-27**.

**Slice 1 — Path traversal (#26)**
- `normalize_dropbox_path` → `AppResult<String>`; rejects `..`, NUL bytes, OS-absolute prefixes (drive `C:\`/UNC). Leading `/` (Dropbox root) preserved.
- New `validate_relative()` + `safe_join()` in `path_util.rs`; all 6 remote-derived local-write sinks in `dropbox_transfer.rs` now go through `safe_join` (hydration loops skip a poisoned entry; single-file sinks fail closed).
- Fallible signature propagated via `?` to `cloudsc_ops`, `remote_index`, `sync_pipeline`.

**Slice 2 — CSP (#27)**
- `"csp": null` → `default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self' data:; connect-src 'self' ipc: http://ipc.localhost`. `script-src` has no `unsafe-inline`/`unsafe-eval`.

## Stack
desktop-tauri

## Jira Ticket
#DBSYNC-27

## Test Plan
- [x] `cargo test` — 69/69 pass (5 new traversal tests)
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `npm --workspace apps/desktop run build` — passes
- [x] Runtime smoke: flyout + setup windows render, IPC (sync/auth/logs/dossiers) works, no CSP violations in webview console — validated by user

## Security note
The real traversal sink is the local write (`PathBuf::from(&folder).join(&relative)` on remote-derived paths), not just the Dropbox path — both are now guarded by a single `safe_join` choke point.

🤖 Generated with Claude Code

https://claude.ai/code/session_01XFcb2z2QG5oQe6v8GyDwhd