### PR TITLE
fix(shell): Win11 context menu surfacing + app icon (#DBSYNC-33)

### DIFF
--- a/apps/desktop/native/windows/shell-menu/README.md
+++ b/apps/desktop/native/windows/shell-menu/README.md
@@ -16,7 +16,10 @@ DBSYNC-33; the actions themselves are handled by the running app
 ## How it works
 
 - One CLSID `{FBF4F890-5407-47BF-BE25-F5B2595FA839}` registered per-user (HKCU,
-  no admin) on `*` (all files, incl. `.cloudsc`) and `Directory` (folders).
+  no admin) on `AllFilesystemObjects` (files, folders and drives) as an
+  `IExplorerCommand` verb with a `command`/`DelegateExecute` subkey +
+  `MultiSelectModel` — required for the verb to surface on Windows 11 (a bare
+  `ExplorerCommandHandler` is culled and never appears).
 - Per-item visibility is decided in `IExplorerCommand::GetState` by reading the
   app's `overlay_state.json` (`%LOCALAPPDATA%\DropboxSyncDesktop\`) for the sync
   root and checking the item's extension. The sync root is cached and only

--- a/apps/desktop/native/windows/shell-menu/src/command.rs
+++ b/apps/desktop/native/windows/shell-menu/src/command.rs
@@ -57,8 +57,11 @@ impl IExplorerCommand_Impl for DropboxSyncCommand_Impl {
     }
 
     fn GetIcon(&self, _items: Ref<'_, IShellItemArray>) -> Result<PWSTR> {
-        // No custom icon (optional in the contract); a follow-up may add branding.
-        Err(E_NOTIMPL.into())
+        // The app's own icon (`<exe>,0`) on the parent and both children.
+        util::guard(Err(E_NOTIMPL.into()), || match util::app_icon_spec() {
+            Some(spec) => util::alloc_wide(&spec),
+            None => Err(E_NOTIMPL.into()),
+        })
     }
 
     fn GetToolTip(&self, _items: Ref<'_, IShellItemArray>) -> Result<PWSTR> {

--- a/apps/desktop/native/windows/shell-menu/src/registry.rs
+++ b/apps/desktop/native/windows/shell-menu/src/registry.rs
@@ -1,5 +1,11 @@
-//! Per-user (HKCU) registration of the COM server + the `ExplorerCommandHandler`
-//! hookup on `*` (all files) and `Directory` (folders). No elevation required.
+//! Per-user (HKCU) registration of the COM server + the context-menu verb.
+//!
+//! Registered on **`AllFilesystemObjects`** (files, folders and drives) as an
+//! `IExplorerCommand` verb. On Windows 11 this surfaces under "Show more
+//! options" (the classic menu); the compact menu needs an MSIX sparse package
+//! (out of scope). The verb REQUIRES a `command` subkey with `DelegateExecute`
+//! and `MultiSelectModel` — a bare `shell\<verb>\ExplorerCommandHandler` (no
+//! `command`) is culled by the Win11 shell and never appears.
 //!
 //! In production the app writes these same keys on startup (see
 //! `src-tauri/src/windows_shell_menu.rs`); `DllRegisterServer`/`regsvr32` here is
@@ -14,38 +20,31 @@ use winreg::RegKey;
 /// String form of `CLSID_DROPBOXSYNC_COMMAND`.
 pub const CLSID_STR: &str = "{FBF4F890-5407-47BF-BE25-F5B2595FA839}";
 
-/// The `shell\<verb>` subkey name carrying `ExplorerCommandHandler`.
+/// The `shell\<verb>` subkey name.
 const VERB: &str = "DropboxSync";
-/// Classes the handler attaches to.
-const TARGET_CLASSES: [&str; 2] = ["*", "Directory"];
+/// Class the verb attaches to: all files, folders and drives.
+const TARGET_CLASS: &str = "AllFilesystemObjects";
 /// App-written config the DLL reads to find the exe to launch.
 const SHELLEXT_KEY: &str = r"Software\DropboxSyncDesktop\ShellExt";
 
-/// Write the COM server + handler hookup under HKCU.
+/// Write the COM server + verb under HKCU.
 pub fn register_hkcu(dll_path: &Path) -> io::Result<()> {
     let hkcu = RegKey::predef(HKEY_CURRENT_USER);
 
     // 1) COM server.
-    let (clsid_key, _) =
-        hkcu.create_subkey(format!(r"Software\Classes\CLSID\{CLSID_STR}"))?;
+    let (clsid_key, _) = hkcu.create_subkey(format!(r"Software\Classes\CLSID\{CLSID_STR}"))?;
     clsid_key.set_value("", &"DropboxSync Explorer Command")?;
     let (inproc, _) =
         hkcu.create_subkey(format!(r"Software\Classes\CLSID\{CLSID_STR}\InprocServer32"))?;
     inproc.set_value("", &dll_path.to_string_lossy().as_ref())?;
     inproc.set_value("ThreadingModel", &"Apartment")?;
 
-    // 2) Handler hookup on each target class.
-    for class in TARGET_CLASSES {
-        let (k, _) =
-            hkcu.create_subkey(format!(r"Software\Classes\{class}\shell\{VERB}"))?;
-        // MUIVerb is a fallback label if the handler can't load; the live menu
-        // text comes from IExplorerCommand::GetTitle.
-        k.set_value("MUIVerb", &"DropboxSync")?;
-        k.set_value("ExplorerCommandHandler", &CLSID_STR)?;
-    }
+    // 2) The context-menu verb. Use the app icon if we can find the exe next to
+    //    the DLL (the app overwrites this with its real exe icon at startup).
+    let icon = exe_next_to_dll(dll_path).map(|e| format!("{},0", e.to_string_lossy()));
+    write_verb(&hkcu, icon.as_deref())?;
 
-    // 3) Record the DLL path; record an exe path if we can find one next to it
-    //    (the app overwrites this with its real current_exe() at startup).
+    // 3) Record the DLL + exe paths for the handler to launch.
     let (cfg, _) = hkcu.create_subkey(SHELLEXT_KEY)?;
     cfg.set_value("DllPath", &dll_path.to_string_lossy().as_ref())?;
     if let Some(exe) = exe_next_to_dll(dll_path) {
@@ -55,13 +54,33 @@ pub fn register_hkcu(dll_path: &Path) -> io::Result<()> {
     Ok(())
 }
 
+/// Write the `AllFilesystemObjects\shell\DropboxSync` verb (+ its `command`
+/// subkey). Shared shape; the app mirrors it in `windows_shell_menu.rs`.
+fn write_verb(hkcu: &RegKey, icon: Option<&str>) -> io::Result<()> {
+    let (k, _) = hkcu.create_subkey(format!(r"Software\Classes\{TARGET_CLASS}\shell\{VERB}"))?;
+    k.set_value("MUIVerb", &"DropboxSync")?;
+    // Show the verb once for a multi-selection rather than per-item.
+    k.set_value("MultiSelectModel", &"Player")?;
+    if let Some(icon) = icon {
+        k.set_value("Icon", &icon)?;
+    }
+    k.set_value("ExplorerCommandHandler", &CLSID_STR)?;
+
+    // The `command` subkey is required for the verb to surface on Win11; the
+    // parent never executes directly (it has subcommands), so DelegateExecute is
+    // effectively inert but must be present.
+    let (cmd, _) =
+        hkcu.create_subkey(format!(r"Software\Classes\{TARGET_CLASS}\shell\{VERB}\command"))?;
+    cmd.set_value("", &"")?;
+    cmd.set_value("DelegateExecute", &CLSID_STR)?;
+    Ok(())
+}
+
 /// Remove everything `register_hkcu` wrote.
 pub fn unregister_hkcu() -> io::Result<()> {
     let hkcu = RegKey::predef(HKEY_CURRENT_USER);
     let _ = hkcu.delete_subkey_all(format!(r"Software\Classes\CLSID\{CLSID_STR}"));
-    for class in TARGET_CLASSES {
-        let _ = hkcu.delete_subkey_all(format!(r"Software\Classes\{class}\shell\{VERB}"));
-    }
+    let _ = hkcu.delete_subkey_all(format!(r"Software\Classes\{TARGET_CLASS}\shell\{VERB}"));
     let _ = hkcu.delete_subkey_all(SHELLEXT_KEY);
     Ok(())
 }

--- a/apps/desktop/native/windows/shell-menu/src/util.rs
+++ b/apps/desktop/native/windows/shell-menu/src/util.rs
@@ -92,6 +92,13 @@ pub fn current_module_path() -> PathBuf {
     }
 }
 
+/// Icon spec (`"<exe>,0"`) for the menu items — the app's own embedded icon.
+/// `None` if the exe can't be resolved.
+pub fn app_icon_spec() -> Option<String> {
+    let exe = crate::registry::resolve_app_exe(&current_module_path())?;
+    Some(format!("{},0", exe.to_string_lossy()))
+}
+
 /// Launch the app with the shell-action args. The exe is resolved from the value
 /// the app wrote at registration; falls back to an exe sitting next to the DLL.
 ///

--- a/apps/desktop/src-tauri/src/windows_shell_menu.rs
+++ b/apps/desktop/src-tauri/src/windows_shell_menu.rs
@@ -26,8 +26,10 @@ const CLSID_STR: &str = "{FBF4F890-5407-47BF-BE25-F5B2595FA839}";
 const DLL_NAME: &str = "dropbox_sync_shell_menu.dll";
 /// `shell\<verb>` subkey carrying `ExplorerCommandHandler`.
 const VERB: &str = "DropboxSync";
-/// Classes the handler attaches to: all files (incl. `.cloudsc`) and folders.
-const TARGET_CLASSES: [&str; 2] = ["*", "Directory"];
+/// Class the verb attaches to: all files, folders and drives. On Win11 the verb
+/// only surfaces with a `command` subkey + `MultiSelectModel` (a bare
+/// `ExplorerCommandHandler` is culled by the shell).
+const TARGET_CLASS: &str = "AllFilesystemObjects";
 /// App-written config the DLL reads to find the exe to launch.
 const SHELLEXT_KEY: &str = r"Software\DropboxSyncDesktop\ShellExt";
 
@@ -50,8 +52,8 @@ pub fn sync_shell_menu_registration() {
 
     match register_com_handler(&dll, &exe) {
         Ok(()) => {
-            // COM handler now serves `.cloudsc` via `*`; drop the legacy flyout
-            // so those files don't get a duplicate "DropboxSync" menu.
+            // COM handler now serves `.cloudsc` via AllFilesystemObjects; drop the
+            // legacy flyout so those files don't get a duplicate "DropboxSync" menu.
             remove_legacy_flyout();
             tracing::info!(dll = %dll.display(), "registered COM shell context menu (HKCU)");
         }
@@ -75,12 +77,19 @@ fn register_com_handler(dll: &Path, exe: &Path) -> io::Result<()> {
     inproc.set_value("", &dll.to_string_lossy().as_ref())?;
     inproc.set_value("ThreadingModel", &"Apartment")?;
 
-    // 2) Handler hookup on each target class.
-    for class in TARGET_CLASSES {
-        let (k, _) = hkcu.create_subkey(format!(r"Software\Classes\{class}\shell\{VERB}"))?;
-        k.set_value("MUIVerb", &"DropboxSync")?;
-        k.set_value("ExplorerCommandHandler", &CLSID_STR)?;
-    }
+    // 2) The context-menu verb on AllFilesystemObjects, with the app's icon.
+    let icon = format!("{},0", exe.to_string_lossy());
+    let (k, _) = hkcu.create_subkey(format!(r"Software\Classes\{TARGET_CLASS}\shell\{VERB}"))?;
+    k.set_value("MUIVerb", &"DropboxSync")?;
+    k.set_value("MultiSelectModel", &"Player")?;
+    k.set_value("Icon", &icon)?;
+    k.set_value("ExplorerCommandHandler", &CLSID_STR)?;
+    // `command` subkey is required for the verb to appear on Win11; the parent
+    // never executes directly (it has subcommands), so DelegateExecute is inert.
+    let (cmd, _) =
+        hkcu.create_subkey(format!(r"Software\Classes\{TARGET_CLASS}\shell\{VERB}\command"))?;
+    cmd.set_value("", &"")?;
+    cmd.set_value("DelegateExecute", &CLSID_STR)?;
 
     // 3) Record the exe the DLL should launch, and the DLL path.
     let (cfg, _) = hkcu.create_subkey(SHELLEXT_KEY)?;


### PR DESCRIPTION
Follow-up fix to #49 (DBSYNC-33 Slice 2).

## Problem
The `IExplorerCommand` verb registered a bare `ExplorerCommandHandler` on `*` and `Directory`. On **Windows 11 (build 26200)** the shell culls such verbs — the menu never appeared on any file/folder (only the legacy `.cloudsc` flyout showed, which masked the bug during merge). COM activation of the CLSID was fine; the issue was purely the registration surface.

## Fix (verified live in Explorer)
- Register on **`AllFilesystemObjects`** (files, folders and drives) as a single verb.
- Add the required **`command` subkey** with `DelegateExecute` + **`MultiSelectModel`** — a bare `shell\<verb>` with no `command` subkey is dropped by the Win11 shell. (Matches the shape used by known-working IExplorerCommand menus.)
- **Icon**: set the parent verb's `Icon` to `<exe>,0` and implement `GetIcon` on the children, so the parent **and** both submenu items show the app icon.
- App-side `windows_shell_menu.rs` mirrors the exact same keys.

Confirmed on Windows 11: **DropboxSync ▸ Désynchroniser / Synchroniser sur le disque** appears under "Show more options" on items under the sync root, with icons on parent and children.

## Verification
DLL: 6 unit tests + clippy clean. App: clippy clean. Registration + icon validated live on the reporter's machine.