### PR TITLE
feat(observability): log sync activity at INFO (#DBSYNC-47)

### DIFF
--- a/apps/desktop/src-tauri/src/auth_session.rs
+++ b/apps/desktop/src-tauri/src/auth_session.rs
@@ -91,6 +91,7 @@ pub(crate) fn force_refresh_session(state: &AppState) -> AppResult<TokenSession>
     };
 
     refresh_token_guarded(&state.token_cache, &state.token_refresh_lock, true, || {
+        tracing::info!(forced = true, "refreshing dropbox access token");
         let refreshed = refresh_access_token_blocking(&state.http_client, &refresh_token)?;
 
         let new_refresh_token = refreshed
@@ -158,6 +159,7 @@ pub(crate) fn get_access_token(state: &AppState) -> AppResult<Zeroizing<String>>
 
     let refreshed_session =
         refresh_token_guarded(&state.token_cache, &state.token_refresh_lock, false, || {
+            tracing::info!(forced = false, "refreshing dropbox access token");
             let refreshed = refresh_access_token_blocking(&state.http_client, &refresh_token)?;
 
             let new_refresh_token = refreshed

--- a/apps/desktop/src-tauri/src/commands.rs
+++ b/apps/desktop/src-tauri/src/commands.rs
@@ -259,6 +259,11 @@ pub fn show_setup_window(app: AppHandle) -> Result<(), String> {
 /// DBSYNC-18) in the OS text editor — Notepad on Windows, the default text
 /// editor on macOS, `xdg-open` on Linux. Falls back to opening the data dir if
 /// no log file exists yet.
+///
+/// Note (DBSYNC-47): this opens a **snapshot** — Notepad and most default text
+/// editors do not live-tail, so the view will not grow while open. Re-invoke to
+/// see new entries, or point a tailing viewer at the file. The file itself is
+/// written continuously (see `logging.rs`); sync activity is logged at INFO.
 #[tauri::command]
 pub fn open_logs() -> Result<(), String> {
     let dir = crate::storage::db::app_data_dir().map_err(|e| e.to_string())?;

--- a/apps/desktop/src-tauri/src/dropbox_transfer.rs
+++ b/apps/desktop/src-tauri/src/dropbox_transfer.rs
@@ -983,6 +983,11 @@ pub(crate) fn download_remote_file_internal(state: &AppState, path_display: &str
             if let Ok(mut engine) = state.sync_engine.lock() {
                 engine.record_conflict();
             }
+            tracing::warn!(
+                path = %relative,
+                conflicted_copy = %conflicted_rel,
+                "sync conflict: local copy preserved before remote overwrite"
+            );
             emit_sync_conflict(&relative, &conflicted_rel, &reason);
         }
     }

--- a/apps/desktop/src-tauri/src/remote_index.rs
+++ b/apps/desktop/src-tauri/src/remote_index.rs
@@ -258,6 +258,14 @@ pub(crate) fn refresh_remote_index_and_enqueue_downloads_internal(
         }
     }
 
+    // Summarise a remote-index refresh that enqueued work (DBSYNC-47); a no-op
+    // refresh stays silent so the periodic sweep doesn't spam the log.
+    if enqueued > 0 {
+        tracing::info!(
+            enqueued,
+            "remote index refresh enqueued download/delete jobs"
+        );
+    }
     Ok(enqueued)
 }
 

--- a/apps/desktop/src-tauri/src/sync_pipeline.rs
+++ b/apps/desktop/src-tauri/src/sync_pipeline.rs
@@ -281,6 +281,22 @@ pub(crate) fn process_sync_queue_internal(state: &AppState) -> AppResult<bool> {
     let max_attempts = 5;
     let attempt = job.attempt_count + 1;
 
+    // Relative path this job acts on (never a secret); used for INFO logging so a
+    // user watching the log sees real sync activity (DBSYNC-47).
+    let job_path = job
+        .source_path
+        .as_deref()
+        .or(job.target_path.as_deref())
+        .unwrap_or("")
+        .to_string();
+    tracing::info!(
+        job_id = job.id,
+        job_type = %job.job_type,
+        path = %job_path,
+        attempt,
+        "sync job started"
+    );
+
     let op_result: AppResult<()> = match job.job_type.as_str() {
         "upload" => job
             .source_path
@@ -323,10 +339,24 @@ pub(crate) fn process_sync_queue_internal(state: &AppState) -> AppResult<bool> {
             if let Ok(mut engine) = state.sync_engine.lock() {
                 engine.record_job_processed();
             }
+            tracing::info!(
+                job_id = job.id,
+                job_type = %job.job_type,
+                path = %job_path,
+                "sync job completed"
+            );
         }
         Err(err) => {
             if attempt >= max_attempts {
                 let msg = format!("job {} failed: {err}", job.id);
+                tracing::error!(
+                    job_id = job.id,
+                    job_type = %job.job_type,
+                    path = %job_path,
+                    attempt,
+                    error = %err,
+                    "sync job failed (max attempts reached)"
+                );
                 state.db.mark_job_failed(job.id, attempt, Some(&msg))?;
             } else {
                 let wait_secs = backoff_seconds(attempt);
@@ -334,6 +364,15 @@ pub(crate) fn process_sync_queue_internal(state: &AppState) -> AppResult<bool> {
                 let msg = format!(
                     "job {} retry scheduled in {}s (attempt {}): {err}",
                     job.id, wait_secs, attempt
+                );
+                tracing::warn!(
+                    job_id = job.id,
+                    job_type = %job.job_type,
+                    path = %job_path,
+                    attempt,
+                    wait_secs,
+                    error = %err,
+                    "sync job failed; retry scheduled"
                 );
                 state
                     .db
@@ -350,6 +389,9 @@ pub(crate) fn process_sync_queue_internal(state: &AppState) -> AppResult<bool> {
 
 pub(crate) fn run_sync_tick_internal(state: &AppState) -> AppResult<SyncTickResult> {
     let enqueued_jobs = scan_local_changes_internal(state)?;
+    if enqueued_jobs > 0 {
+        tracing::info!(count = enqueued_jobs, "enqueued local changes for sync");
+    }
 
     // Drain up to `SYNC_BATCH_CAP` due jobs in this tick instead of exactly one,
     // so large backlogs make real progress every 60s. Mirrors the drain loop in
@@ -372,6 +414,16 @@ pub(crate) fn run_sync_tick_internal(state: &AppState) -> AppResult<SyncTickResu
     }
 
     let scanned_files = state.db.list_local_files()?.len();
+    // Only summarise a tick that actually did something, so the idle 60s poll
+    // doesn't spam the log (DBSYNC-47).
+    if enqueued_jobs > 0 || processed_job {
+        tracing::info!(
+            scanned_files,
+            enqueued_jobs,
+            processed_job,
+            "sync tick complete"
+        );
+    }
     Ok(SyncTickResult {
         scanned_files,
         enqueued_jobs,


### PR DESCRIPTION
## Summary
The sync engine was near-silent in the log (sync_pipeline had 1 tracing event; remote_index/auth_session had none), so watching the log during a sync showed nothing. This instruments the sync lifecycle at INFO.

- **process_sync_queue_internal**: `sync job started` / `sync job completed` (job_id, job_type, relative path); failures → `warn` (retry) / `error` (max attempts) with the error.
- **run_sync_tick_internal**: `enqueued local changes` + `sync tick complete` — only when the tick did work, so the idle 60s poll stays silent.
- **auth_session**: `refreshing dropbox access token` on each real refresh.
- **remote_index**: summary when a refresh enqueues download/delete jobs.
- **dropbox_transfer**: `sync conflict` when a local copy is preserved.

Job/summary granularity only — no per-chunk spam (per-transfer progress stays a UI event, DBSYNC-34). **No secrets** logged: only relative paths, job types, counts — never tokens. Documented that the Logs button opens a non-tailing snapshot.

## Stack
desktop-tauri

## Jira Ticket
#DBSYNC-47

## Test Plan
- [x] `cargo test` — 69/69 pass
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] Log shows sync activity during a sync — validated by user smoke

🤖 Generated with Claude Code

https://claude.ai/code/session_01XFcb2z2QG5oQe6v8GyDwhd