### PR TITLE
fix(security): stop echoing the OAuth response body on token-parse failure (#DBSYNC-49)

### DIFF
--- a/apps/desktop/src-tauri/src/auth/oauth.rs
+++ b/apps/desktop/src-tauri/src/auth/oauth.rs
@@ -160,12 +160,10 @@ pub async fn complete_oauth(
     }
 
     let token: TokenResponse = serde_json::from_slice::<RawTokenResponse>(&body)
-        .map_err(|e| {
-            AppError::Auth(format!(
-                "token parse failed: {e}; body: {}",
-                String::from_utf8_lossy(&body)
-            ))
-        })?
+        // Do NOT echo the body: on a 2xx response it contains the access/refresh
+        // token, which would leak in cleartext if this error is logged or shown
+        // (DBSYNC-49). The serde error alone identifies the parse failure.
+        .map_err(|e| AppError::Auth(format!("token parse failed: {e}")))?
         .into();
 
     Ok(token)


### PR DESCRIPTION
## Summary
In `complete_oauth`, a 2xx token response whose JSON failed to deserialize built an `AppError::Auth` embedding the **full response body** — which on a successful auth-code exchange contains the access/refresh token. If that error were ever logged or shown, the token would leak in cleartext (a latent leak flagged during the DBSYNC-47 review).

Fix: drop the body from the message (`"token parse failed: {e}"`), matching the refresh path which already omits it. Non-2xx error bodies (Dropbox error objects, no token) are unaffected.

## Stack
desktop-tauri

## Jira Ticket
#DBSYNC-49

## Test Plan
- [x] `cargo test` — 69/69 pass
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] No happy-path change (only an error-path message on a malformed 2xx body, not reachable by hand)

🤖 Generated with Claude Code

https://claude.ai/code/session_01XFcb2z2QG5oQe6v8GyDwhd