### PR TITLE
fix(ux): reflect Syncing/Idle in tray tooltip on sync transitions (#DBSYNC-48)

### DIFF
--- a/apps/desktop/src-tauri/src/auth_session.rs
+++ b/apps/desktop/src-tauri/src/auth_session.rs
@@ -256,6 +256,17 @@ pub(crate) fn update_tray_tooltip(app: &tauri::AppHandle, label: &str) {
     }
 }
 
+/// Refreshes the tray tooltip to reflect the current sync status. Uses the
+/// globally-stored `AppHandle` (set in `setup()`), so background sync threads —
+/// which don't carry an `AppHandle` — can refresh it right at each
+/// `sync_running` transition instead of waiting for the 60s scheduler poll,
+/// which almost always misses the short "Syncing" window (DBSYNC-48).
+pub(crate) fn refresh_tray_tooltip(state: &AppState) {
+    if let Some(app) = crate::state::APP_HANDLE.get() {
+        update_tray_tooltip(app, &current_tray_status_label(state));
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::{refresh_token_guarded, TokenSession};

--- a/apps/desktop/src-tauri/src/commands.rs
+++ b/apps/desktop/src-tauri/src/commands.rs
@@ -201,6 +201,9 @@ pub fn start_background_scheduler(
                 .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
                 .is_ok()
         {
+            // Show "Syncing" for the duration of this tick (DBSYNC-48); the
+            // tooltip is refreshed back to Idle/Error after the store below.
+            update_tray_tooltip(&app, &current_tray_status_label(&app_state));
             // Run the sync tick first so a local folder deletion is detected,
             // its `delete` job enqueued, and drained within this same tick
             // (deleting the folder remotely) before discovery runs. Otherwise
@@ -408,6 +411,8 @@ pub fn trigger_sync_tick(state: tauri::State<AppState>) -> Result<TriggerSyncRes
         return Ok(TriggerSyncResponse { accepted: false });
     }
 
+    // Reflect the sync start in the tray tooltip immediately (DBSYNC-48).
+    crate::auth_session::refresh_tray_tooltip(state.inner());
     let app_state = state.inner().clone();
     std::thread::spawn(move || {
         let result = run_sync_tick_internal(&app_state);
@@ -417,6 +422,7 @@ pub fn trigger_sync_tick(state: tauri::State<AppState>) -> Result<TriggerSyncRes
             }
         }
         app_state.sync_running.store(false, Ordering::Release);
+        crate::auth_session::refresh_tray_tooltip(&app_state);
     });
 
     Ok(TriggerSyncResponse { accepted: true })
@@ -458,6 +464,8 @@ pub fn trigger_hydrate_cloudsc_placeholder(
         return Ok(TriggerActionResponse { accepted: false });
     }
 
+    // Reflect the sync start in the tray tooltip immediately (DBSYNC-48).
+    crate::auth_session::refresh_tray_tooltip(state.inner());
     let app_state = state.inner().clone();
     std::thread::spawn(move || {
         let result = hydrate_cloudsc_placeholder_internal(&app_state, &placeholder_local_rel_path);
@@ -472,6 +480,7 @@ pub fn trigger_hydrate_cloudsc_placeholder(
             engine.set_last_scan_at(Utc::now().to_rfc3339());
         }
         app_state.sync_running.store(false, Ordering::Release);
+        crate::auth_session::refresh_tray_tooltip(&app_state);
     });
 
     Ok(TriggerActionResponse { accepted: true })
@@ -490,6 +499,8 @@ pub fn trigger_download_remote_file(
         return Ok(TriggerActionResponse { accepted: false });
     }
 
+    // Reflect the sync start in the tray tooltip immediately (DBSYNC-48).
+    crate::auth_session::refresh_tray_tooltip(state.inner());
     let app_state = state.inner().clone();
     std::thread::spawn(move || {
         let result = download_remote_file_internal(&app_state, &path_display);
@@ -502,6 +513,7 @@ pub fn trigger_download_remote_file(
             engine.set_last_scan_at(Utc::now().to_rfc3339());
         }
         app_state.sync_running.store(false, Ordering::Release);
+        crate::auth_session::refresh_tray_tooltip(&app_state);
     });
 
     Ok(TriggerActionResponse { accepted: true })
@@ -520,6 +532,8 @@ pub fn trigger_hydrate_remote_folder(
         return Ok(TriggerActionResponse { accepted: false });
     }
 
+    // Reflect the sync start in the tray tooltip immediately (DBSYNC-48).
+    crate::auth_session::refresh_tray_tooltip(state.inner());
     let app_state = state.inner().clone();
     std::thread::spawn(move || {
         let result = hydrate_remote_folder_internal(&app_state, &folder_path_display);
@@ -534,6 +548,7 @@ pub fn trigger_hydrate_remote_folder(
             engine.set_last_scan_at(Utc::now().to_rfc3339());
         }
         app_state.sync_running.store(false, Ordering::Release);
+        crate::auth_session::refresh_tray_tooltip(&app_state);
     });
 
     Ok(TriggerActionResponse { accepted: true })

--- a/apps/desktop/src-tauri/src/open_handlers.rs
+++ b/apps/desktop/src-tauri/src/open_handlers.rs
@@ -38,6 +38,7 @@ pub(crate) fn spawn_drain_sync_queue_if_idle(app_state: AppState) {
         {
             return;
         }
+        crate::auth_session::refresh_tray_tooltip(&app_state);
         let mut safety = 0usize;
         while safety < 1000 {
             safety += 1;
@@ -51,6 +52,7 @@ pub(crate) fn spawn_drain_sync_queue_if_idle(app_state: AppState) {
             }
         }
         app_state.sync_running.store(false, Ordering::Release);
+        crate::auth_session::refresh_tray_tooltip(&app_state);
     });
 }
 


### PR DESCRIPTION
## Summary
The system-tray tooltip was stuck on `Idle` during a sync: it was only refreshed by the 60s scheduler poll, which almost always misses the short `sync_running=true` window.

Adds `auth_session::refresh_tray_tooltip(state)` — reads the already-global `crate::state::APP_HANDLE` (background sync threads carry no `AppHandle`) and re-renders the tooltip from `current_tray_status_label`. Called at **every** `sync_running` transition (start after the compare_exchange-to-true, end after `store(false)`): the 4 trigger commands, the scheduler tick, and the `.cloudsc`-open drain in `open_handlers`. Event-driven, no busy-loop, no change to the poll cadence.

## Stack
desktop-tauri

## Jira Ticket
#DBSYNC-48

## Test Plan
- [x] `cargo test` — 69/69 pass
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] Tray tooltip shows `Syncing` during a sync and `Idle`/`Error` after — validated by user

🤖 Generated with Claude Code

https://claude.ai/code/session_01XFcb2z2QG5oQe6v8GyDwhd