### PR TITLE
feat(perf): Dropbox longpoll + cursor deltas for remote changes (#DBSYNC-30)

### DIFF
--- a/apps/desktop/src-tauri/src/auth/oauth_complete.rs
+++ b/apps/desktop/src-tauri/src/auth/oauth_complete.rs
@@ -70,5 +70,11 @@ pub(crate) async fn complete_oauth_internal(
         engine.clear_oauth_pending();
     }
 
+    // Drop any stale delta cursor so the longpoll loop reseeds against this
+    // (possibly new) account (DBSYNC-30).
+    let _ = app_state
+        .db
+        .set_app_config(crate::remote_index::REMOTE_DELTA_CURSOR_KEY, "");
+
     Ok(())
 }

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -13,6 +13,7 @@ mod open_handlers;
 mod overlay_state;
 mod path_util;
 mod remote_index;
+mod remote_longpoll;
 mod run_events;
 mod state;
 mod storage;
@@ -292,6 +293,10 @@ pub fn run() {
                 if let Err(e) = crate::fs_watcher::arm_watcher(&state) {
                     tracing::warn!(error = %e, "failed to arm filesystem watcher at startup");
                 }
+                // Start the Dropbox longpoll loop for near-instant remote change
+                // detection (DBSYNC-30). Idles until logged in; the 5-min sweep
+                // remains the reconciliation fallback.
+                crate::remote_longpoll::start_longpoll(&state);
             }
 
             Ok(())

--- a/apps/desktop/src-tauri/src/models.rs
+++ b/apps/desktop/src-tauri/src/models.rs
@@ -44,6 +44,15 @@ pub(crate) struct UploadSessionStartResponse {
     pub session_id: String,
 }
 
+/// Response from `/2/files/list_folder/longpoll` (DBSYNC-30).
+#[derive(Deserialize)]
+pub(crate) struct DropboxLongpollResponse {
+    pub changes: bool,
+    /// If present, wait at least this many seconds before longpolling again.
+    #[serde(default)]
+    pub backoff: Option<u64>,
+}
+
 #[derive(Deserialize)]
 pub(crate) struct DropboxEntry {
     #[serde(rename = ".tag")]

--- a/apps/desktop/src-tauri/src/remote_index.rs
+++ b/apps/desktop/src-tauri/src/remote_index.rs
@@ -8,7 +8,7 @@ use crate::models::{DropboxEntry, DropboxListFolderResponse};
 use crate::path_util::normalize_dropbox_path;
 use crate::state::AppState;
 
-#[derive(Clone)]
+#[derive(Clone, Debug, PartialEq)]
 pub(crate) struct RemoteFileMeta {
     pub content_hash: String,
     pub rev: String,
@@ -29,24 +29,6 @@ pub(crate) enum DeltaAction {
     Remove(String),
     /// A folder entry or an unusable entry — nothing to apply.
     Ignore,
-}
-
-impl PartialEq for RemoteFileMeta {
-    fn eq(&self, other: &Self) -> bool {
-        self.content_hash == other.content_hash
-            && self.rev == other.rev
-            && self.modified_ts == other.modified_ts
-    }
-}
-
-impl std::fmt::Debug for RemoteFileMeta {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("RemoteFileMeta")
-            .field("content_hash", &self.content_hash)
-            .field("rev", &self.rev)
-            .field("modified_ts", &self.modified_ts)
-            .finish()
-    }
 }
 
 /// Classify a `list_folder`/`continue` delta entry. A `deleted` entry carries no

--- a/apps/desktop/src-tauri/src/remote_index.rs
+++ b/apps/desktop/src-tauri/src/remote_index.rs
@@ -15,6 +15,79 @@ pub(crate) struct RemoteFileMeta {
     pub modified_ts: i64,
 }
 
+/// `app_config` key holding the persisted `list_folder` cursor for cursor-delta
+/// remote change detection (DBSYNC-30). Cleared by `reset_sync_state` (folder
+/// change) and on (re)login so the loop reseeds against the new state.
+pub(crate) const REMOTE_DELTA_CURSOR_KEY: &str = "remote_delta_cursor";
+
+/// What a single `list_folder`/`continue` delta entry means for the local index.
+#[derive(Debug, PartialEq)]
+pub(crate) enum DeltaAction {
+    /// A file was added or modified remotely.
+    Upsert(String, RemoteFileMeta),
+    /// A file/folder was removed remotely.
+    Remove(String),
+    /// A folder entry or an unusable entry — nothing to apply.
+    Ignore,
+}
+
+impl PartialEq for RemoteFileMeta {
+    fn eq(&self, other: &Self) -> bool {
+        self.content_hash == other.content_hash
+            && self.rev == other.rev
+            && self.modified_ts == other.modified_ts
+    }
+}
+
+impl std::fmt::Debug for RemoteFileMeta {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("RemoteFileMeta")
+            .field("content_hash", &self.content_hash)
+            .field("rev", &self.rev)
+            .field("modified_ts", &self.modified_ts)
+            .finish()
+    }
+}
+
+/// Classify a `list_folder`/`continue` delta entry. A `deleted` entry carries no
+/// hash/rev; a `file` entry needs both. Pure — unit-testable without network.
+pub(crate) fn delta_action_from_entry(entry: &DropboxEntry) -> DeltaAction {
+    let Some(path_display) = entry.path_display.as_deref() else {
+        return DeltaAction::Ignore;
+    };
+    let rel = path_display.trim_start_matches('/').to_string();
+    match entry.tag.as_str() {
+        "file" => {
+            let content_hash = entry.content_hash.clone().unwrap_or_default();
+            let rev = entry.rev.clone().unwrap_or_default();
+            if content_hash.is_empty() || rev.is_empty() {
+                return DeltaAction::Ignore;
+            }
+            let modified_ts = entry
+                .server_modified
+                .as_deref()
+                .map(parse_rfc3339_ts_to_unix)
+                .unwrap_or(0);
+            DeltaAction::Upsert(
+                rel,
+                RemoteFileMeta {
+                    content_hash,
+                    rev,
+                    modified_ts,
+                },
+            )
+        }
+        "deleted" => DeltaAction::Remove(rel),
+        _ => DeltaAction::Ignore,
+    }
+}
+
+/// True if a `list_folder/continue` response signals an invalidated cursor
+/// (HTTP 409 with a `reset` error) — the caller must re-snapshot. Pure.
+pub(crate) fn is_reset_error(status: u16, body: &str) -> bool {
+    status == 409 && (body.contains("\"reset\"") || body.contains("reset/"))
+}
+
 pub(crate) fn parse_rfc3339_ts_to_unix(input: &str) -> i64 {
     chrono::DateTime::parse_from_rfc3339(input)
         .map(|v| v.with_timezone(&Utc).timestamp())
@@ -118,7 +191,7 @@ fn remote_meta_from_entry(entry: &DropboxEntry) -> Option<(String, RemoteFileMet
 /// of returning whatever was collected so far.
 pub(crate) fn fetch_all_remote_file_metadata(
     state: &AppState,
-) -> AppResult<HashMap<String, RemoteFileMeta>> {
+) -> AppResult<(HashMap<String, RemoteFileMeta>, String)> {
     let token = get_access_token(state)?;
     let client = &state.http_client;
 
@@ -177,7 +250,9 @@ pub(crate) fn fetch_all_remote_file_metadata(
             .map_err(|e| AppError::Other(format!("list_folder/continue parse failed: {e}")))?;
     }
 
-    Ok(remote_by_path)
+    // The final cursor points at the exact remote state this snapshot captured;
+    // it is the correct seed for cursor-delta longpoll (DBSYNC-30).
+    Ok((remote_by_path, entries_resp.cursor))
 }
 
 pub(crate) fn refresh_remote_index_and_enqueue_downloads_internal(
@@ -188,73 +263,20 @@ pub(crate) fn refresh_remote_index_and_enqueue_downloads_internal(
         return Ok(0);
     }
 
-    let remote_by_path = fetch_all_remote_file_metadata(state)?;
+    let (remote_by_path, _cursor) = fetch_all_remote_file_metadata(state)?;
 
-    let existing_jobs = state.db.list_recent_jobs(400)?;
-    let pending_targets: HashSet<String> = existing_jobs
-        .iter()
-        .filter(|j| j.status == "queued" || j.status == "retry_wait" || j.status == "running")
-        .filter_map(|j| j.target_path.clone().or(j.source_path.clone()))
-        .collect();
+    let pending_targets = pending_job_targets(state)?;
 
     let mut enqueued = 0usize;
     for local in local_files {
         let rel = local.relative_path;
-        if rel.ends_with(".cloudsc") {
-            continue;
-        }
-        if pending_targets.contains(&rel) {
+        if rel.ends_with(".cloudsc") || pending_targets.contains(&rel) {
             continue;
         }
 
-        let prev_remote = state.db.get_remote_file(&rel)?;
-        let remote_meta = remote_by_path
-            .get(&normalize_dropbox_path(&rel)?.to_lowercase())
-            .cloned();
-        let Some(remote_meta) = remote_meta else {
-            // Remote copy is gone. Only propagate the deletion when we had
-            // previously indexed a remote copy (otherwise the file may simply
-            // never have been uploaded yet).
-            if let Some(prev) = prev_remote {
-                if local.hash == prev.content_hash {
-                    // Local matches the last-synced remote content: safe to
-                    // delete locally (remote-wins).
-                    state.db.enqueue_job("local_delete", Some(&rel), Some(&rel))?;
-                    enqueued += 1;
-                } else {
-                    // Local was modified while the remote was deleted: keep the
-                    // local copy and flag a conflict instead of losing data.
-                    state.db.add_conflict(
-                        &rel,
-                        &rel,
-                        "remote deleted while local had unsynced changes",
-                    )?;
-                    state.db.remove_remote_file(&rel)?;
-                    if let Ok(mut engine) = state.sync_engine.lock() {
-                        engine.record_conflict();
-                    }
-                }
-            }
-            continue;
-        };
-
-        let should_download = match prev_remote {
-            None => false,
-            Some(prev) => prev.content_hash != remote_meta.content_hash,
-        };
-
-        state
-            .db
-            .upsert_remote_file(
-                &rel,
-                &remote_meta.content_hash,
-                &remote_meta.rev,
-                remote_meta.modified_ts,
-            )?;
-
-        if should_download && local.hash != remote_meta.content_hash {
-            state.db.enqueue_job("download", Some(&rel), Some(&rel))?;
-            enqueued += 1;
+        match remote_by_path.get(&normalize_dropbox_path(&rel)?.to_lowercase()) {
+            Some(remote_meta) => enqueued += reconcile_remote_present(state, &rel, remote_meta)?,
+            None => enqueued += reconcile_remote_absent(state, &rel)?,
         }
     }
 
@@ -265,6 +287,200 @@ pub(crate) fn refresh_remote_index_and_enqueue_downloads_internal(
             enqueued,
             "remote index refresh enqueued download/delete jobs"
         );
+    }
+    Ok(enqueued)
+}
+
+/// The set of relative paths with an in-flight job, so we don't enqueue a
+/// duplicate download/delete for a file already being processed.
+fn pending_job_targets(state: &AppState) -> AppResult<HashSet<String>> {
+    Ok(state
+        .db
+        .list_recent_jobs(400)?
+        .iter()
+        .filter(|j| j.status == "queued" || j.status == "retry_wait" || j.status == "running")
+        .filter_map(|j| j.target_path.clone().or(j.source_path.clone()))
+        .collect())
+}
+
+/// Reconcile a path that is PRESENT on the remote: record its metadata and, when
+/// the remote content changed vs the last-synced state and the local copy
+/// differs, enqueue a download. Returns jobs enqueued (0/1). Shared by the full
+/// sweep and the cursor-delta path (DBSYNC-30) so both behave identically.
+pub(crate) fn reconcile_remote_present(
+    state: &AppState,
+    rel: &str,
+    remote_meta: &RemoteFileMeta,
+) -> AppResult<usize> {
+    let prev_remote = state.db.get_remote_file(rel)?;
+    let should_download = match &prev_remote {
+        None => false,
+        Some(prev) => prev.content_hash != remote_meta.content_hash,
+    };
+
+    state.db.upsert_remote_file(
+        rel,
+        &remote_meta.content_hash,
+        &remote_meta.rev,
+        remote_meta.modified_ts,
+    )?;
+
+    if should_download {
+        if let Some(local) = state.db.get_local_file(rel)? {
+            if local.hash != remote_meta.content_hash {
+                state.db.enqueue_job("download", Some(rel), Some(rel))?;
+                return Ok(1);
+            }
+        }
+    }
+    Ok(0)
+}
+
+/// Reconcile a path that is ABSENT from the remote (deleted remotely). Propagates
+/// a remote-wins local delete ONLY when the local copy still matches the
+/// last-synced remote content; a diverged local copy is kept and flagged as a
+/// conflict (never lost). Returns jobs enqueued (0/1). Shared by the full sweep
+/// and the cursor-delta path.
+pub(crate) fn reconcile_remote_absent(state: &AppState, rel: &str) -> AppResult<usize> {
+    let Some(prev) = state.db.get_remote_file(rel)? else {
+        // Never indexed remotely — the file may simply never have been uploaded.
+        return Ok(0);
+    };
+    let Some(local) = state.db.get_local_file(rel)? else {
+        // No local file to delete (already gone / dehydrated / never downloaded):
+        // just drop the stale remote index row.
+        state.db.remove_remote_file(rel)?;
+        return Ok(0);
+    };
+
+    if local.hash == prev.content_hash {
+        // Local matches the last-synced remote content: safe remote-wins delete.
+        // The local_delete job clears both index rows.
+        state.db.enqueue_job("local_delete", Some(rel), Some(rel))?;
+        Ok(1)
+    } else {
+        // Local was modified while the remote was deleted: keep it, flag conflict.
+        state
+            .db
+            .add_conflict(rel, rel, "remote deleted while local had unsynced changes")?;
+        state.db.remove_remote_file(rel)?;
+        if let Ok(mut engine) = state.sync_engine.lock() {
+            engine.record_conflict();
+        }
+        Ok(0)
+    }
+}
+
+/// Full recursive remote snapshot: reconcile the index against every local file
+/// and persist the resulting cursor as the seed for cursor-delta longpoll. The
+/// cursor MUST come from this same sweep so it points at exactly the state the
+/// index now reflects (not a later `get_latest_cursor`). Returns the cursor.
+pub(crate) fn seed_remote_delta_cursor(state: &AppState) -> AppResult<String> {
+    let (remote_by_path, cursor) = fetch_all_remote_file_metadata(state)?;
+
+    let local_files = state.db.list_local_files()?;
+    if !local_files.is_empty() {
+        let pending_targets = pending_job_targets(state)?;
+        for local in local_files {
+            let rel = local.relative_path;
+            if rel.ends_with(".cloudsc") || pending_targets.contains(&rel) {
+                continue;
+            }
+            match remote_by_path.get(&normalize_dropbox_path(&rel)?.to_lowercase()) {
+                Some(meta) => {
+                    reconcile_remote_present(state, &rel, meta)?;
+                }
+                None => {
+                    reconcile_remote_absent(state, &rel)?;
+                }
+            }
+        }
+    }
+
+    state
+        .db
+        .set_app_config(REMOTE_DELTA_CURSOR_KEY, &cursor)?;
+    Ok(cursor)
+}
+
+/// Apply the remote changes since the persisted cursor (DBSYNC-30): call
+/// `list_folder/continue`, apply each delta entry to `remote_file_index` via the
+/// shared guarded reconcilers, and advance + persist the cursor per page. On an
+/// invalidated cursor (`reset`), discard it and re-snapshot. Returns jobs
+/// enqueued. The caller drains the queue.
+pub(crate) fn apply_remote_delta(state: &AppState) -> AppResult<usize> {
+    let mut cursor = match state.db.get_app_config(REMOTE_DELTA_CURSOR_KEY)? {
+        Some(c) if !c.is_empty() => c,
+        // No cursor yet: seed a fresh snapshot; the next longpoll continues from it.
+        _ => {
+            seed_remote_delta_cursor(state)?;
+            return Ok(0);
+        }
+    };
+
+    let token = get_access_token(state)?;
+    let client = &state.http_client;
+    let mut enqueued = 0usize;
+
+    loop {
+        let pending_targets = pending_job_targets(state)?;
+
+        let response = client
+            .post("https://api.dropboxapi.com/2/files/list_folder/continue")
+            .bearer_auth(token.as_str())
+            .json(&serde_json::json!({ "cursor": cursor }))
+            .send()
+            .map_err(|e| AppError::Network(format!("list_folder/continue request failed: {e}")))?;
+
+        if !response.status().is_success() {
+            let status = response.status().as_u16();
+            let body = response
+                .text()
+                .unwrap_or_else(|_| "<unreadable body>".to_string());
+            if is_reset_error(status, &body) {
+                // Cursor invalidated: discard it and re-snapshot from scratch.
+                tracing::info!("remote delta cursor reset; re-snapshotting");
+                state.db.set_app_config(REMOTE_DELTA_CURSOR_KEY, "")?;
+                seed_remote_delta_cursor(state)?;
+                return Ok(enqueued);
+            }
+            return Err(AppError::Dropbox {
+                status,
+                message: format!("list_folder/continue delta: {body}"),
+            });
+        }
+
+        let resp: DropboxListFolderResponse = response
+            .json()
+            .map_err(|e| AppError::Other(format!("list_folder/continue parse failed: {e}")))?;
+
+        for entry in &resp.entries {
+            match delta_action_from_entry(entry) {
+                DeltaAction::Upsert(rel, meta) => {
+                    if !rel.ends_with(".cloudsc") && !pending_targets.contains(&rel) {
+                        enqueued += reconcile_remote_present(state, &rel, &meta)?;
+                    }
+                }
+                DeltaAction::Remove(rel) => {
+                    if !rel.ends_with(".cloudsc") && !pending_targets.contains(&rel) {
+                        enqueued += reconcile_remote_absent(state, &rel)?;
+                    }
+                }
+                DeltaAction::Ignore => {}
+            }
+        }
+
+        // Advance + persist per page so a crash mid-stream resumes cleanly.
+        cursor = resp.cursor;
+        state.db.set_app_config(REMOTE_DELTA_CURSOR_KEY, &cursor)?;
+
+        if !resp.has_more {
+            break;
+        }
+    }
+
+    if enqueued > 0 {
+        tracing::info!(enqueued, "longpoll delta enqueued download/delete jobs");
     }
     Ok(enqueued)
 }
@@ -327,5 +543,177 @@ mod tests {
         let entry = file_entry(None, Some("hash123"), Some("rev1"), None);
 
         assert!(remote_meta_from_entry(&entry).is_none());
+    }
+
+    // ---------------------------------------------------------------------------
+    // Cursor-delta remote change detection (DBSYNC-30)
+    // ---------------------------------------------------------------------------
+
+    use std::sync::atomic::AtomicBool;
+    use std::sync::{Arc, Mutex};
+
+    fn build_state() -> AppState {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let db_path = dir.path().join("app.db");
+        // Leak the tempdir so the DB file outlives the test body.
+        std::mem::forget(dir);
+        let db = crate::storage::db::Db::new_at(&db_path).expect("db init");
+        AppState {
+            secure_store: crate::storage::secure_store::SecureStore::new(),
+            db: Arc::new(db),
+            sync_engine: Arc::new(Mutex::new(crate::sync::engine::SyncEngine::new())),
+            token_cache: Arc::new(Mutex::new(None)),
+            scheduler_started: Arc::new(Mutex::new(false)),
+            oauth_listener: Arc::new(Mutex::new(None)),
+            sync_running: Arc::new(AtomicBool::new(false)),
+            token_refresh_lock: Arc::new(Mutex::new(())),
+            http_client: crate::state::build_http_client(),
+        }
+    }
+
+    fn job_targets(state: &AppState, job_type: &str) -> Vec<String> {
+        state
+            .db
+            .list_recent_jobs(200)
+            .unwrap()
+            .into_iter()
+            .filter(|j| j.job_type == job_type)
+            .filter_map(|j| j.target_path)
+            .collect()
+    }
+
+    #[test]
+    fn delta_action_classifies_file_deleted_folder_and_invalid() {
+        match delta_action_from_entry(&file_entry(Some("/A/b.txt"), Some("h"), Some("r"), None)) {
+            DeltaAction::Upsert(rel, meta) => {
+                assert_eq!(rel, "A/b.txt");
+                assert_eq!(meta.content_hash, "h");
+                assert_eq!(meta.rev, "r");
+            }
+            other => panic!("expected Upsert, got {other:?}"),
+        }
+
+        let mut deleted = file_entry(Some("/A/gone.txt"), None, None, None);
+        deleted.tag = "deleted".to_string();
+        assert_eq!(
+            delta_action_from_entry(&deleted),
+            DeltaAction::Remove("A/gone.txt".to_string())
+        );
+
+        let mut folder = file_entry(Some("/A"), None, None, None);
+        folder.tag = "folder".to_string();
+        assert_eq!(delta_action_from_entry(&folder), DeltaAction::Ignore);
+
+        // file with missing hash/rev, or missing path_display → Ignore
+        assert_eq!(
+            delta_action_from_entry(&file_entry(Some("/A/x"), None, Some("r"), None)),
+            DeltaAction::Ignore
+        );
+        assert_eq!(
+            delta_action_from_entry(&file_entry(None, Some("h"), Some("r"), None)),
+            DeltaAction::Ignore
+        );
+    }
+
+    #[test]
+    fn is_reset_error_detects_reset_only() {
+        assert!(is_reset_error(
+            409,
+            r#"{"error_summary":"reset/...","error":{".tag":"reset"}}"#
+        ));
+        assert!(!is_reset_error(409, r#"{"error_summary":"path/not_found/.."}"#));
+        assert!(!is_reset_error(200, "reset/whatever"));
+    }
+
+    #[test]
+    fn reconcile_remote_absent_deletes_when_local_matches_last_synced() {
+        let state = build_state();
+        state.db.upsert_remote_file("a.txt", "H", "rev", 0).unwrap();
+        state.db.upsert_local_file("a.txt", "H", 3, 0).unwrap();
+
+        let n = reconcile_remote_absent(&state, "a.txt").unwrap();
+        assert_eq!(n, 1);
+        assert_eq!(job_targets(&state, "local_delete"), vec!["a.txt".to_string()]);
+    }
+
+    #[test]
+    fn reconcile_remote_absent_keeps_diverged_local_as_conflict() {
+        let state = build_state();
+        state.db.upsert_remote_file("b.txt", "H", "rev", 0).unwrap();
+        state.db.upsert_local_file("b.txt", "DIFFERENT", 3, 0).unwrap();
+
+        let n = reconcile_remote_absent(&state, "b.txt").unwrap();
+        assert_eq!(n, 0, "a diverged local file must NOT be deleted");
+        assert!(job_targets(&state, "local_delete").is_empty());
+        assert!(state.db.get_remote_file("b.txt").unwrap().is_none());
+    }
+
+    #[test]
+    fn reconcile_remote_absent_no_local_just_drops_remote_row() {
+        let state = build_state();
+        state.db.upsert_remote_file("c.txt", "H", "rev", 0).unwrap();
+
+        let n = reconcile_remote_absent(&state, "c.txt").unwrap();
+        assert_eq!(n, 0);
+        assert!(state.db.get_remote_file("c.txt").unwrap().is_none());
+        assert!(job_targets(&state, "local_delete").is_empty());
+    }
+
+    #[test]
+    fn reconcile_remote_absent_never_indexed_is_noop() {
+        let state = build_state();
+        let n = reconcile_remote_absent(&state, "d.txt").unwrap();
+        assert_eq!(n, 0);
+        assert!(state.db.list_recent_jobs(50).unwrap().is_empty());
+    }
+
+    #[test]
+    fn reconcile_remote_present_enqueues_download_on_remote_change() {
+        let state = build_state();
+        state.db.upsert_remote_file("e.txt", "OLD", "rev0", 0).unwrap();
+        state.db.upsert_local_file("e.txt", "OLD", 3, 0).unwrap();
+
+        let meta = RemoteFileMeta {
+            content_hash: "NEW".to_string(),
+            rev: "rev1".to_string(),
+            modified_ts: 0,
+        };
+        let n = reconcile_remote_present(&state, "e.txt", &meta).unwrap();
+        assert_eq!(n, 1);
+        assert_eq!(job_targets(&state, "download"), vec!["e.txt".to_string()]);
+        assert_eq!(
+            state.db.get_remote_file("e.txt").unwrap().unwrap().content_hash,
+            "NEW"
+        );
+    }
+
+    #[test]
+    fn reconcile_remote_present_no_download_when_unchanged() {
+        let state = build_state();
+        state.db.upsert_remote_file("f.txt", "SAME", "rev0", 0).unwrap();
+        state.db.upsert_local_file("f.txt", "SAME", 3, 0).unwrap();
+
+        let meta = RemoteFileMeta {
+            content_hash: "SAME".to_string(),
+            rev: "rev0".to_string(),
+            modified_ts: 0,
+        };
+        let n = reconcile_remote_present(&state, "f.txt", &meta).unwrap();
+        assert_eq!(n, 0);
+        assert!(job_targets(&state, "download").is_empty());
+    }
+
+    #[test]
+    fn reset_sync_state_clears_the_delta_cursor() {
+        let state = build_state();
+        state
+            .db
+            .set_app_config(REMOTE_DELTA_CURSOR_KEY, "cursor-abc")
+            .unwrap();
+        state.db.reset_sync_state().unwrap();
+        assert_eq!(
+            state.db.get_app_config(REMOTE_DELTA_CURSOR_KEY).unwrap(),
+            None
+        );
     }
 }

--- a/apps/desktop/src-tauri/src/remote_longpoll.rs
+++ b/apps/desktop/src-tauri/src/remote_longpoll.rs
@@ -21,6 +21,10 @@ const LONGPOLL_HTTP_TIMEOUT_SECS: u64 = LONGPOLL_TIMEOUT_SECS + 90 + 15;
 const IDLE_SLEEP_SECS: u64 = 15;
 const MIN_BACKOFF_SECS: u64 = 5;
 const MAX_BACKOFF_SECS: u64 = 60;
+/// When a change is pending but another sync owns the gate, wait this long
+/// before re-longpolling, so we don't spin issuing back-to-back requests
+/// (which would return `changes:true` instantly) until the other sync frees it.
+const GATE_BUSY_SLEEP_SECS: u64 = 3;
 
 /// Single-instance guard — the loop is started once from `lib.rs setup()`.
 static LONGPOLL_STARTED: OnceLock<()> = OnceLock::new();
@@ -79,8 +83,11 @@ fn longpoll_loop(state: &AppState) {
         match do_longpoll(state, &cursor) {
             Ok(resp) => {
                 err_backoff = 0;
-                if resp.changes {
-                    apply_and_drain(state);
+                if resp.changes && !apply_and_drain(state) {
+                    // Another sync owns the gate; the delta wasn't applied and the
+                    // cursor didn't advance. Pause so we don't hot-loop re-longpolling
+                    // the still-pending change until that sync finishes.
+                    std::thread::sleep(Duration::from_secs(GATE_BUSY_SLEEP_SECS));
                 }
                 if let Some(secs) = resp.backoff {
                     std::thread::sleep(Duration::from_secs(secs));
@@ -147,8 +154,10 @@ fn do_longpoll(state: &AppState, cursor: &str) -> AppResult<DropboxLongpollRespo
         .map_err(|e| AppError::Other(format!("longpoll parse failed: {e}")))
 }
 
-/// Apply the remote delta + drain, under the shared single-flight gate.
-fn apply_and_drain(state: &AppState) {
+/// Apply the remote delta + drain, under the shared single-flight gate. Returns
+/// `false` if another sync owned the gate (nothing applied — caller should pause
+/// before re-longpolling the still-pending change).
+fn apply_and_drain(state: &AppState) -> bool {
     if state
         .sync_running
         .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
@@ -156,7 +165,7 @@ fn apply_and_drain(state: &AppState) {
     {
         // A scan/tick/watcher already owns the sync; the next longpoll or the
         // 5-min sweep reconciles. No double-drain.
-        return;
+        return false;
     }
     crate::auth_session::refresh_tray_tooltip(state);
     match crate::remote_index::apply_remote_delta(state) {
@@ -167,6 +176,7 @@ fn apply_and_drain(state: &AppState) {
     crate::sync_pipeline::drain_sync_queue(state);
     state.sync_running.store(false, Ordering::Release);
     crate::auth_session::refresh_tray_tooltip(state);
+    true
 }
 
 #[cfg(test)]

--- a/apps/desktop/src-tauri/src/remote_longpoll.rs
+++ b/apps/desktop/src-tauri/src/remote_longpoll.rs
@@ -1,0 +1,197 @@
+//! Dropbox longpoll loop (DBSYNC-30): the remote counterpart of the DBSYNC-29
+//! filesystem watcher. Blocks on `/2/files/list_folder/longpoll` and applies
+//! cursor deltas the moment the remote changes, instead of a periodic full
+//! re-list. One background thread; the 5-min sweep stays as reconciliation
+//! fallback. Work is gated by the shared `sync_running` CAS.
+
+use std::sync::atomic::Ordering;
+use std::sync::OnceLock;
+use std::time::Duration;
+
+use crate::error::{AppError, AppResult};
+use crate::models::DropboxLongpollResponse;
+use crate::state::AppState;
+
+/// Longpoll block time (seconds). Dropbox adds up to 90s of jitter on top.
+const LONGPOLL_TIMEOUT_SECS: u64 = 30;
+/// Per-request HTTP timeout for the longpoll: block + jitter + slack. The shared
+/// client's 30s default would abort this long-blocking call, so we override it.
+const LONGPOLL_HTTP_TIMEOUT_SECS: u64 = LONGPOLL_TIMEOUT_SECS + 90 + 15;
+/// Idle sleep when not logged in / no sync folder configured yet.
+const IDLE_SLEEP_SECS: u64 = 15;
+const MIN_BACKOFF_SECS: u64 = 5;
+const MAX_BACKOFF_SECS: u64 = 60;
+
+/// Single-instance guard — the loop is started once from `lib.rs setup()`.
+static LONGPOLL_STARTED: OnceLock<()> = OnceLock::new();
+
+/// Start the background longpoll loop (idempotent; a second call is a no-op).
+pub(crate) fn start_longpoll(state: &AppState) {
+    if LONGPOLL_STARTED.set(()).is_err() {
+        return;
+    }
+    let st = state.clone();
+    std::thread::spawn(move || longpoll_loop(&st));
+}
+
+/// Exponential error backoff: 0 → 5s → 10s → … capped at 60s.
+fn next_backoff(prev: u64) -> u64 {
+    if prev == 0 {
+        MIN_BACKOFF_SECS
+    } else {
+        (prev * 2).min(MAX_BACKOFF_SECS)
+    }
+}
+
+fn longpoll_loop(state: &AppState) {
+    let mut err_backoff = 0u64;
+    loop {
+        // 1. Ready check: a sync folder AND a usable token. Handles logout —
+        // get_access_token errs → idle; a later login resumes the loop.
+        let folder_ok = state
+            .db
+            .get_sync_folder()
+            .ok()
+            .flatten()
+            .map(|f| !f.trim().is_empty())
+            .unwrap_or(false);
+        if !folder_ok || crate::auth_session::get_access_token(state).is_err() {
+            std::thread::sleep(Duration::from_secs(IDLE_SLEEP_SECS));
+            continue;
+        }
+
+        // 2. Ensure a cursor exists (seed a snapshot if not).
+        let cursor = match ensure_cursor(state) {
+            Ok(c) => c,
+            Err(e) => {
+                tracing::warn!(error = %e, "longpoll: failed to obtain remote cursor");
+                err_backoff = next_backoff(err_backoff);
+                std::thread::sleep(Duration::from_secs(err_backoff));
+                continue;
+            }
+        };
+        let Some(cursor) = cursor else {
+            // Just seeded (no changes to poll yet); loop to longpoll next round.
+            continue;
+        };
+
+        // 3. Longpoll (unauthenticated, long-blocking).
+        match do_longpoll(state, &cursor) {
+            Ok(resp) => {
+                err_backoff = 0;
+                if resp.changes {
+                    apply_and_drain(state);
+                }
+                if let Some(secs) = resp.backoff {
+                    std::thread::sleep(Duration::from_secs(secs));
+                }
+            }
+            Err(e) => {
+                tracing::warn!(error = %e, "longpoll request failed; backing off");
+                err_backoff = next_backoff(err_backoff);
+                std::thread::sleep(Duration::from_secs(err_backoff));
+            }
+        }
+    }
+}
+
+/// Return the current delta cursor, seeding a fresh snapshot if none exists.
+/// Returns `Ok(None)` when it had to seed this round (caller loops again).
+fn ensure_cursor(state: &AppState) -> AppResult<Option<String>> {
+    match state
+        .db
+        .get_app_config(crate::remote_index::REMOTE_DELTA_CURSOR_KEY)?
+    {
+        Some(c) if !c.is_empty() => Ok(Some(c)),
+        _ => {
+            crate::remote_index::seed_remote_delta_cursor(state)?;
+            Ok(None)
+        }
+    }
+}
+
+fn do_longpoll(state: &AppState, cursor: &str) -> AppResult<DropboxLongpollResponse> {
+    // The longpoll endpoint is on the `notify` host and takes NO Authorization
+    // header (auth = noauth); only `continue` (in apply_remote_delta) is authed.
+    let response = state
+        .http_client
+        .post("https://notify.dropboxapi.com/2/files/list_folder/longpoll")
+        .timeout(Duration::from_secs(LONGPOLL_HTTP_TIMEOUT_SECS))
+        .json(&serde_json::json!({ "cursor": cursor, "timeout": LONGPOLL_TIMEOUT_SECS }))
+        .send()
+        .map_err(|e| AppError::Network(format!("longpoll request failed: {e}")))?;
+
+    if !response.status().is_success() {
+        let status = response.status().as_u16();
+        let body = response
+            .text()
+            .unwrap_or_else(|_| "<unreadable body>".to_string());
+        if crate::remote_index::is_reset_error(status, &body) {
+            // Invalidated cursor: clear it so the next iteration reseeds.
+            let _ = state
+                .db
+                .set_app_config(crate::remote_index::REMOTE_DELTA_CURSOR_KEY, "");
+            return Ok(DropboxLongpollResponse {
+                changes: false,
+                backoff: None,
+            });
+        }
+        return Err(AppError::Dropbox {
+            status,
+            message: format!("longpoll: {body}"),
+        });
+    }
+
+    response
+        .json::<DropboxLongpollResponse>()
+        .map_err(|e| AppError::Other(format!("longpoll parse failed: {e}")))
+}
+
+/// Apply the remote delta + drain, under the shared single-flight gate.
+fn apply_and_drain(state: &AppState) {
+    if state
+        .sync_running
+        .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+        .is_err()
+    {
+        // A scan/tick/watcher already owns the sync; the next longpoll or the
+        // 5-min sweep reconciles. No double-drain.
+        return;
+    }
+    crate::auth_session::refresh_tray_tooltip(state);
+    match crate::remote_index::apply_remote_delta(state) {
+        Ok(n) if n > 0 => tracing::info!(enqueued = n, "longpoll applied remote delta"),
+        Ok(_) => {}
+        Err(e) => tracing::error!(error = %e, "apply_remote_delta failed"),
+    }
+    crate::sync_pipeline::drain_sync_queue(state);
+    state.sync_running.store(false, Ordering::Release);
+    crate::auth_session::refresh_tray_tooltip(state);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{next_backoff, MAX_BACKOFF_SECS, MIN_BACKOFF_SECS};
+    use crate::models::DropboxLongpollResponse;
+
+    #[test]
+    fn backoff_grows_and_caps() {
+        assert_eq!(next_backoff(0), MIN_BACKOFF_SECS);
+        assert_eq!(next_backoff(5), 10);
+        assert_eq!(next_backoff(40), MAX_BACKOFF_SECS);
+        assert_eq!(next_backoff(MAX_BACKOFF_SECS), MAX_BACKOFF_SECS);
+    }
+
+    #[test]
+    fn longpoll_response_deserializes_both_shapes() {
+        let with: DropboxLongpollResponse =
+            serde_json::from_str(r#"{"changes":true,"backoff":10}"#).unwrap();
+        assert!(with.changes);
+        assert_eq!(with.backoff, Some(10));
+
+        let without: DropboxLongpollResponse =
+            serde_json::from_str(r#"{"changes":false}"#).unwrap();
+        assert!(!without.changes);
+        assert_eq!(without.backoff, None);
+    }
+}

--- a/apps/desktop/src-tauri/src/storage/db.rs
+++ b/apps/desktop/src-tauri/src/storage/db.rs
@@ -113,6 +113,12 @@ impl Db {
         conn.execute("DELETE FROM sync_jobs", [])?;
         conn.execute("DELETE FROM sync_conflicts", [])?;
         conn.execute("DELETE FROM known_folders", [])?;
+        // Drop the cursor-delta cursor so remote change detection re-seeds
+        // against the new folder (DBSYNC-30); other app_config keys are kept.
+        conn.execute(
+            "DELETE FROM app_config WHERE key = 'remote_delta_cursor'",
+            [],
+        )?;
         Ok(())
     }
 


### PR DESCRIPTION
## Summary
Adds near-real-time remote change detection via Dropbox **longpoll + cursor deltas** — the remote counterpart of the DBSYNC-29 local watcher — replacing reliance on the periodic full recursive `list_folder` sweep. (The ticket's N+1 `get_metadata` problem was already solved; the sweep is a constant number of calls.) Closes #40, #41.

**Slice 1 — cursor + delta apply (`remote_index.rs`)**
- `fetch_all_remote_file_metadata` returns the snapshot's final cursor (correct delta seed; NOT `get_latest_cursor`). Persisted in `app_config`.
- Factored `reconcile_remote_present` / `reconcile_remote_absent` out of `refresh_remote_index_and_enqueue_downloads_internal` (pure moves) → shared by sweep + delta, so the **DBSYNC-45 remote-wins guard** (local_delete only when local matches last-synced; diverged local → conflict, never lost) is reused.
- `delta_action_from_entry`, `is_reset_error`, `seed_remote_delta_cursor`, `apply_remote_delta` (`continue` loop, per-page cursor persist, `reset` → re-snapshot). `reset_sync_state` clears the cursor.

**Slice 2 — longpoll loop (`remote_longpoll.rs`)**
- One background thread (OnceLock single-instance), started in `lib.rs setup()`. Ready-check → ensure cursor → longpoll (notify host, **no auth**, per-request **135s** timeout since it blocks ~120s and the shared 30s client would kill it) → on changes `apply_remote_delta` + drain under the `sync_running` CAS gate → honor `backoff`; exponential error backoff. Cursor cleared on login (reseeds per account). The 5-min sweep stays as reconciliation fallback.

## Stack
desktop-tauri

## Jira Ticket
#DBSYNC-30

## Test Plan
- [x] `cargo test` — 93/93 pass (+11: delta classify, reset detect, 4 reconcile-absent branches incl. conflict-keep, 2 reconcile-present, cursor clear, backoff, longpoll serde)
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] User smoke: a change on Dropbox web reflected locally within seconds

## Notes
Scope: a brand-NEW remote file still becomes a `.cloudsc` on the 5-min sweep (placeholder creation is a separate mechanism); longpoll accelerates changes/deletes of already-tracked files. Data-loss care: remote deletions reuse the existing guarded path (no new deletion logic).

🤖 Generated with Claude Code

https://claude.ai/code/session_01XFcb2z2QG5oQe6v8GyDwhd