### PR TITLE
fix(security): zeroize OAuth access/refresh tokens in memory (#DBSYNC-46)

### DIFF
--- a/apps/desktop/src-tauri/src/auth/oauth.rs
+++ b/apps/desktop/src-tauri/src/auth/oauth.rs
@@ -29,11 +29,33 @@ pub const DROPBOX_REDIRECT_URI: &str = match option_env!("DROPBOX_REDIRECT_URI")
     None => "http://localhost:53682/callback",
 };
 
-#[derive(Deserialize)]
+/// OAuth token payload. The bearer credentials are wrapped in `Zeroizing` so
+/// they are wiped from memory on drop (DBSYNC-46). `expires_in` is not secret.
 pub struct TokenResponse {
-    pub access_token: String,
-    pub refresh_token: Option<String>,
+    pub access_token: Zeroizing<String>,
+    pub refresh_token: Option<Zeroizing<String>>,
     pub expires_in: Option<i64>,
+}
+
+/// Plain deserialization target for the token endpoint response. `Zeroizing`
+/// has no `Deserialize` impl, so we parse into this and immediately MOVE the
+/// strings into `Zeroizing` (a move reuses the same allocation — the secret
+/// bytes are never copied, and this value's plain lifetime is a single stmt).
+#[derive(Deserialize)]
+struct RawTokenResponse {
+    access_token: String,
+    refresh_token: Option<String>,
+    expires_in: Option<i64>,
+}
+
+impl From<RawTokenResponse> for TokenResponse {
+    fn from(raw: RawTokenResponse) -> Self {
+        TokenResponse {
+            access_token: Zeroizing::new(raw.access_token),
+            refresh_token: raw.refresh_token.map(Zeroizing::new),
+            expires_in: raw.expires_in,
+        }
+    }
 }
 
 fn resolve_app_key() -> AppResult<String> {
@@ -137,12 +159,14 @@ pub async fn complete_oauth(
         )));
     }
 
-    let token = serde_json::from_slice::<TokenResponse>(&body).map_err(|e| {
-        AppError::Auth(format!(
-            "token parse failed: {e}; body: {}",
-            String::from_utf8_lossy(&body)
-        ))
-    })?;
+    let token: TokenResponse = serde_json::from_slice::<RawTokenResponse>(&body)
+        .map_err(|e| {
+            AppError::Auth(format!(
+                "token parse failed: {e}; body: {}",
+                String::from_utf8_lossy(&body)
+            ))
+        })?
+        .into();
 
     Ok(token)
 }
@@ -156,11 +180,13 @@ pub fn refresh_access_token_blocking(
 
     let response = client
         .post("https://api.dropboxapi.com/oauth2/token")
+        // Pass by `&str` so no owned plain-String copy of the refresh token is
+        // made here (DBSYNC-46); `refresh_token` is already a borrowed &str.
         .form(&[
-            ("refresh_token", refresh_token.to_string()),
-            ("grant_type", "refresh_token".to_string()),
-            ("client_id", app_key),
-            ("redirect_uri", redirect_uri),
+            ("refresh_token", refresh_token),
+            ("grant_type", "refresh_token"),
+            ("client_id", app_key.as_str()),
+            ("redirect_uri", redirect_uri.as_str()),
         ])
         .send()
         .map_err(|e| AppError::Network(format!("refresh token request failed: {e}")))?;
@@ -176,6 +202,7 @@ pub fn refresh_access_token_blocking(
     }
 
     response
-        .json::<TokenResponse>()
+        .json::<RawTokenResponse>()
+        .map(TokenResponse::from)
         .map_err(|e| AppError::Auth(format!("refresh token parse failed: {e}")))
 }

--- a/apps/desktop/src-tauri/src/auth_session.rs
+++ b/apps/desktop/src-tauri/src/auth_session.rs
@@ -2,6 +2,7 @@ use std::sync::atomic::Ordering;
 use std::sync::{Arc, Mutex};
 
 use chrono::{Duration, Utc};
+use zeroize::Zeroizing;
 
 use crate::auth::oauth::refresh_access_token_blocking;
 use crate::error::{AppError, AppResult};
@@ -116,7 +117,7 @@ pub(crate) fn force_refresh_session(state: &AppState) -> AppResult<TokenSession>
     })
 }
 
-pub(crate) fn get_access_token(state: &AppState) -> AppResult<String> {
+pub(crate) fn get_access_token(state: &AppState) -> AppResult<Zeroizing<String>> {
     if let Ok(cache) = state.token_cache.lock() {
         if let Some(session) = cache.as_ref() {
             if !session_needs_refresh(session) {
@@ -133,7 +134,7 @@ pub(crate) fn get_access_token(state: &AppState) -> AppResult<String> {
                 .get_token()
                 .map_err(|e| AppError::Auth(format!("missing dropbox token session: {e}")))?;
             let migrated = TokenSession {
-                access_token: legacy_token,
+                access_token: Zeroizing::new(legacy_token),
                 refresh_token: None,
                 expires_at: None,
             };
@@ -259,13 +260,14 @@ pub(crate) fn update_tray_tooltip(app: &tauri::AppHandle, label: &str) {
 mod tests {
     use super::{refresh_token_guarded, TokenSession};
     use chrono::{Duration, Utc};
+    use zeroize::Zeroizing;
     use std::sync::atomic::{AtomicUsize, Ordering};
     use std::sync::{Arc, Mutex};
 
     fn fresh_session() -> TokenSession {
         TokenSession {
-            access_token: "canned-access-token".to_string(),
-            refresh_token: Some("canned-refresh-token".to_string()),
+            access_token: Zeroizing::new("canned-access-token".to_string()),
+            refresh_token: Some(Zeroizing::new("canned-refresh-token".to_string())),
             // Far in the future so `session_needs_refresh` returns false and the
             // double-check reuses it instead of refreshing again.
             expires_at: Some((Utc::now() + Duration::hours(1)).to_rfc3339()),
@@ -308,7 +310,7 @@ mod tests {
         );
         for r in results {
             let session = r.expect("guarded refresh should succeed");
-            assert_eq!(session.access_token, "canned-access-token");
+            assert_eq!(session.access_token.as_str(), "canned-access-token");
         }
     }
 }

--- a/apps/desktop/src-tauri/src/cloudsc_ops.rs
+++ b/apps/desktop/src-tauri/src/cloudsc_ops.rs
@@ -45,7 +45,7 @@ pub(crate) fn index_remote_folder_children_as_cloudsc_placeholders_internal(
     let mut entries_resp: DropboxListFolderResponse = {
         let response = client
             .post("https://api.dropboxapi.com/2/files/list_folder")
-            .bearer_auth(&token)
+            .bearer_auth(token.as_str())
             .json(&serde_json::json!({
                 "path": remote_folder_path_display,
                 "recursive": false,
@@ -133,7 +133,7 @@ pub(crate) fn index_remote_folder_children_as_cloudsc_placeholders_internal(
         }
         let response = client
             .post("https://api.dropboxapi.com/2/files/list_folder/continue")
-            .bearer_auth(&token)
+            .bearer_auth(token.as_str())
             .json(&serde_json::json!({ "cursor": entries_resp.cursor }))
             .send()
             .map_err(|e| AppError::Network(format!("list_folder/continue request failed: {e}")))?;

--- a/apps/desktop/src-tauri/src/dropbox_transfer.rs
+++ b/apps/desktop/src-tauri/src/dropbox_transfer.rs
@@ -254,7 +254,7 @@ pub(crate) fn list_remote_folder(
     let client = &state.http_client;
     let response = client
         .post("https://api.dropboxapi.com/2/files/list_folder")
-        .bearer_auth(&token)
+        .bearer_auth(token.as_str())
         .json(&serde_json::json!({
             "path": dropbox_path,
             "recursive": false,
@@ -843,7 +843,7 @@ pub(crate) fn upload_local_file_internal(
             let client = &state.http_client;
             let resp = client
                 .post("https://content.dropboxapi.com/2/files/upload")
-                .bearer_auth(&token)
+                .bearer_auth(token.as_str())
                 .header(
                     "Dropbox-API-Arg",
                     serde_json::json!({
@@ -894,7 +894,7 @@ pub(crate) fn delete_remote_file_internal(state: &AppState, relative: &str) -> A
     let client = &state.http_client;
     let resp = client
         .post("https://api.dropboxapi.com/2/files/delete_v2")
-        .bearer_auth(&token)
+        .bearer_auth(token.as_str())
         .json(&serde_json::json!({
             "path": dropbox_path
         }))
@@ -1032,7 +1032,7 @@ pub(crate) fn hydrate_remote_folder_internal(
 
     let response = client
         .post("https://api.dropboxapi.com/2/files/list_folder")
-        .bearer_auth(&token)
+        .bearer_auth(token.as_str())
         .json(&serde_json::json!({
             "path": folder_path_display,
             "recursive": true,
@@ -1093,7 +1093,7 @@ pub(crate) fn hydrate_remote_folder_internal(
 
         entries_resp = client
             .post("https://api.dropboxapi.com/2/files/list_folder/continue")
-            .bearer_auth(&token)
+            .bearer_auth(token.as_str())
             .json(&serde_json::json!({ "cursor": entries_resp.cursor.clone() }))
             .send()
             .map_err(|e| {
@@ -1137,7 +1137,7 @@ pub(crate) fn pull_remote_snapshot_internal(state: &AppState) -> AppResult<usize
 
     let list_folder_resp = client
         .post("https://api.dropboxapi.com/2/files/list_folder")
-        .bearer_auth(&token)
+        .bearer_auth(token.as_str())
         .json(&serde_json::json!({
             "path": "",
             "recursive": true,
@@ -1198,7 +1198,7 @@ pub(crate) fn pull_remote_snapshot_internal(state: &AppState) -> AppResult<usize
 
         let continue_resp = client
             .post("https://api.dropboxapi.com/2/files/list_folder/continue")
-            .bearer_auth(&token)
+            .bearer_auth(token.as_str())
             .json(&serde_json::json!({ "cursor": response.cursor.clone() }))
             .send()
             .map_err(|e| {

--- a/apps/desktop/src-tauri/src/remote_index.rs
+++ b/apps/desktop/src-tauri/src/remote_index.rs
@@ -31,7 +31,7 @@ pub(crate) fn fetch_remote_file_metadata(
 
     let response = client
         .post("https://api.dropboxapi.com/2/files/get_metadata")
-        .bearer_auth(&token)
+        .bearer_auth(token.as_str())
         .json(&serde_json::json!({
             "path": dropbox_path,
             "include_media_info": false,
@@ -127,7 +127,7 @@ pub(crate) fn fetch_all_remote_file_metadata(
     let mut entries_resp: DropboxListFolderResponse = {
         let response = client
             .post("https://api.dropboxapi.com/2/files/list_folder")
-            .bearer_auth(&token)
+            .bearer_auth(token.as_str())
             .json(&serde_json::json!({
                 "path": "",
                 "recursive": true,
@@ -160,7 +160,7 @@ pub(crate) fn fetch_all_remote_file_metadata(
         }
         let response = client
             .post("https://api.dropboxapi.com/2/files/list_folder/continue")
-            .bearer_auth(&token)
+            .bearer_auth(token.as_str())
             .json(&serde_json::json!({ "cursor": entries_resp.cursor }))
             .send()
             .map_err(|e| AppError::Network(format!("list_folder/continue request failed: {e}")))?;

--- a/apps/desktop/src-tauri/src/storage/secure_store.rs
+++ b/apps/desktop/src-tauri/src/storage/secure_store.rs
@@ -1,5 +1,6 @@
 use keyring::Entry;
-use serde::{Deserialize, Serialize};
+use serde::Deserialize;
+use zeroize::Zeroizing;
 
 const SERVICE: &str = "dropbox-sync-desktop";
 
@@ -22,11 +23,27 @@ pub struct SecureStore;
 
 /// Full OAuth session persisted in the OS keychain, including `refresh_token`.
 /// Survives app restarts. The in-memory `AppState::token_cache` is only a runtime copy.
-#[derive(Clone, Debug, Serialize, Deserialize)]
+///
+/// The bearer credentials are `Zeroizing` so the cached in-memory copy is wiped
+/// on drop (DBSYNC-46). Persisted fields are written to the keyring individually
+/// (see `store_session`), so `TokenSession` itself is never (de)serialized —
+/// hence no `Serialize`/`Deserialize` derive; the legacy JSON blob is parsed via
+/// `LegacyTokenSession` below.
+#[derive(Clone, Debug)]
 pub struct TokenSession {
-    pub access_token: String,
-    pub refresh_token: Option<String>,
-    pub expires_at: Option<String>, // RFC3339
+    pub access_token: Zeroizing<String>,
+    pub refresh_token: Option<Zeroizing<String>>,
+    pub expires_at: Option<String>, // RFC3339 — not secret
+}
+
+/// Plain parse target for the pre-`TokenSession` single-JSON-blob keyring entry.
+/// Only used in the one-time migration in `get_session`; strings are moved into
+/// `Zeroizing` immediately after parsing.
+#[derive(Deserialize)]
+struct LegacyTokenSession {
+    access_token: String,
+    refresh_token: Option<String>,
+    expires_at: Option<String>,
 }
 
 impl SecureStore {
@@ -71,16 +88,21 @@ impl SecureStore {
                 _ => None,
             };
             return Ok(TokenSession {
-                access_token: access,
-                refresh_token: refresh,
+                access_token: Zeroizing::new(access),
+                refresh_token: refresh.map(Zeroizing::new),
                 expires_at,
             });
         }
 
         let legacy_e = Entry::new(SERVICE, LEGACY_SESSION_KEY)?;
         let json = legacy_e.get_password()?;
-        let session: TokenSession =
+        let legacy: LegacyTokenSession =
             serde_json::from_str(&json).map_err(|_| keyring::Error::NoEntry)?;
+        let session = TokenSession {
+            access_token: Zeroizing::new(legacy.access_token),
+            refresh_token: legacy.refresh_token.map(Zeroizing::new),
+            expires_at: legacy.expires_at,
+        };
         self.store_session(&session)?;
         Ok(session)
     }


### PR DESCRIPTION
## Summary
Follow-up to DBSYNC-28. Wipes the long-lived OAuth bearer credentials from memory (#31, #32).

**Slice 1 — holders + refresh-form copy**
- `TokenResponse` / `TokenSession` tokens → `Zeroizing<String>` (wiped on drop). Parsed via private plain structs (`RawTokenResponse`, `LegacyTokenSession`) whose strings are **moved** into `Zeroizing` (no byte copy). Removed unused `Serialize`/`Deserialize` from `TokenSession`.
- `refresh_access_token_blocking` builds the form via `.as_str()` — no owned plain-`String` copy of the refresh token.

**Slice 2 — propagation**
- `get_access_token()` returns `Zeroizing<String>`; 12 `bearer_auth(&token)` sites → `bearer_auth(token.as_str())`. Helper fns with `token: &str` params keep working via Deref coercion.

`expires_in` and the CSRF state token stay plain (not sensitive); keyring at-rest storage unchanged.

## Stack
desktop-tauri

## Jira Ticket
#DBSYNC-46

## Test Plan
- [x] `cargo test` — 69/69 pass
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] OAuth reconnect + sync smoke — no auth errors (validated by user)

🤖 Generated with Claude Code

https://claude.ai/code/session_01XFcb2z2QG5oQe6v8GyDwhd