### PR TITLE
feat(cloudsc): collapse a dehydrated folder into a single folder .cloudsc (#DBSYNC-54)

### DIFF
--- a/apps/desktop/src-tauri/src/cloudsc_ops.rs
+++ b/apps/desktop/src-tauri/src/cloudsc_ops.rs
@@ -343,24 +343,12 @@ pub(crate) fn dehydrate_path_internal(state: &AppState, rel: &str) -> AppResult<
 
     let mut created: Vec<String> = Vec::new();
     if abs.is_dir() {
-        // Recurse: dehydrate every synced file under the folder (keep the tree).
-        for entry in WalkDir::new(&abs).into_iter().filter_map(|e| e.ok()) {
-            if !entry.file_type().is_file() {
-                continue;
-            }
-            let file_rel = match entry.path().strip_prefix(&root) {
-                Ok(r) => r.to_string_lossy().replace('\\', "/"),
-                Err(_) => continue,
-            };
-            if file_rel.ends_with(".cloudsc") || should_ignore_local_path(&file_rel) {
-                continue;
-            }
-            match dehydrate_one_file(state, &root, &file_rel) {
-                Ok(true) => created.push(file_rel),
-                Ok(false) => {} // not fully synced — left untouched
-                Err(e) => tracing::warn!(path = %file_rel, error = %e, "dehydrate skipped a file"),
-            }
-        }
+        // Collapse the whole folder into a single `<folder>.cloudsc` — the exact
+        // inverse of folder hydration (which lazily re-expands one level). Rejects
+        // the whole folder (touching nothing) if any file is unsynced; degrades to
+        // per-file placeholders if a file is locked (DBSYNC-54).
+        let mut placeholders = dehydrate_folder_collapse(state, &root, rel)?;
+        created.append(&mut placeholders);
     } else if abs.is_file() {
         if dehydrate_one_file(state, &root, rel)? {
             created.push(rel.to_string());
@@ -382,49 +370,245 @@ pub(crate) fn dehydrate_path_internal(state: &AppState, rel: &str) -> AppResult<
     Ok(count)
 }
 
-/// Dehydrate a single file iff it is fully synced (local + remote present and
-/// content matches). Returns `Ok(true)` if dehydrated, `Ok(false)` if not synced
-/// (skipped, untouched). The ORDER of the three mutations is load-bearing.
-fn dehydrate_one_file(state: &AppState, root: &Path, rel: &str) -> AppResult<bool> {
-    // Must be a tracked file with a known remote copy.
+/// Is `rel` a fully-synced tracked file? i.e. present in the local index, with a
+/// known remote copy, AND the ACTUAL on-disk bytes hash equal to the last-synced
+/// remote hash. The on-disk re-hash is the AUTHORITATIVE freshness check (never
+/// trust the possibly-stale index row): a file edited but not yet re-indexed by
+/// the watcher/scan must not be treated as synced, or dehydrating it would
+/// permanently lose the edit (index-freshness TOCTOU). Returns `Err` only if the
+/// file can't be read.
+fn is_file_fully_synced(state: &AppState, root: &Path, rel: &str) -> AppResult<bool> {
     if state.db.get_local_file(rel)?.is_none() {
         return Ok(false);
     }
     let Some(remote) = state.db.get_remote_file(rel)? else {
         return Ok(false);
     };
-
     let abs = safe_join(root, rel)?;
-    // AUTHORITATIVE freshness check: hash the ACTUAL on-disk bytes now, not the
-    // (possibly stale) index row. A file edited but not yet re-indexed by the
-    // watcher/scan must NOT be dehydrated — deleting it would permanently lose
-    // the edit (index-freshness TOCTOU). Only proceed if disk == last-synced remote.
     let (on_disk_hash, _size, _mtime) = hash_file(&abs)?;
-    if on_disk_hash != remote.content_hash {
-        return Ok(false); // unsynced (or index-stale) local edit — keep the file
-    }
+    Ok(on_disk_hash == remote.content_hash)
+}
 
-    let placeholder_path = {
-        let mut s = abs.clone().into_os_string();
-        s.push(".cloudsc");
-        PathBuf::from(s)
-    };
+/// `<abs>.cloudsc` — the placeholder path for a file/folder at `abs`.
+fn with_cloudsc_suffix(abs: &Path) -> PathBuf {
+    let mut s = abs.to_path_buf().into_os_string();
+    s.push(".cloudsc");
+    PathBuf::from(s)
+}
+
+/// Write the `<abs>.cloudsc` placeholder for a synced file `rel`, recreating its
+/// parent directory if a collapse attempt removed it (degrade path).
+fn write_file_placeholder(root: &Path, rel: &str) -> AppResult<()> {
+    let path = with_cloudsc_suffix(&safe_join(root, rel)?);
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)
+            .map_err(|e| AppError::Io(format!("failed creating dir for placeholder: {e}")))?;
+    }
     let meta = CloudscMeta {
         version: 1,
         tag: "file".to_string(),
         remote_path_display: normalize_dropbox_path(rel)?,
     };
+    write_cloudsc_placeholder_file(&path, &meta)
+}
 
-    // 1) Write the placeholder first — this activates the DBSYNC-45 dehydration
-    //    guard so a concurrent scan/watcher tick can't remote-delete this path.
-    write_cloudsc_placeholder_file(&placeholder_path, &meta)?;
-    // 2) Untrack the file BEFORE deleting it, so the scan/watcher never sees a
-    //    tracked-file deletion to propagate.
+/// Dehydrate a single file iff it is fully synced. Returns `Ok(true)` if
+/// dehydrated, `Ok(false)` if not synced (skipped, untouched). The ORDER of the
+/// mutations is load-bearing. If the OS refuses to delete the file (locked / in
+/// use), the placeholder + untrack are rolled back so the file is left fully
+/// synced (never an orphan placeholder over a still-present file).
+fn dehydrate_one_file(state: &AppState, root: &Path, rel: &str) -> AppResult<bool> {
+    if !is_file_fully_synced(state, root, rel)? {
+        return Ok(false); // unsynced (or index-stale) local edit — keep the file
+    }
+
+    let abs = safe_join(root, rel)?;
+    let row = state
+        .db
+        .get_local_file(rel)?
+        .ok_or_else(|| AppError::Sync(format!("missing index row for {rel}")))?;
+    let placeholder_path = with_cloudsc_suffix(&abs);
+
+    // 1) Write the placeholder + 2) untrack BEFORE deleting, so a concurrent
+    //    scan/watcher tick can't remote-delete this path.
+    write_file_placeholder(root, rel)?;
     state.db.remove_local_file(rel)?;
-    // 3) Delete the local file (frees the disk space).
-    fs::remove_file(&abs)
-        .map_err(|e| AppError::Io(format!("failed removing local file for dehydrate: {e}")))?;
+    // 3) Delete the local file; on failure, restore the fully-synced state.
+    if let Err(e) = fs::remove_file(&abs) {
+        let _ = fs::remove_file(&placeholder_path);
+        state
+            .db
+            .upsert_local_file(rel, &row.hash, row.size_bytes, row.modified_ts)?;
+        return Err(AppError::Io(format!(
+            "failed removing local file for dehydrate: {e}"
+        )));
+    }
     Ok(true)
+}
+
+/// Collapse a fully-synced folder into a single `<folder>.cloudsc` (`tag:
+/// "folder"`) — the inverse of folder hydration (DBSYNC-54). Returns the rel(s)
+/// that became placeholders.
+///
+/// Rejects the WHOLE folder (touching nothing) if it contains any file that isn't
+/// safe to delete: `.cloudsc` placeholders and ignored/ephemeral files are fine,
+/// but any unsynced/untracked user file aborts so no edit is ever lost.
+///
+/// Robustness (per PO): a file the OS won't delete (locked / in use) is left fully
+/// synced — its untrack is rolled back — and the operation degrades to per-file
+/// dehydration of the deletable siblings (folder kept, NO folder placeholder).
+///
+/// The local delete must NEVER propagate to Dropbox: every file is untracked
+/// before it is deleted, and the folder rows are untracked before the dirs are
+/// removed (a leftover subfolder row would make `process_known_folder_deletion`
+/// fire a RECURSIVE remote delete).
+fn dehydrate_folder_collapse(
+    state: &AppState,
+    root: &Path,
+    folder_rel: &str,
+) -> AppResult<Vec<String>> {
+    // Never collapse the sync root itself — that would delete the whole sync folder.
+    if folder_rel.is_empty() {
+        return Err(AppError::Sync(
+            "cannot free up space on the sync root itself".to_string(),
+        ));
+    }
+    let abs = safe_join(root, folder_rel)?;
+
+    // Phase 1 — enumerate the subtree, FAIL CLOSED. Any walk error aborts before we
+    // mutate anything: proceeding on an incomplete enumeration could later delete a
+    // file we never untracked (→ a remote delete) or lose an unsynced file we never
+    // got to reject. Collect the verified files, the existing `.cloudsc` children,
+    // and the directories (to remove empty-only). Any unsynced/untracked user file
+    // rejects the WHOLE folder.
+    let mut files: Vec<(String, crate::storage::db::FileIndexRow)> = Vec::new();
+    let mut cloudsc_children: Vec<PathBuf> = Vec::new();
+    let mut dirs: Vec<(usize, PathBuf)> = Vec::new();
+    for entry in WalkDir::new(&abs) {
+        let entry = entry.map_err(|e| {
+            AppError::Io(format!(
+                "cannot free up space: could not fully read folder '{folder_rel}' ({e}); nothing was changed"
+            ))
+        })?;
+        let ft = entry.file_type();
+        if ft.is_dir() {
+            dirs.push((entry.depth(), entry.path().to_path_buf()));
+            continue;
+        }
+        if !ft.is_file() {
+            continue; // symlink/other — left in place; it blocks the collapse (→ degrade)
+        }
+        let file_rel = match entry.path().strip_prefix(root) {
+            Ok(r) => r.to_string_lossy().replace('\\', "/"),
+            Err(_) => continue,
+        };
+        if file_rel.ends_with(".cloudsc") {
+            cloudsc_children.push(entry.path().to_path_buf());
+            continue;
+        }
+        if should_ignore_local_path(&file_rel) {
+            continue; // ignored/ephemeral — not deleted; blocks the collapse (→ degrade)
+        }
+        if !is_file_fully_synced(state, root, &file_rel)? {
+            return Err(AppError::Sync(format!(
+                "cannot free up space: folder '{folder_rel}' has unsynced changes in '{file_rel}'; sync it first"
+            )));
+        }
+        let row = state
+            .db
+            .get_local_file(&file_rel)?
+            .ok_or_else(|| AppError::Sync(format!("missing index row for {file_rel}")))?;
+        files.push((file_rel, row));
+    }
+
+    // Phase 2 — delete each verified file (untrack-before-delete + rollback on
+    // failure). A file the OS won't delete is re-tracked and left fully synced.
+    let mut deleted: Vec<String> = Vec::new();
+    let mut any_failed = false;
+    for (file_rel, row) in &files {
+        // Re-verify immediately before deleting. Phase 1's full-subtree re-hash can
+        // take a while on a large folder, and a file verified early may have been
+        // edited since — never delete one that no longer matches remote (that edit
+        // isn't uploaded yet). Keep it synced and degrade to per-file for the rest.
+        if !is_file_fully_synced(state, root, file_rel)? {
+            return degrade_to_per_file(root, &deleted);
+        }
+        state.db.remove_local_file(file_rel)?;
+        match fs::remove_file(safe_join(root, file_rel)?) {
+            Ok(()) => deleted.push(file_rel.clone()),
+            Err(e) => {
+                state
+                    .db
+                    .upsert_local_file(file_rel, &row.hash, row.size_bytes, row.modified_ts)?;
+                any_failed = true;
+                tracing::warn!(path = %file_rel, error = %e, "dehydrate: file locked, left synced");
+            }
+        }
+    }
+    // A locked file → don't attempt the collapse; degrade to per-file for the rest.
+    if any_failed {
+        return degrade_to_per_file(root, &deleted);
+    }
+
+    // Remove the already-dehydrated `.cloudsc` children (subsumed by the folder
+    // placeholder). If one won't delete, degrade rather than half-collapse.
+    for p in &cloudsc_children {
+        if fs::remove_file(p).is_err() {
+            return degrade_to_per_file(root, &deleted);
+        }
+    }
+
+    // Untrack the subtree's folder rows BEFORE removing the dirs — a surviving
+    // subfolder row would make `process_known_folder_deletion` fire a RECURSIVE
+    // remote delete.
+    untrack_folders_subtree(state, folder_rel)?;
+
+    // Remove directories deepest-first, EMPTY-ONLY (`remove_dir`, never a blanket
+    // `remove_dir_all`). A dir left non-empty by a file that arrived after Phase 1,
+    // or by an ignored/symlink entry, simply isn't removed — so that content is
+    // preserved instead of being blown away.
+    dirs.sort_by(|a, b| b.0.cmp(&a.0));
+    for (_, dir) in &dirs {
+        let _ = fs::remove_dir(dir); // ignores "directory not empty"
+    }
+
+    if abs.exists() {
+        // The folder couldn't be fully emptied (a concurrent/ignored/symlink entry
+        // remains) → degrade: represent what we freed as per-file placeholders. The
+        // folder stays and is re-tracked by the next sweep.
+        return degrade_to_per_file(root, &deleted);
+    }
+
+    // Fully collapsed → a single folder placeholder.
+    let meta = CloudscMeta {
+        version: 1,
+        tag: "folder".to_string(),
+        remote_path_display: normalize_dropbox_path(folder_rel)?,
+    };
+    write_cloudsc_placeholder_file(&with_cloudsc_suffix(&abs), &meta)?;
+    Ok(vec![folder_rel.to_string()])
+}
+
+/// Write a per-file `.cloudsc` for each already-deleted file (recreating parent
+/// dirs a collapse attempt may have removed). Used when a folder can't be cleanly
+/// collapsed; the freed files are represented individually and the folder is kept.
+fn degrade_to_per_file(root: &Path, deleted: &[String]) -> AppResult<Vec<String>> {
+    for file_rel in deleted {
+        write_file_placeholder(root, file_rel)?;
+    }
+    Ok(deleted.to_vec())
+}
+
+/// Remove every `known_folders` row for `folder_rel` and anything beneath it
+/// (`folder_rel/…`). Keys are `/`-canonical, so a lexical prefix match is exact.
+fn untrack_folders_subtree(state: &AppState, folder_rel: &str) -> AppResult<()> {
+    let prefix = format!("{folder_rel}/");
+    for folder in state.db.list_known_folders()? {
+        if folder == folder_rel || folder.starts_with(&prefix) {
+            state.db.remove_known_folder(&folder)?;
+        }
+    }
+    Ok(())
 }
 
 #[cfg(test)]
@@ -560,6 +744,226 @@ mod tests {
         assert!(
             deletes.is_empty(),
             "dehydration must never enqueue a remote delete, got {deletes:?}"
+        );
+    }
+
+    /// Register a real file under the sync root as a fully-synced tracked file.
+    fn track_synced_file(state: &AppState, sync: &Path, rel: &str, bytes: &[u8]) {
+        let abs = sync.join(rel);
+        std::fs::create_dir_all(abs.parent().unwrap()).unwrap();
+        std::fs::write(&abs, bytes).unwrap();
+        let (h, _, _) = hash_file(&abs).unwrap();
+        state.db.upsert_local_file(rel, &h, bytes.len() as i64, 0).unwrap();
+        state.db.upsert_remote_file(rel, &h, "rev", 0).unwrap();
+    }
+
+    #[test]
+    fn dehydrate_folder_collapses_to_single_placeholder_and_frees_tree() {
+        let tmp = tempfile::tempdir().unwrap();
+        let sync = tmp.path().join("synced");
+        let state = build_state(&sync);
+        track_synced_file(&state, &sync, "dir/a.txt", b"aaa");
+        track_synced_file(&state, &sync, "dir/sub/b.txt", b"bbb");
+        state.db.upsert_known_folder("dir").unwrap();
+        state.db.upsert_known_folder("dir/sub").unwrap();
+
+        let n = dehydrate_path_internal(&state, "dir").unwrap();
+        assert_eq!(n, 1);
+        assert!(!sync.join("dir").exists(), "the whole local subtree is freed");
+        assert!(
+            sync.join("dir.cloudsc").exists(),
+            "one folder-level placeholder written"
+        );
+        let meta = read_cloudsc_placeholder_file(&sync.join("dir.cloudsc")).unwrap();
+        assert_eq!(meta.tag, "folder", "must be a folder placeholder");
+        // Every descendant row untracked (files + subfolders).
+        assert!(state.db.get_local_file("dir/a.txt").unwrap().is_none());
+        assert!(state.db.get_local_file("dir/sub/b.txt").unwrap().is_none());
+        assert!(
+            state.db.list_known_folders().unwrap().is_empty(),
+            "known folders untracked"
+        );
+    }
+
+    #[test]
+    fn dehydrate_folder_rejects_when_a_child_is_unsynced() {
+        let tmp = tempfile::tempdir().unwrap();
+        let sync = tmp.path().join("synced");
+        let state = build_state(&sync);
+        track_synced_file(&state, &sync, "dir/ok.txt", b"ok");
+        // An unsynced sibling (on-disk bytes hash != remote hash).
+        std::fs::write(sync.join("dir/edited.txt"), b"local only").unwrap();
+        state.db.upsert_local_file("dir/edited.txt", "LOCAL", 10, 0).unwrap();
+        state.db.upsert_remote_file("dir/edited.txt", "REMOTE", "rev", 0).unwrap();
+
+        let err = dehydrate_path_internal(&state, "dir").unwrap_err();
+        assert!(format!("{err}").contains("unsynced"), "got: {err}");
+        // Nothing touched — reject happens before any mutation.
+        assert!(sync.join("dir/ok.txt").exists());
+        assert!(sync.join("dir/edited.txt").exists());
+        assert!(!sync.join("dir.cloudsc").exists());
+        assert!(state.db.get_local_file("dir/ok.txt").unwrap().is_some());
+    }
+
+    #[test]
+    fn dehydrate_folder_does_not_trigger_remote_delete() {
+        let tmp = tempfile::tempdir().unwrap();
+        let sync = tmp.path().join("synced");
+        let state = build_state(&sync);
+        track_synced_file(&state, &sync, "dir/a.txt", b"aaa");
+        track_synced_file(&state, &sync, "dir/sub/b.txt", b"bbb");
+        state.db.upsert_known_folder("dir").unwrap();
+        state.db.upsert_known_folder("dir/sub").unwrap();
+
+        dehydrate_path_internal(&state, "dir").unwrap();
+
+        // Re-evaluate every now-absent path — files AND subfolders. None may enqueue
+        // a remote delete (a leftover subfolder row would cause a RECURSIVE delete).
+        crate::sync_pipeline::process_changed_paths(
+            &state,
+            &[
+                "dir".to_string(),
+                "dir/sub".to_string(),
+                "dir/a.txt".to_string(),
+                "dir/sub/b.txt".to_string(),
+            ],
+        )
+        .unwrap();
+        let deletes: Vec<String> = state
+            .db
+            .list_recent_jobs(50)
+            .unwrap()
+            .into_iter()
+            .filter(|j| j.job_type == "delete")
+            .filter_map(|j| j.target_path)
+            .collect();
+        assert!(
+            deletes.is_empty(),
+            "folder dehydration must never enqueue a remote delete, got {deletes:?}"
+        );
+    }
+
+    #[test]
+    fn dehydrate_refuses_sync_root() {
+        let tmp = tempfile::tempdir().unwrap();
+        let sync = tmp.path().join("synced");
+        let state = build_state(&sync);
+        std::fs::write(sync.join("keep.txt"), b"x").unwrap();
+
+        let err = dehydrate_path_internal(&state, "").unwrap_err();
+        assert!(format!("{err}").contains("sync root"), "got: {err}");
+        assert!(sync.join("keep.txt").exists(), "root contents untouched");
+    }
+
+    /// When a file can't be deleted (locked / in use), it must stay fully synced
+    /// (real, tracked) and the folder degrades to per-file dehydration of the rest
+    /// — never a partial collapse. Simulated on Windows by holding an open handle
+    /// that denies delete-sharing, so `fs::remove_file` fails with a sharing
+    /// violation (`remove_file` clears the read-only attribute, so that wouldn't).
+    #[cfg(windows)]
+    #[test]
+    fn dehydrate_folder_locked_file_stays_synced_and_siblings_go_per_file() {
+        use std::os::windows::fs::OpenOptionsExt;
+        let tmp = tempfile::tempdir().unwrap();
+        let sync = tmp.path().join("synced");
+        let state = build_state(&sync);
+        track_synced_file(&state, &sync, "dir/free.txt", b"free");
+        track_synced_file(&state, &sync, "dir/locked.txt", b"lock");
+        state.db.upsert_known_folder("dir").unwrap();
+
+        // FILE_SHARE_READ only (no delete-sharing) → deletion fails while held; a
+        // reader (the freshness re-hash) is still allowed.
+        let locked = sync.join("dir/locked.txt");
+        let handle = std::fs::OpenOptions::new()
+            .read(true)
+            .share_mode(0x1)
+            .open(&locked)
+            .unwrap();
+
+        let n = dehydrate_path_internal(&state, "dir").unwrap();
+
+        // Degraded to per-file: no folder collapse, folder kept.
+        assert!(
+            !sync.join("dir.cloudsc").exists(),
+            "must not collapse to a folder placeholder when a file is locked"
+        );
+        assert!(sync.join("dir").is_dir(), "folder is kept");
+        // The deletable sibling became a placeholder.
+        assert_eq!(n, 1, "one deletable sibling dehydrated");
+        assert!(!sync.join("dir/free.txt").exists());
+        assert!(sync.join("dir/free.txt.cloudsc").exists());
+        // The locked file stays REAL and still tracked (synced) — nothing lost.
+        assert!(locked.exists(), "locked file is kept");
+        assert!(
+            state.db.get_local_file("dir/locked.txt").unwrap().is_some(),
+            "locked file stays tracked/synced after rollback"
+        );
+
+        drop(handle); // release so the tempdir can be cleaned up
+    }
+
+    #[test]
+    fn dehydrate_folder_with_ignored_file_degrades_to_per_file() {
+        let tmp = tempfile::tempdir().unwrap();
+        let sync = tmp.path().join("synced");
+        let state = build_state(&sync);
+        track_synced_file(&state, &sync, "dir/a.txt", b"aaa");
+        state.db.upsert_known_folder("dir").unwrap();
+        // An ignored file keeps the folder non-empty → no collapse, but no data loss.
+        std::fs::write(sync.join("dir/.DS_Store"), b"junk").unwrap();
+
+        let n = dehydrate_path_internal(&state, "dir").unwrap();
+
+        assert_eq!(n, 1);
+        assert!(
+            !sync.join("dir.cloudsc").exists(),
+            "must not collapse while an ignored file remains"
+        );
+        assert!(sync.join("dir").is_dir(), "folder kept");
+        assert!(sync.join("dir/.DS_Store").exists(), "ignored file preserved");
+        assert!(!sync.join("dir/a.txt").exists());
+        assert!(sync.join("dir/a.txt.cloudsc").exists(), "freed file → per-file placeholder");
+    }
+
+    #[test]
+    fn dehydrate_folder_collapses_over_existing_cloudsc_children() {
+        let tmp = tempfile::tempdir().unwrap();
+        let sync = tmp.path().join("synced");
+        let state = build_state(&sync);
+        track_synced_file(&state, &sync, "dir/a.txt", b"aaa");
+        state.db.upsert_known_folder("dir").unwrap();
+        // A previously-dehydrated child placeholder must not block the collapse.
+        std::fs::write(sync.join("dir/old.txt.cloudsc"), b"{}").unwrap();
+
+        let n = dehydrate_path_internal(&state, "dir").unwrap();
+
+        assert_eq!(n, 1);
+        assert!(!sync.join("dir").exists(), "subtree freed incl. the .cloudsc child");
+        assert!(sync.join("dir.cloudsc").exists(), "collapsed to one folder placeholder");
+        let meta = read_cloudsc_placeholder_file(&sync.join("dir.cloudsc")).unwrap();
+        assert_eq!(meta.tag, "folder");
+    }
+
+    #[test]
+    fn dehydrate_folder_leaves_sibling_folders_tracked() {
+        let tmp = tempfile::tempdir().unwrap();
+        let sync = tmp.path().join("synced");
+        let state = build_state(&sync);
+        track_synced_file(&state, &sync, "dir/a.txt", b"aaa");
+        state.db.upsert_known_folder("dir").unwrap();
+        // Siblings whose known-folder rows share a name PREFIX with "dir" must NOT
+        // be untracked (a `starts_with` bug would nuke them → recursive remote delete).
+        state.db.upsert_known_folder("dir2").unwrap();
+        state.db.upsert_known_folder("dirtest/sub").unwrap();
+
+        dehydrate_path_internal(&state, "dir").unwrap();
+
+        let mut folders = state.db.list_known_folders().unwrap();
+        folders.sort();
+        assert_eq!(
+            folders,
+            vec!["dir2".to_string(), "dirtest/sub".to_string()],
+            "only 'dir' and its descendants may be untracked"
         );
     }
 }


### PR DESCRIPTION
Unsyncing a **folder** now collapses it into one `<folder>.cloudsc` (tag "folder") — the exact inverse of folder hydration (which lazily re-expands one level) — instead of writing a `.cloudsc` per child and keeping the tree. Follow-up to DBSYNC-33.

### Behaviour
- Fully-synced folder → single `<folder>.cloudsc`, whole local subtree freed; re-hydrate recreates it (lazy, one level).
- Any unsynced/untracked user file in the folder → **whole folder rejected**, nothing touched (PO decision).
- A **locked file** (OS won't delete it) → rolled back and left fully synced; the folder **degrades to per-file** dehydration of the deletable siblings (no folder placeholder).
- Refuses to dehydrate the sync root itself.

### Safety (reviewed twice by the CTO agent; deletes must never propagate to Dropbox)
- **Fail-closed Phase 1**: any `WalkDir` error aborts before *any* mutation — never proceed on an incomplete enumeration (which could delete an un-untracked file → remote delete).
- **Precise deletion, never `remove_dir_all`**: only Phase-1-verified files are deleted (untrack-before-delete), each **re-verified immediately before deletion** so an edit made during the scan is never lost. Directories are removed **empty-only** (`remove_dir`, deepest-first), so a file that arrives mid-operation keeps its dir non-empty and is preserved.
- Folder rows untracked **before** dir removal — a leftover subfolder row would make `process_known_folder_deletion` fire a **recursive** remote delete.
- Verified: no path physically deletes a file/subfolder while its index/known-folders row still exists, in every branch (collapse, locked-degrade, cloudsc-removal-degrade, leftover-degrade).

### CTO review trail
Round 1 caught a BLOCKER (walk `.ok()` swallowed errors → possible remote delete) and a data-loss WARNING (blanket `remove_dir_all`). Round 2 confirmed both resolved and caught a widened verify→delete TOCTOU (edit-during-scan) — now fixed with the per-file re-verify. Remaining items are NITs.

### Tests
8 new (collapse, unsynced-reject, no-remote-delete incl. subfolders, sync-root guard, Windows locked-file degrade, ignored-file degrade, collapse-over-`.cloudsc`-child, sibling-folder survival). Full suite **112 pass**, clippy `-D warnings` clean.