### PR TITLE
feat(perf): filesystem watcher for near-instant local sync (#DBSYNC-29)

### DIFF
--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -919,6 +919,7 @@ dependencies = [
  "base64 0.22.1",
  "chrono",
  "keyring",
+ "notify-debouncer-mini",
  "rand 0.8.5",
  "reqwest 0.12.28",
  "rfd",
@@ -1170,6 +1171,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
+]
+
+[[package]]
+name = "fsevent-sys"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76ee7a02da4d231650c7cea31349b889be2f45ddb3ef3032d2ec8185f6313fd2"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -1962,6 +1972,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "inotify"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "153be1941a183ec9ccd095ddbe17a8b8d435ef6c76e9e02451b933c3999af2c8"
+dependencies = [
+ "bitflags 2.11.0",
+ "inotify-sys",
+ "libc",
+]
+
+[[package]]
+name = "inotify-sys"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c033f80b2c113cdf91ab7a33faa9cbc014726dcad99880c8609af2a370edf37d"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2138,6 +2168,26 @@ dependencies = [
  "security-framework 3.7.0",
  "windows-sys 0.60.2",
  "zeroize",
+]
+
+[[package]]
+name = "kqueue"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "273c0752728918e0ac4976f2b275b6fefb9ecd400585dec929419f3844cd87b5"
+dependencies = [
+ "kqueue-sys",
+ "libc",
+]
+
+[[package]]
+name = "kqueue-sys"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07293a4e297ac234359b510362495713f75ea345d5307140414f20c69ffeb087"
+dependencies = [
+ "bitflags 2.11.0",
+ "libc",
 ]
 
 [[package]]
@@ -2370,6 +2420,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
 dependencies = [
  "libc",
+ "log",
  "wasi 0.11.1+wasi-snapshot-preview1",
  "windows-sys 0.61.2",
 ]
@@ -2459,6 +2510,45 @@ name = "nodrop"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb"
+
+[[package]]
+name = "notify"
+version = "8.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d3d07927151ff8575b7087f245456e549fea62edf0ec4e565a5ee50c8402bc3"
+dependencies = [
+ "bitflags 2.11.0",
+ "fsevent-sys",
+ "inotify",
+ "kqueue",
+ "libc",
+ "log",
+ "mio",
+ "notify-types",
+ "walkdir",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "notify-debouncer-mini"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17849edfaabd9a5fef1c606d99cfc615a8e99f7ac4366406d86c7942a3184cf2"
+dependencies = [
+ "log",
+ "notify",
+ "notify-types",
+ "tempfile",
+]
+
+[[package]]
+name = "notify-types"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42b8cfee0e339a0337359f3c88165702ac6e600dc01c0cc9579a92d62b08477a"
+dependencies = [
+ "bitflags 2.11.0",
+]
 
 [[package]]
 name = "nu-ansi-term"

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -16,6 +16,7 @@ tauri-build = { version = "2", features = ["config-json5"] }
 base64 = "0.22"
 chrono = { version = "0.4", features = ["serde"] }
 keyring = { version = "3", features = ["apple-native", "windows-native", "sync-secret-service"] }
+notify-debouncer-mini = "0.7.0"
 rand = "0.8"
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls", "blocking"] }
 rfd = "0.14"

--- a/apps/desktop/src-tauri/src/commands.rs
+++ b/apps/desktop/src-tauri/src/commands.rs
@@ -100,11 +100,19 @@ pub fn set_sync_folder(state: tauri::State<AppState>, folder: String) -> Result<
     if prev != folder {
         state.db.reset_sync_state()?;
     }
-    let mut engine = state
-        .sync_engine
-        .lock()
-        .map_err(|_| "sync engine lock poisoned".to_string())?;
-    engine.set_tracked_path(folder);
+    {
+        let mut engine = state
+            .sync_engine
+            .lock()
+            .map_err(|_| "sync engine lock poisoned".to_string())?;
+        engine.set_tracked_path(folder);
+    }
+    // Re-arm the filesystem watcher for the (possibly new) sync folder
+    // (DBSYNC-29); arm_watcher drops any previous watcher so the old root is no
+    // longer watched. Best-effort — the periodic fallback still runs.
+    if let Err(e) = crate::fs_watcher::arm_watcher(state.inner()) {
+        tracing::warn!(error = %e, "failed to re-arm filesystem watcher after folder change");
+    }
     Ok(())
 }
 
@@ -218,7 +226,10 @@ pub fn start_background_scheduler(
             app_state.sync_running.store(false, Ordering::Release);
             update_tray_tooltip(&app, &current_tray_status_label(&app_state));
         }
-        std::thread::sleep(StdDuration::from_secs(60));
+        // Safety-net full scan. The filesystem watcher (DBSYNC-29) is now the
+        // primary, near-instant trigger, so this only needs to reconcile missed
+        // events + run the remote-index pass — every 5 min instead of 60s.
+        std::thread::sleep(StdDuration::from_secs(300));
     });
 
     Ok(true)

--- a/apps/desktop/src-tauri/src/fs_watcher.rs
+++ b/apps/desktop/src-tauri/src/fs_watcher.rs
@@ -127,9 +127,13 @@ fn on_debounced_batch(
 /// forms compare equal.
 fn normalize_verbatim(p: &Path) -> PathBuf {
     let s = p.to_string_lossy();
-    match s.strip_prefix(r"\\?\") {
-        Some(stripped) => PathBuf::from(stripped),
-        None => p.to_path_buf(),
+    if let Some(unc) = s.strip_prefix(r"\\?\UNC\") {
+        // `\\?\UNC\server\share` → `\\server\share` (network-share sync root).
+        PathBuf::from(format!(r"\\{unc}"))
+    } else if let Some(stripped) = s.strip_prefix(r"\\?\") {
+        PathBuf::from(stripped)
+    } else {
+        p.to_path_buf()
     }
 }
 

--- a/apps/desktop/src-tauri/src/fs_watcher.rs
+++ b/apps/desktop/src-tauri/src/fs_watcher.rs
@@ -1,0 +1,233 @@
+//! Filesystem watcher (DBSYNC-29): near-instant local change detection via the
+//! `notify` crate, replacing the 60s full-scan poll as the *primary* trigger.
+//! A debounced batch of changed paths is handed to the targeted, network-free
+//! `sync_pipeline::process_changed_paths` (no full walk), gated by the same
+//! `sync_running` single-flight CAS as every other sync entry point. The
+//! periodic full scan remains as a 5-minute safety net.
+
+use std::collections::HashSet;
+use std::path::{Path, PathBuf};
+use std::sync::atomic::Ordering;
+use std::sync::{Mutex, OnceLock};
+use std::time::Duration;
+
+use notify_debouncer_mini::notify::{RecommendedWatcher, RecursiveMode};
+use notify_debouncer_mini::{new_debouncer, DebounceEventResult, Debouncer};
+
+use crate::error::{AppError, AppResult};
+use crate::path_util::{is_editor_temp_path, should_ignore_local_path, validate_relative};
+use crate::state::AppState;
+
+/// Keeps the debouncer (its OS watch + worker thread) alive for the app's
+/// lifetime. A module static — not an `AppState` field — mirrors the
+/// `state::APP_HANDLE` rationale and keeps it out of the test constructor.
+static WATCHER: OnceLock<Mutex<Option<Debouncer<RecommendedWatcher>>>> = OnceLock::new();
+
+const DEBOUNCE_MS: u64 = 500;
+
+/// (Re)create the watcher for the currently-configured sync folder. Idempotent:
+/// the previous debouncer is dropped (stopping the old watch) before the new one
+/// is stored, so calling this on startup and again on every sync-folder change
+/// never leaks or double-watches. Best-effort: returns `Ok(())` when there is no
+/// folder to watch, and any watcher failure is surfaced for the caller to log.
+pub(crate) fn arm_watcher(state: &AppState) -> AppResult<()> {
+    let Some(folder) = state.db.get_sync_folder()? else {
+        return Ok(());
+    };
+    if folder.trim().is_empty() {
+        return Ok(());
+    }
+    let root = PathBuf::from(&folder);
+    if !root.is_dir() {
+        return Ok(());
+    }
+    // canonicalize() yields the on-disk form (Windows: a `\\?\` verbatim prefix
+    // and the real case). We strip events against BOTH this and the configured
+    // root because a *deleted* path can't be re-canonicalized (see map_event_path).
+    let canon_root = root.canonicalize().unwrap_or_else(|_| root.clone());
+
+    let cb_state = state.clone();
+    let cb_canon = canon_root.clone();
+    let cb_configured = root.clone();
+    let mut debouncer = new_debouncer(
+        Duration::from_millis(DEBOUNCE_MS),
+        move |res: DebounceEventResult| match res {
+            Ok(events) => {
+                let paths: Vec<PathBuf> = events.into_iter().map(|e| e.path).collect();
+                on_debounced_batch(&cb_state, &cb_canon, &cb_configured, paths);
+            }
+            Err(error) => {
+                tracing::warn!(error = %error, "fs watcher error");
+            }
+        },
+    )
+    .map_err(|e| AppError::Other(format!("fs watcher init failed: {e}")))?;
+
+    debouncer
+        .watcher()
+        .watch(&root, RecursiveMode::Recursive)
+        .map_err(|e| AppError::Other(format!("fs watch failed: {e}")))?;
+
+    let slot = WATCHER.get_or_init(|| Mutex::new(None));
+    let mut guard = slot
+        .lock()
+        .map_err(|_| AppError::Other("fs watcher lock poisoned".to_string()))?;
+    // Dropping any previous debouncer here stops the old OS watch + thread.
+    *guard = Some(debouncer);
+    tracing::info!(root = %root.display(), "filesystem watcher armed");
+    Ok(())
+}
+
+/// Handle a debounced batch: map paths, then run targeted processing + drain on
+/// a worker thread (keeping the debouncer thread responsive), under the sync gate.
+fn on_debounced_batch(
+    state: &AppState,
+    canon_root: &Path,
+    configured_root: &Path,
+    paths: Vec<PathBuf>,
+) {
+    let mut rels: Vec<String> = Vec::new();
+    let mut seen: HashSet<String> = HashSet::new();
+    for abs in &paths {
+        if let Some(rel) = map_event_path(canon_root, configured_root, abs) {
+            if seen.insert(rel.clone()) {
+                rels.push(rel);
+            }
+        }
+    }
+    if rels.is_empty() {
+        return;
+    }
+
+    let st = state.clone();
+    std::thread::spawn(move || {
+        // If a scan/tick already owns the sync, skip: the periodic fallback or the
+        // next batch will pick these paths up. Also prevents reacting to the sync
+        // engine's own writes (downloads/hydration), which hold the gate.
+        if st
+            .sync_running
+            .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+            .is_err()
+        {
+            return;
+        }
+        crate::auth_session::refresh_tray_tooltip(&st);
+        match crate::sync_pipeline::process_changed_paths(&st, &rels) {
+            Ok(n) if n > 0 => tracing::info!(count = n, "watcher enqueued targeted change(s)"),
+            Ok(_) => {}
+            Err(e) => tracing::error!(error = %e, "process_changed_paths failed"),
+        }
+        crate::sync_pipeline::drain_sync_queue(&st);
+        st.sync_running.store(false, Ordering::Release);
+        crate::auth_session::refresh_tray_tooltip(&st);
+    });
+}
+
+/// Strip a leading Windows `\\?\` verbatim prefix so verbatim and non-verbatim
+/// forms compare equal.
+fn normalize_verbatim(p: &Path) -> PathBuf {
+    let s = p.to_string_lossy();
+    match s.strip_prefix(r"\\?\") {
+        Some(stripped) => PathBuf::from(stripped),
+        None => p.to_path_buf(),
+    }
+}
+
+/// Map an absolute event path to a `/`-relative path under the sync root, or
+/// `None` when it is outside the root or should be ignored (`.cloudsc`, dotfile
+/// junk, editor/temp files, or a path that fails relative-path validation).
+/// Strips against both the canonical and configured roots (verbatim-normalized)
+/// to survive the Windows `\\?\`/case mismatch and deleted (un-canonicalizable)
+/// paths.
+pub(crate) fn map_event_path(
+    canon_root: &Path,
+    configured_root: &Path,
+    abs: &Path,
+) -> Option<String> {
+    let abs_n = normalize_verbatim(abs);
+    let canon_n = normalize_verbatim(canon_root);
+    let conf_n = normalize_verbatim(configured_root);
+
+    let rel = abs_n
+        .strip_prefix(&canon_n)
+        .ok()
+        .or_else(|| abs_n.strip_prefix(&conf_n).ok())?;
+
+    let rel = rel.to_string_lossy().replace('\\', "/");
+    let rel = rel.trim_start_matches('/').to_string();
+    if rel.is_empty()
+        || rel.ends_with(".cloudsc")
+        || should_ignore_local_path(&rel)
+        || is_editor_temp_path(&rel)
+    {
+        return None;
+    }
+    if validate_relative(&rel).is_err() {
+        return None;
+    }
+    Some(rel)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::Path;
+
+    use super::map_event_path;
+
+    #[test]
+    fn maps_a_file_under_the_root_to_a_forward_slash_relative() {
+        let root = Path::new("/sync/root");
+        assert_eq!(
+            map_event_path(root, root, Path::new("/sync/root/Cocina/Pizza.txt")),
+            Some("Cocina/Pizza.txt".to_string())
+        );
+    }
+
+    #[test]
+    fn root_itself_maps_to_none() {
+        let root = Path::new("/sync/root");
+        assert_eq!(map_event_path(root, root, Path::new("/sync/root")), None);
+    }
+
+    #[test]
+    fn path_outside_root_maps_to_none() {
+        let root = Path::new("/sync/root");
+        assert_eq!(
+            map_event_path(root, root, Path::new("/etc/passwd")),
+            None
+        );
+    }
+
+    #[test]
+    fn cloudsc_ignored_and_temp_paths_map_to_none() {
+        let root = Path::new("/sync/root");
+        assert_eq!(
+            map_event_path(root, root, Path::new("/sync/root/a.txt.cloudsc")),
+            None
+        );
+        assert_eq!(
+            map_event_path(root, root, Path::new("/sync/root/.DS_Store")),
+            None
+        );
+        assert_eq!(
+            map_event_path(root, root, Path::new("/sync/root/doc.txt.tmp")),
+            None
+        );
+        assert_eq!(
+            map_event_path(root, root, Path::new("/sync/root/~$report.docx")),
+            None
+        );
+    }
+
+    #[test]
+    fn falls_back_to_configured_root_when_canonical_differs() {
+        // Simulate a canonical root the event path does not match (e.g. case /
+        // verbatim), but the configured root does.
+        let canon = Path::new("/sync/ROOT-canon");
+        let configured = Path::new("/sync/root");
+        assert_eq!(
+            map_event_path(canon, configured, Path::new("/sync/root/a.txt")),
+            Some("a.txt".to_string())
+        );
+    }
+}

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -5,6 +5,7 @@ mod cloudsc_ops;
 mod commands;
 mod dropbox_transfer;
 mod error;
+mod fs_watcher;
 mod logging;
 mod models;
 mod oauth_listener;
@@ -283,6 +284,15 @@ pub fn run() {
             // `dropbox_transfer::emit_upload_progress` to emit `upload-progress` events
             // from background sync work. Not duplicated in `start_background_scheduler`.
             let _ = crate::state::APP_HANDLE.set(app.handle().clone());
+
+            // Start the filesystem watcher for near-instant local change
+            // detection (DBSYNC-29); best-effort — the 5-min fallback scan
+            // covers anything it can't watch.
+            if let Some(state) = app.try_state::<crate::state::AppState>() {
+                if let Err(e) = crate::fs_watcher::arm_watcher(&state) {
+                    tracing::warn!(error = %e, "failed to arm filesystem watcher at startup");
+                }
+            }
 
             Ok(())
         })

--- a/apps/desktop/src-tauri/src/path_util.rs
+++ b/apps/desktop/src-tauri/src/path_util.rs
@@ -12,6 +12,26 @@ pub(crate) fn should_ignore_local_path(relative: &str) -> bool {
     p == ".DS_Store" || p.ends_with("/.DS_Store") || p.starts_with("._") || p.contains("/._")
 }
 
+/// True if the path looks like an editor/download temp or lock file that should
+/// not trigger a sync on its own (DBSYNC-29). The real file's own event arrives
+/// separately; watching these just causes churn (and they're often deleted
+/// moments later). Matches the last path component only.
+pub(crate) fn is_editor_temp_path(relative: &str) -> bool {
+    let name = relative
+        .rsplit(['/', '\\'])
+        .next()
+        .unwrap_or(relative)
+        .to_ascii_lowercase();
+    name.ends_with(".tmp")
+        || name.ends_with(".swp")
+        || name.ends_with(".swx")
+        || name.ends_with(".crdownload")
+        || name.ends_with(".part")
+        || name.ends_with('~') // Vim/Emacs/gedit backup
+        || name.starts_with("~$") // MS Office lock/owner file
+        || (name.starts_with(".~lock.") && name.ends_with('#')) // LibreOffice lock
+}
+
 pub(crate) fn relpath_under(sync_folder: &Path, absolute: &Path) -> AppResult<String> {
     Ok(absolute
         .strip_prefix(sync_folder)
@@ -424,6 +444,26 @@ mod tests {
         let joined = safe_join(root, "Cocina/Pizza.txt").expect("legit join");
         assert!(joined.starts_with(root));
         assert_eq!(joined, Path::new("/sync/root/Cocina/Pizza.txt"));
+    }
+
+    #[test]
+    fn editor_temp_paths_are_recognized() {
+        use super::is_editor_temp_path;
+        for temp in [
+            "doc.txt.tmp",
+            "sub/.file.swp",
+            "a.swx",
+            "video.crdownload",
+            "big.iso.part",
+            "notes.txt~",
+            "~$report.docx",
+            ".~lock.sheet.ods#",
+        ] {
+            assert!(is_editor_temp_path(temp), "should flag {temp:?}");
+        }
+        for real in ["report.docx", "a/b/c.txt", "photo.jpg", "archive.tar.gz"] {
+            assert!(!is_editor_temp_path(real), "should NOT flag {real:?}");
+        }
     }
 
     #[test]

--- a/apps/desktop/src-tauri/src/sync_pipeline.rs
+++ b/apps/desktop/src-tauri/src/sync_pipeline.rs
@@ -144,6 +144,35 @@ fn process_known_folder_deletion(
     Ok(1)
 }
 
+/// How a watched path currently resolves on disk. Distinguishes a genuine
+/// absence (`NotFound`) from a transient stat failure (permission, Windows
+/// sharing-violation, AV/network lock) — the latter must NEVER be treated as a
+/// deletion, or a racy stat on a just-written file would enqueue a spurious
+/// remote delete (DBSYNC-29 review; the full scan guards this via `walk_had_error`).
+enum PathKind {
+    File,
+    Dir,
+    Absent,
+    Other,
+}
+
+/// Classify a path. `Err` means a non-`NotFound` IO error — the caller must skip
+/// it (not delete). Uses `symlink_metadata` so a symlink is not followed.
+fn classify_path(path: &Path) -> std::io::Result<PathKind> {
+    match std::fs::symlink_metadata(path) {
+        Ok(m) if m.is_file() => Ok(PathKind::File),
+        Ok(m) if m.is_dir() => Ok(PathKind::Dir),
+        Ok(_) => Ok(PathKind::Other),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(PathKind::Absent),
+        Err(e) => Err(e),
+    }
+}
+
+/// Grace period before a targeted deletion is committed: re-stat once so a
+/// delete-then-recreate save (some editors briefly unlink the target) is seen as
+/// a modification, not a momentary remote delete + re-add (DBSYNC-29 review).
+const DELETE_CONFIRM_MS: u64 = 150;
+
 /// Targeted, network-free change detection for a specific set of `/`-relative
 /// paths (from the filesystem watcher, DBSYNC-29). Re-evaluates each path against
 /// the index and enqueues the same jobs the full scan would — without walking the
@@ -191,63 +220,109 @@ pub(crate) fn process_changed_paths(state: &AppState, paths: &[String]) -> AppRe
     let mut enqueued = 0usize;
     for rel in rels {
         let absolute = tracked_root.join(&rel);
-        if absolute.is_file() {
-            enqueued += process_local_file_change(
-                state,
-                &tracked_root,
-                &rel,
-                &absolute,
-                known_map.get(&rel),
-                &mut pending_targets,
-            )?;
-        } else if absolute.is_dir() {
-            // A moved-in / newly-created directory: record it and enqueue any
-            // pre-existing children (a bounded walk of just this subtree, not the
-            // whole root). Recursive watching also emits child events separately.
-            state.db.upsert_known_folder(&rel)?;
-            for entry in WalkDir::new(&absolute).into_iter().flatten() {
-                if !entry.file_type().is_file() {
-                    continue;
-                }
-                let child_rel = match entry.path().strip_prefix(&tracked_root) {
-                    Ok(r) => r.to_string_lossy().replace('\\', "/"),
-                    Err(_) => continue,
-                };
-                if child_rel.ends_with(".cloudsc") || should_ignore_local_path(&child_rel) {
-                    continue;
-                }
+        let kind = match classify_path(&absolute) {
+            Ok(k) => k,
+            Err(e) => {
+                // Transient stat failure — NOT a deletion. Skip; the next event or
+                // the 5-min fallback scan reconciles it (DBSYNC-29 review blocker).
+                tracing::warn!(path = %rel, error = %e, "stat failed; not treating as a deletion");
+                continue;
+            }
+        };
+
+        match kind {
+            PathKind::File => {
                 enqueued += process_local_file_change(
                     state,
                     &tracked_root,
-                    &child_rel,
-                    entry.path(),
-                    known_map.get(&child_rel),
+                    &rel,
+                    &absolute,
+                    known_map.get(&rel),
                     &mut pending_targets,
                 )?;
             }
-        } else {
-            // Absent on disk → deletion. Handle both a single file and a removed
-            // directory prefix (delete tracked descendants + the folder rows).
-            if known_map.contains_key(&rel) {
-                enqueued += process_local_file_deletion(state, &tracked_root, &rel)?;
-            }
-            let prefix = format!("{rel}/");
-            for prev in &known {
-                if prev.relative_path == rel {
-                    continue; // already handled above
+            PathKind::Dir => {
+                // A moved-in / newly-created directory: record it and enqueue any
+                // pre-existing children (a bounded walk of just this subtree, not
+                // the whole root). Recursive watching also emits child events.
+                state.db.upsert_known_folder(&rel)?;
+                for entry in WalkDir::new(&absolute).into_iter().flatten() {
+                    if !entry.file_type().is_file() {
+                        continue;
+                    }
+                    let child_rel = match entry.path().strip_prefix(&tracked_root) {
+                        Ok(r) => r.to_string_lossy().replace('\\', "/"),
+                        Err(_) => continue,
+                    };
+                    if child_rel.ends_with(".cloudsc") || should_ignore_local_path(&child_rel) {
+                        continue;
+                    }
+                    enqueued += process_local_file_change(
+                        state,
+                        &tracked_root,
+                        &child_rel,
+                        entry.path(),
+                        known_map.get(&child_rel),
+                        &mut pending_targets,
+                    )?;
                 }
-                if prev.relative_path.starts_with(&prefix)
-                    && !prev.relative_path.ends_with(".cloudsc")
-                    && !should_ignore_local_path(&prev.relative_path)
-                {
-                    enqueued += process_local_file_deletion(state, &tracked_root, &prev.relative_path)?;
-                }
             }
-            for folder_rel in state.db.list_known_folders()? {
-                if folder_rel == rel || folder_rel.starts_with(&prefix) {
-                    enqueued += process_known_folder_deletion(state, &tracked_root, &folder_rel)?;
-                }
+            PathKind::Other => {
+                // Symlink or other special file — not something we sync; skip.
+                continue;
             }
+            PathKind::Absent => {
+                // Confirm the absence is stable before propagating any remote
+                // delete, so a delete-then-recreate atomic save is treated as a
+                // modification (its recreate event/re-stat wins) rather than a
+                // momentary remote delete + re-add.
+                std::thread::sleep(std::time::Duration::from_millis(DELETE_CONFIRM_MS));
+                if !matches!(classify_path(&absolute), Ok(PathKind::Absent)) {
+                    continue;
+                }
+                enqueued += enqueue_targeted_deletions(state, &tracked_root, &rel, &known)?;
+            }
+        }
+    }
+
+    Ok(enqueued)
+}
+
+/// Enqueue remote deletions for an explicitly-absent path: the file itself (if
+/// tracked), every tracked descendant under a removed directory prefix, and any
+/// matching `known_folders` rows. Every delete goes through the DBSYNC-45
+/// dehydration guard in the per-item helpers.
+fn enqueue_targeted_deletions(
+    state: &AppState,
+    tracked_root: &Path,
+    rel: &str,
+    known: &[FileIndexRow],
+) -> AppResult<usize> {
+    let mut enqueued = 0usize;
+
+    // The path itself, if it was a tracked file.
+    if known.iter().any(|k| k.relative_path == rel) {
+        enqueued += process_local_file_deletion(state, tracked_root, rel)?;
+    }
+
+    // Tracked descendants of a removed directory prefix.
+    let prefix = format!("{rel}/");
+    for prev in known {
+        if prev.relative_path == rel {
+            continue; // already handled above
+        }
+        if prev.relative_path.starts_with(&prefix)
+            && !prev.relative_path.ends_with(".cloudsc")
+            && !should_ignore_local_path(&prev.relative_path)
+        {
+            enqueued += process_local_file_deletion(state, tracked_root, &prev.relative_path)?;
+        }
+    }
+
+    // Matching known-folder rows (the removed dir itself + any sub-folders).
+    for folder_rel in state.db.list_known_folders()? {
+        if folder_rel == rel || folder_rel.starts_with(&prefix) {
+            enqueued += process_known_folder_deletion(state, tracked_root, &folder_rel)?;
         }
     }
 

--- a/apps/desktop/src-tauri/src/sync_pipeline.rs
+++ b/apps/desktop/src-tauri/src/sync_pipeline.rs
@@ -1,5 +1,5 @@
 use std::collections::{HashMap, HashSet};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use chrono::{Duration, Utc};
 use walkdir::WalkDir;
@@ -49,6 +49,209 @@ pub(crate) fn refresh_queue_depth_internal(state: &AppState) -> AppResult<()> {
 /// rather than deleted by the user. Used to suppress spurious remote deletions.
 fn placeholder_exists(tracked_root: &std::path::Path, rel: &str) -> bool {
     tracked_root.join(format!("{rel}.cloudsc")).exists()
+}
+
+/// Evaluate a single local file against the index and enqueue an upload if it is
+/// new or changed (routing a change that races a still-pending upload to a
+/// conflicted copy). Returns the number of jobs enqueued (0 or 1). Shared by the
+/// full walk (`scan_local_changes_internal`) and the targeted watcher path
+/// (`process_changed_paths`) so both behave identically (DBSYNC-29).
+fn process_local_file_change(
+    state: &AppState,
+    tracked_root: &Path,
+    relative: &str,
+    absolute: &Path,
+    known: Option<&FileIndexRow>,
+    pending_targets: &mut HashSet<String>,
+) -> AppResult<usize> {
+    let (hash, size_bytes, modified_ts) = hash_file(absolute)?;
+
+    match known {
+        None => {
+            state.db.enqueue_job("upload", Some(relative), Some(relative))?;
+            state
+                .db
+                .upsert_local_file(relative, &hash, size_bytes, modified_ts)?;
+            pending_targets.insert(relative.to_string());
+            Ok(1)
+        }
+        Some(prev) if prev.hash != hash => {
+            if pending_targets.contains(relative) {
+                let conflicted_path = create_conflicted_copy(absolute)?;
+                let conflicted_rel = conflicted_path
+                    .strip_prefix(tracked_root)
+                    .map_err(|e| AppError::Io(e.to_string()))?
+                    .to_string_lossy()
+                    .replace('\\', "/");
+                state.db.add_conflict(
+                    relative,
+                    relative,
+                    "concurrent local update while job pending",
+                )?;
+                state
+                    .db
+                    .enqueue_job("upload", Some(&conflicted_rel), Some(&conflicted_rel))?;
+                state
+                    .db
+                    .upsert_local_file(relative, &hash, size_bytes, modified_ts)?;
+                if let Ok(mut engine) = state.sync_engine.lock() {
+                    engine.record_conflict();
+                }
+                Ok(1)
+            } else {
+                state.db.enqueue_job("upload", Some(relative), Some(relative))?;
+                state
+                    .db
+                    .upsert_local_file(relative, &hash, size_bytes, modified_ts)?;
+                pending_targets.insert(relative.to_string());
+                Ok(1)
+            }
+        }
+        _ => Ok(0),
+    }
+}
+
+/// Propagate a single local FILE deletion to the remote, honoring the DBSYNC-45
+/// dehydration guard (a `<rel>.cloudsc`-backed path was dehydrated, not deleted,
+/// so it is only untracked, never remote-deleted). Returns jobs enqueued (0/1).
+fn process_local_file_deletion(
+    state: &AppState,
+    tracked_root: &Path,
+    prev_rel: &str,
+) -> AppResult<usize> {
+    if placeholder_exists(tracked_root, prev_rel) {
+        state.db.remove_local_file(prev_rel)?;
+        return Ok(0);
+    }
+    state.db.enqueue_job("delete", Some(prev_rel), Some(prev_rel))?;
+    state.db.remove_local_file(prev_rel)?;
+    Ok(1)
+}
+
+/// Propagate a single known-FOLDER deletion (recursive remote `delete_v2`),
+/// honoring the DBSYNC-45 dehydration guard. Returns jobs enqueued (0/1).
+fn process_known_folder_deletion(
+    state: &AppState,
+    tracked_root: &Path,
+    rel: &str,
+) -> AppResult<usize> {
+    if placeholder_exists(tracked_root, rel) {
+        state.db.remove_known_folder(rel)?;
+        return Ok(0);
+    }
+    state.db.enqueue_job("delete", Some(rel), Some(rel))?;
+    state.db.remove_known_folder(rel)?;
+    Ok(1)
+}
+
+/// Targeted, network-free change detection for a specific set of `/`-relative
+/// paths (from the filesystem watcher, DBSYNC-29). Re-evaluates each path against
+/// the index and enqueues the same jobs the full scan would — without walking the
+/// whole tree. The caller drains the queue. Deletions are only inferred from a
+/// path being explicitly absent on disk (never from an incomplete walk), and the
+/// whole-root-missing case is still gated by `is_dir()`, so this can't mass-delete.
+pub(crate) fn process_changed_paths(state: &AppState, paths: &[String]) -> AppResult<usize> {
+    let folder = state
+        .db
+        .get_sync_folder()?
+        .ok_or_else(|| AppError::Sync("sync folder not configured".to_string()))?;
+    let tracked_root = PathBuf::from(&folder);
+    // Same catastrophic-mass-deletion guard as the full scan: if the whole root
+    // is missing/unmounted, treat nothing as deleted.
+    if !tracked_root.is_dir() {
+        return Ok(0);
+    }
+
+    let known = state.db.list_local_files()?;
+    let known_map: HashMap<String, FileIndexRow> = known
+        .iter()
+        .map(|f| (f.relative_path.clone(), f.clone()))
+        .collect();
+    let existing_jobs = state.db.list_recent_jobs(200)?;
+    let mut pending_targets: HashSet<String> = existing_jobs
+        .iter()
+        .filter(|j| j.status == "queued" || j.status == "retry_wait" || j.status == "running")
+        .filter_map(|j| j.target_path.clone())
+        .collect();
+
+    // Normalize + dedupe the incoming paths, dropping placeholders/ignored ones.
+    let mut rels: Vec<String> = Vec::new();
+    let mut seen: HashSet<String> = HashSet::new();
+    for p in paths {
+        let rel = p.replace('\\', "/");
+        let rel = rel.trim_start_matches('/').to_string();
+        if rel.is_empty() || rel.ends_with(".cloudsc") || should_ignore_local_path(&rel) {
+            continue;
+        }
+        if seen.insert(rel.clone()) {
+            rels.push(rel);
+        }
+    }
+
+    let mut enqueued = 0usize;
+    for rel in rels {
+        let absolute = tracked_root.join(&rel);
+        if absolute.is_file() {
+            enqueued += process_local_file_change(
+                state,
+                &tracked_root,
+                &rel,
+                &absolute,
+                known_map.get(&rel),
+                &mut pending_targets,
+            )?;
+        } else if absolute.is_dir() {
+            // A moved-in / newly-created directory: record it and enqueue any
+            // pre-existing children (a bounded walk of just this subtree, not the
+            // whole root). Recursive watching also emits child events separately.
+            state.db.upsert_known_folder(&rel)?;
+            for entry in WalkDir::new(&absolute).into_iter().flatten() {
+                if !entry.file_type().is_file() {
+                    continue;
+                }
+                let child_rel = match entry.path().strip_prefix(&tracked_root) {
+                    Ok(r) => r.to_string_lossy().replace('\\', "/"),
+                    Err(_) => continue,
+                };
+                if child_rel.ends_with(".cloudsc") || should_ignore_local_path(&child_rel) {
+                    continue;
+                }
+                enqueued += process_local_file_change(
+                    state,
+                    &tracked_root,
+                    &child_rel,
+                    entry.path(),
+                    known_map.get(&child_rel),
+                    &mut pending_targets,
+                )?;
+            }
+        } else {
+            // Absent on disk → deletion. Handle both a single file and a removed
+            // directory prefix (delete tracked descendants + the folder rows).
+            if known_map.contains_key(&rel) {
+                enqueued += process_local_file_deletion(state, &tracked_root, &rel)?;
+            }
+            let prefix = format!("{rel}/");
+            for prev in &known {
+                if prev.relative_path == rel {
+                    continue; // already handled above
+                }
+                if prev.relative_path.starts_with(&prefix)
+                    && !prev.relative_path.ends_with(".cloudsc")
+                    && !should_ignore_local_path(&prev.relative_path)
+                {
+                    enqueued += process_local_file_deletion(state, &tracked_root, &prev.relative_path)?;
+                }
+            }
+            for folder_rel in state.db.list_known_folders()? {
+                if folder_rel == rel || folder_rel.starts_with(&prefix) {
+                    enqueued += process_known_folder_deletion(state, &tracked_root, &folder_rel)?;
+                }
+            }
+        }
+    }
+
+    Ok(enqueued)
 }
 
 pub(crate) fn scan_local_changes_internal(state: &AppState) -> AppResult<usize> {
@@ -119,55 +322,14 @@ pub(crate) fn scan_local_changes_internal(state: &AppState) -> AppResult<usize> 
 
         seen_paths.insert(relative.clone());
 
-        let (hash, size_bytes, modified_ts) = hash_file(&absolute)?;
-
-        match known_map.get(&relative) {
-            None => {
-                state.db.enqueue_job("upload", Some(&relative), Some(&relative))?;
-                state
-                    .db
-                    .upsert_local_file(&relative, &hash, size_bytes, modified_ts)?;
-                pending_targets.insert(relative.clone());
-                enqueued_jobs += 1;
-            }
-            Some(prev) if prev.hash != hash => {
-                if pending_targets.contains(&relative) {
-                    let conflicted_path = create_conflicted_copy(&absolute)?;
-                    let conflicted_rel = conflicted_path
-                        .strip_prefix(&tracked_root)
-                        .map_err(|e| AppError::Io(e.to_string()))?
-                        .to_string_lossy()
-                        .replace('\\', "/");
-                    {
-                        state.db.add_conflict(
-                            &relative,
-                            &relative,
-                            "concurrent local update while job pending",
-                        )?;
-                        state.db.enqueue_job(
-                            "upload",
-                            Some(&conflicted_rel),
-                            Some(&conflicted_rel),
-                        )?;
-                        state
-                            .db
-                            .upsert_local_file(&relative, &hash, size_bytes, modified_ts)?;
-                    }
-                    if let Ok(mut engine) = state.sync_engine.lock() {
-                        engine.record_conflict();
-                    }
-                    enqueued_jobs += 1;
-                } else {
-                    state.db.enqueue_job("upload", Some(&relative), Some(&relative))?;
-                    state
-                        .db
-                        .upsert_local_file(&relative, &hash, size_bytes, modified_ts)?;
-                    pending_targets.insert(relative.clone());
-                    enqueued_jobs += 1;
-                }
-            }
-            _ => {}
-        }
+        enqueued_jobs += process_local_file_change(
+            state,
+            &tracked_root,
+            &relative,
+            &absolute,
+            known_map.get(&relative),
+            &mut pending_targets,
+        )?;
     }
 
     // Only propagate FILE deletions when we trust the walk was complete.
@@ -180,21 +342,8 @@ pub(crate) fn scan_local_changes_internal(state: &AppState) -> AppResult<usize> 
                 continue;
             }
             if !seen_paths.contains(&prev.relative_path) {
-                // DATA-LOSS GUARD (DBSYNC-45): a real file replaced by a
-                // `<name>.cloudsc` placeholder was DEHYDRATED, not deleted by the
-                // user. Propagating a remote delete here would destroy the user's
-                // remote copy. Untrack it locally, but never delete remotely.
-                if placeholder_exists(&tracked_root, &prev.relative_path) {
-                    state.db.remove_local_file(&prev.relative_path)?;
-                    continue;
-                }
-                state.db.enqueue_job(
-                    "delete",
-                    Some(&prev.relative_path),
-                    Some(&prev.relative_path),
-                )?;
-                state.db.remove_local_file(&prev.relative_path)?;
-                enqueued_jobs += 1;
+                enqueued_jobs +=
+                    process_local_file_deletion(state, &tracked_root, &prev.relative_path)?;
             }
         }
     }
@@ -242,17 +391,7 @@ pub(crate) fn scan_local_changes_internal(state: &AppState) -> AppResult<usize> 
     if !walk_had_error {
         for rel in state.db.list_known_folders()? {
             if !seen_dirs.contains(&rel) {
-                // DATA-LOSS GUARD (DBSYNC-45): a hydrated folder replaced by a
-                // `<name>.cloudsc` placeholder was DEHYDRATED, not deleted. A
-                // recursive remote `delete_v2` here would wipe the user's remote
-                // folder. Untrack it locally, but never delete remotely.
-                if placeholder_exists(&tracked_root, &rel) {
-                    state.db.remove_known_folder(&rel)?;
-                    continue;
-                }
-                state.db.enqueue_job("delete", Some(&rel), Some(&rel))?;
-                state.db.remove_known_folder(&rel)?;
-                enqueued_jobs += 1;
+                enqueued_jobs += process_known_folder_deletion(state, &tracked_root, &rel)?;
             }
         }
     }
@@ -269,6 +408,25 @@ pub(crate) fn scan_local_changes_internal(state: &AppState) -> AppResult<usize> 
 
     refresh_queue_depth_internal(state)?;
     Ok(enqueued_jobs + remote_enqueued)
+}
+
+/// Drains the sync queue until it is empty (or an infra error stops it), in
+/// batches. Shared by the `.cloudsc`-open drain and the filesystem watcher
+/// (DBSYNC-29). The `sync_running` single-flight gate is the caller's
+/// responsibility. The 1000-iteration cap is a runaway guard.
+pub(crate) fn drain_sync_queue(state: &AppState) {
+    let mut safety = 0usize;
+    while safety < 1000 {
+        safety += 1;
+        match process_sync_queue_internal(state) {
+            Ok(true) => continue,
+            Ok(false) => break,
+            Err(e) => {
+                tracing::error!(error = %e, "process_sync_queue failed (drain)");
+                break;
+            }
+        }
+    }
 }
 
 pub(crate) fn process_sync_queue_internal(state: &AppState) -> AppResult<bool> {
@@ -439,7 +597,7 @@ mod tests {
     use chrono::{Duration, Utc};
     use tempfile::tempdir;
 
-    use super::{run_sync_tick_internal, SYNC_BATCH_CAP};
+    use super::{process_changed_paths, run_sync_tick_internal, SYNC_BATCH_CAP};
     use crate::state::AppState;
     use crate::storage::db::Db;
     use crate::storage::secure_store::SecureStore;
@@ -566,5 +724,128 @@ mod tests {
             1,
             "the future retry_wait job should remain queued/pending, untouched"
         );
+    }
+
+    // ---------------------------------------------------------------------------
+    // Targeted per-path processing (DBSYNC-29)
+    // ---------------------------------------------------------------------------
+
+    fn sync_root(state: &AppState) -> std::path::PathBuf {
+        std::path::PathBuf::from(state.db.get_sync_folder().unwrap().unwrap())
+    }
+
+    fn job_targets(state: &AppState, job_type: &str) -> Vec<String> {
+        state
+            .db
+            .list_recent_jobs(500)
+            .expect("jobs")
+            .into_iter()
+            .filter(|j| j.job_type == job_type)
+            .filter_map(|j| j.target_path)
+            .collect()
+    }
+
+    #[test]
+    fn targeted_created_file_enqueues_upload_and_indexes() {
+        let tmp = tempdir().expect("tempdir");
+        let state = build_state(tmp.path());
+        std::fs::write(sync_root(&state).join("a.txt"), b"hello").unwrap();
+
+        let n = process_changed_paths(&state, &["a.txt".to_string()]).expect("process");
+        assert_eq!(n, 1);
+        assert_eq!(job_targets(&state, "upload"), vec!["a.txt".to_string()]);
+        assert!(state.db.get_local_file("a.txt").unwrap().is_some());
+    }
+
+    #[test]
+    fn targeted_modified_file_enqueues_upload() {
+        let tmp = tempdir().expect("tempdir");
+        let state = build_state(tmp.path());
+        std::fs::write(sync_root(&state).join("m.txt"), b"new-content").unwrap();
+        // Index an out-of-date hash so the on-disk content is a "modification".
+        state.db.upsert_local_file("m.txt", "stale-hash", 3, 0).unwrap();
+
+        let n = process_changed_paths(&state, &["m.txt".to_string()]).expect("process");
+        assert_eq!(n, 1);
+        assert_eq!(job_targets(&state, "upload"), vec!["m.txt".to_string()]);
+    }
+
+    #[test]
+    fn targeted_removed_file_enqueues_delete() {
+        let tmp = tempdir().expect("tempdir");
+        let state = build_state(tmp.path());
+        // Indexed but absent on disk → deletion.
+        state.db.upsert_local_file("gone.txt", "h", 3, 0).unwrap();
+
+        let n = process_changed_paths(&state, &["gone.txt".to_string()]).expect("process");
+        assert_eq!(n, 1);
+        assert_eq!(job_targets(&state, "delete"), vec!["gone.txt".to_string()]);
+        assert!(state.db.get_local_file("gone.txt").unwrap().is_none());
+    }
+
+    #[test]
+    fn targeted_dehydrated_file_is_not_remote_deleted() {
+        let tmp = tempdir().expect("tempdir");
+        let state = build_state(tmp.path());
+        state.db.upsert_local_file("d.txt", "h", 3, 0).unwrap();
+        // A `.cloudsc` placeholder means it was DEHYDRATED, not deleted (DBSYNC-45).
+        std::fs::write(sync_root(&state).join("d.txt.cloudsc"), b"{}").unwrap();
+
+        let n = process_changed_paths(&state, &["d.txt".to_string()]).expect("process");
+        assert_eq!(n, 0);
+        assert!(job_targets(&state, "delete").is_empty());
+        assert!(state.db.get_local_file("d.txt").unwrap().is_none()); // untracked, not deleted
+    }
+
+    #[test]
+    fn targeted_ignored_and_cloudsc_paths_are_skipped() {
+        let tmp = tempdir().expect("tempdir");
+        let state = build_state(tmp.path());
+
+        let n = process_changed_paths(
+            &state,
+            &[
+                ".DS_Store".to_string(),
+                "x.cloudsc".to_string(),
+                "._resource".to_string(),
+            ],
+        )
+        .expect("process");
+        assert_eq!(n, 0);
+        assert!(state.db.list_recent_jobs(50).unwrap().is_empty());
+    }
+
+    #[test]
+    fn targeted_removed_directory_deletes_children_and_folder() {
+        let tmp = tempdir().expect("tempdir");
+        let state = build_state(tmp.path());
+        state.db.upsert_local_file("dir/a.txt", "h", 1, 0).unwrap();
+        state.db.upsert_local_file("dir/b.txt", "h", 1, 0).unwrap();
+        state.db.upsert_known_folder("dir").unwrap();
+        // Nothing on disk under `dir` → the whole folder was removed.
+
+        let n = process_changed_paths(&state, &["dir".to_string()]).expect("process");
+        assert_eq!(n, 3);
+        let deletes = job_targets(&state, "delete");
+        assert!(deletes.contains(&"dir/a.txt".to_string()));
+        assert!(deletes.contains(&"dir/b.txt".to_string()));
+        assert!(deletes.contains(&"dir".to_string()));
+        assert!(state.db.get_local_file("dir/a.txt").unwrap().is_none());
+        assert!(state.db.list_known_folders().unwrap().is_empty());
+    }
+
+    #[test]
+    fn targeted_missing_sync_root_bails_out() {
+        let tmp = tempdir().expect("tempdir");
+        let state = build_state(tmp.path());
+        state
+            .db
+            .set_sync_folder(&tmp.path().join("does-not-exist").to_string_lossy())
+            .unwrap();
+        state.db.upsert_local_file("a.txt", "h", 1, 0).unwrap();
+
+        let n = process_changed_paths(&state, &["a.txt".to_string()]).expect("process");
+        assert_eq!(n, 0, "a missing root must never be read as a mass deletion");
+        assert!(state.db.list_recent_jobs(50).unwrap().is_empty());
     }
 }


### PR DESCRIPTION
## Summary
Replaces the 60s full-scan poll as the **primary** local-change trigger with a `notify` filesystem watcher, and processes only the changed paths (targeted, no full walk). Closes #37, #38.

**Slice 1 — targeted per-path processing (`sync_pipeline.rs`)**
- Factored the per-file create/modify/conflict, file-deletion, and known-folder-deletion logic out of `scan_local_changes_internal` into shared helpers (pure moves; full-scan behavior unchanged).
- New `process_changed_paths(state, paths)`: network-free; re-evaluates each path vs the index (on-disk→upload-if-changed; dir→track + bounded subtree walk; absent→targeted delete incl. dir-prefix descendants + `known_folders`), each delete honoring the DBSYNC-45 dehydration guard. `is_dir()` gate + absent-path-only deletion means it can't mass-delete on an unmounted root.
- Factored `drain_sync_queue(state)`, shared with the watcher.

**Slice 2 — notify watcher (`fs_watcher.rs`)**
- `notify-debouncer-mini` (notify 8.2), 500ms debounce, recursive watch on the sync root. `map_event_path` handles the Windows `\?\` verbatim prefix + dual-root strip and filters `.cloudsc`/ignored/editor-temp (new `path_util::is_editor_temp_path`). Batch → `process_changed_paths` + drain on a worker thread under the `sync_running` CAS gate.
- Handle in a module static; `arm_watcher` drops any previous watcher (no double-watch). Armed at `lib.rs setup()` + re-armed in `set_sync_folder`.
- Periodic fallback lowered 60s→300s (safety net + remote-index pass).

## Stack
desktop-tauri

## Jira Ticket
#DBSYNC-29

## Test Plan
- [x] `cargo test` — 82/82 pass (+13: 7 targeted, 5 map_event_path, 1 editor-temp)
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] User smoke: create/edit/delete near-instant (~1s) + rapid-save debounce validated; dehydration guard covered by unit test

🤖 Generated with Claude Code

https://claude.ai/code/session_01XFcb2z2QG5oQe6v8GyDwhd