### PR TITLE
fix(security): zeroize PKCE verifier, restrict app key visibility (#DBSYNC-28)

### DIFF
--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -940,6 +940,7 @@ dependencies = [
  "walkdir",
  "windows-sys 0.59.0",
  "winreg",
+ "zeroize",
 ]
 
 [[package]]
@@ -6374,18 +6375,18 @@ dependencies = [
 
 [[package]]
 name = "zeroize"
-version = "1.8.2"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
 dependencies = [
  "zeroize_derive",
 ]
 
 [[package]]
 name = "zeroize_derive"
-version = "1.4.3"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
+checksum = "3c50655cbb0fe3fc43170059e702f1ce5e19b84cec58dc87b037a09935c2f328"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -33,6 +33,7 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 url = "2"
 urlencoding = "2"
 walkdir = "2"
+zeroize = "1.9.0"
 
 [dev-dependencies]
 tempfile = "3"

--- a/apps/desktop/src-tauri/src/auth/oauth.rs
+++ b/apps/desktop/src-tauri/src/auth/oauth.rs
@@ -4,12 +4,20 @@ use reqwest::Client;
 use serde::Deserialize;
 use sha2::{Digest, Sha256};
 
+use zeroize::Zeroizing;
+
 use crate::error::{AppError, AppResult};
 
 /// Dropbox App Console → your app → **Settings** → **App key** (OAuth2 `client_id`).
 /// Prefer providing this value via `DROPBOX_APP_KEY` in `.env` for dev/build.
 /// The build command embeds it at compile time via `option_env!`.
-pub const DROPBOX_APP_KEY: &str = match option_env!("DROPBOX_APP_KEY") {
+///
+/// Threat model: this is the **public OAuth `client_id`**, not a secret. It is
+/// meant to be sent to Dropbox and is recoverable from the binary regardless
+/// (PKCE, not a client secret, is what protects the flow). `pub(crate)` here is
+/// visibility hygiene — keeping the surface minimal — not a confidentiality
+/// control; do not treat this value as sensitive.
+pub(crate) const DROPBOX_APP_KEY: &str = match option_env!("DROPBOX_APP_KEY") {
     Some(k) => k,
     None => "",
 };
@@ -89,7 +97,10 @@ pub fn start_oauth() -> AppResult<(String, String, String)> {
     Ok((auth_url, state, verifier))
 }
 
-pub async fn complete_oauth(code: String, verifier: String) -> AppResult<TokenResponse> {
+pub async fn complete_oauth(
+    code: String,
+    verifier: Zeroizing<String>,
+) -> AppResult<TokenResponse> {
     let app_key = resolve_app_key()?;
     let redirect_uri = resolve_redirect_uri();
     let client = Client::builder()
@@ -98,12 +109,16 @@ pub async fn complete_oauth(code: String, verifier: String) -> AppResult<TokenRe
         .map_err(|e| AppError::Network(format!("failed to build oauth http client: {e}")))?;
     let response = client
         .post("https://api.dropboxapi.com/oauth2/token")
+        // Pass values by `&str` so no additional owned copy of the verifier is
+        // made here; `verifier` (Zeroizing) is wiped when it drops at the end of
+        // this call. (serde_urlencoded's transient body buffer is owned by
+        // reqwest and dropped after send — the best-effort limit here.)
         .form(&[
-            ("code", code),
-            ("grant_type", "authorization_code".to_string()),
-            ("client_id", app_key),
-            ("redirect_uri", redirect_uri),
-            ("code_verifier", verifier),
+            ("code", code.as_str()),
+            ("grant_type", "authorization_code"),
+            ("client_id", app_key.as_str()),
+            ("redirect_uri", redirect_uri.as_str()),
+            ("code_verifier", verifier.as_str()),
         ])
         .send()
         .await

--- a/apps/desktop/src-tauri/src/sync/engine.rs
+++ b/apps/desktop/src-tauri/src/sync/engine.rs
@@ -1,4 +1,5 @@
 use serde::Serialize;
+use zeroize::Zeroizing;
 
 #[derive(Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -15,7 +16,11 @@ pub struct SyncStatus {
 
 pub struct SyncEngine {
     pending_oauth_state: Option<String>,
-    pending_pkce_verifier: Option<String>,
+    // PKCE code verifier: wrapped in `Zeroizing` so its bytes are wiped from
+    // memory when the field is cleared or the engine is dropped (DBSYNC-28).
+    // `pending_oauth_state` is the CSRF state token — not secret — so it stays a
+    // plain `String`.
+    pending_pkce_verifier: Option<Zeroizing<String>>,
     tracked_path: Option<String>,
     queue_depth: usize,
     last_error: Option<String>,
@@ -40,14 +45,16 @@ impl SyncEngine {
 
     pub fn set_oauth_context(&mut self, state: String, verifier: String) {
         self.pending_oauth_state = Some(state);
-        self.pending_pkce_verifier = Some(verifier);
+        self.pending_pkce_verifier = Some(Zeroizing::new(verifier));
     }
 
     pub fn pending_oauth_state(&self) -> Option<String> {
         self.pending_oauth_state.clone()
     }
 
-    pub fn pending_pkce_verifier(&self) -> Option<String> {
+    /// Returns a `Zeroizing` copy of the pending PKCE verifier, so the caller's
+    /// copy is also wiped on drop — no plain `String` clone escapes the engine.
+    pub fn pending_pkce_verifier(&self) -> Option<Zeroizing<String>> {
         self.pending_pkce_verifier.clone()
     }
 


### PR DESCRIPTION
## Summary
Two auth-hygiene fixes for **DBSYNC-28** (#29).

- **Zeroize PKCE verifier**: `SyncEngine.pending_pkce_verifier` is now `Option<Zeroizing<String>>` — wiped on clear and on drop. The getter returns `Zeroizing<String>` and `complete_oauth` takes `Zeroizing<String>`, building the token-exchange form via `.as_str()` so no plain-`String` clone of the verifier escapes. `pending_oauth_state` (CSRF token) stays a plain `String` (not sensitive).
- **Restrict app key**: `DROPBOX_APP_KEY` `pub const` → `pub(crate) const` (used only in-crate), with a doc comment on the threat model — it is the public OAuth `client_id`, not a secret; the change is visibility hygiene, not a confidentiality control.
- Added `zeroize` 1.9 as a direct dependency.

## Stack
desktop-tauri

## Jira Ticket
#DBSYNC-28

## Test Plan
- [x] `cargo test` — 69/69 pass
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] OAuth reconnect smoke — login/token-exchange flow unchanged (validated by user)

## Notes
Zeroization-on-drop is a type-level guarantee (`Zeroizing`), not directly unit-testable (freed memory). The transient urlencoded request body inside reqwest is the best-effort limit — it is owned by reqwest and dropped after send.

🤖 Generated with Claude Code

https://claude.ai/code/session_01XFcb2z2QG5oQe6v8GyDwhd