### PR TITLE
fix(sync): stop editor temp files from causing phantom sync errors (#DBSYNC-55)

### DIFF
--- a/apps/desktop/src-tauri/src/dropbox_transfer.rs
+++ b/apps/desktop/src-tauri/src/dropbox_transfer.rs
@@ -15,8 +15,8 @@ use crate::models::{
     UploadProgressEvent, UploadSessionStartResponse,
 };
 use crate::path_util::{
-    create_conflicted_copy, hash_file, is_path_allowed, normalize_dropbox_path, parse_prefix_csv,
-    relpath_under, safe_join,
+    create_conflicted_copy, hash_file, is_ignored_local_path, is_path_allowed,
+    normalize_dropbox_path, parse_prefix_csv, relpath_under, safe_join,
 };
 use crate::state::AppState;
 use crate::storage::db::FileIndexRow;
@@ -801,16 +801,45 @@ pub(crate) fn upload_local_file_internal(
         return Ok(());
     }
 
-    let token = get_access_token(state)?;
     let folder = state
         .db
         .get_sync_folder()?
         .ok_or_else(|| AppError::Sync("sync folder not configured".to_string()))?;
 
     let local_path = safe_join(Path::new(&folder), relative)?;
-    if !local_path.exists() {
-        return Err(AppError::Sync(format!("local file missing for upload: {relative}")));
+    // Distinguish a genuine absence (NotFound) from a transient stat failure
+    // (permission, Windows sharing-violation, an editor's atomic save mid-rename).
+    // Only a confirmed NotFound is treated as "gone"; anything else is returned as
+    // an error so the job retries — we must NEVER conclude "deleted" from a racy
+    // check (DBSYNC-55; mirrors `sync_pipeline::classify_path`).
+    match std::fs::symlink_metadata(&local_path) {
+        Ok(_) => {} // present — fall through to the upload
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            // The source vanished before we could upload it — an editor temp file
+            // (`~$doc.docx`) deleted on close, or a file removed right after it was
+            // created. Failing the job surfaces as a stuck "Error" the user can't
+            // clear, so no-op instead. Forget the row only when there is nothing on
+            // Dropbox to reconcile (a temp/ignored path, or a file never uploaded).
+            // If it HAD a remote copy, leave the index row and DO NOT enqueue a
+            // delete here: the guarded deletion-detection path (classify_path +
+            // re-stat) decides whether this was a real deletion to propagate — an
+            // unguarded delete from here could wrongly wipe a live remote file
+            // during an atomic save.
+            tracing::info!(file_path = %relative, "upload cancelled: local file no longer exists");
+            let had_remote = state.db.get_remote_file(relative)?.is_some();
+            if !had_remote || is_ignored_local_path(relative) {
+                state.db.remove_local_file(relative)?;
+            }
+            return Ok(());
+        }
+        Err(e) => {
+            return Err(AppError::Io(format!(
+                "failed to stat local file for upload: {e}"
+            )));
+        }
     }
+
+    let token = get_access_token(state)?;
 
     // Skip the upload when Dropbox already holds identical content. This avoids
     // re-uploading files that originated from Dropbox (e.g. after a sync-state

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -293,6 +293,16 @@ pub fn run() {
                     Err(e) => tracing::error!(error = %e, "failed to recover running jobs"),
                 }
 
+                // Clear phantom "Error" state from editor-temp files a previous
+                // build tracked/failed (DBSYNC-55).
+                match crate::sync_pipeline::cleanup_stale_upload_state(state.inner()) {
+                    Ok(count) if count > 0 => {
+                        tracing::info!(count, "cleaned stale editor-temp sync state on startup");
+                    }
+                    Ok(_) => {}
+                    Err(e) => tracing::error!(error = %e, "failed to clean stale upload state"),
+                }
+
                 crate::overlay_state::refresh_overlay_state_internal(state.inner());
 
                 if crate::commands::should_show_main_window_for_onboarding(state.inner()) {

--- a/apps/desktop/src-tauri/src/path_util.rs
+++ b/apps/desktop/src-tauri/src/path_util.rs
@@ -32,6 +32,15 @@ pub(crate) fn is_editor_temp_path(relative: &str) -> bool {
         || (name.starts_with(".~lock.") && name.ends_with('#')) // LibreOffice lock
 }
 
+/// Single "never sync this local path" predicate for the whole pipeline: OS junk
+/// ([`should_ignore_local_path`]) plus editor/download temp & lock files
+/// ([`is_editor_temp_path`]). Editor temps must be excluded from the full scan too
+/// — not just the fs watcher — or an `~$doc.docx` the scan sees gets enqueued and
+/// tracked, then fails the upload when the editor deletes it (DBSYNC-55).
+pub(crate) fn is_ignored_local_path(relative: &str) -> bool {
+    should_ignore_local_path(relative) || is_editor_temp_path(relative)
+}
+
 pub(crate) fn relpath_under(sync_folder: &Path, absolute: &Path) -> AppResult<String> {
     Ok(absolute
         .strip_prefix(sync_folder)
@@ -257,9 +266,34 @@ mod tests {
     use std::path::Path;
 
     use super::{
-        backoff_seconds, hash_file, normalize_dropbox_path, safe_join, validate_relative,
-        DROPBOX_BLOCK_SIZE,
+        backoff_seconds, hash_file, is_ignored_local_path, normalize_dropbox_path, safe_join,
+        validate_relative, DROPBOX_BLOCK_SIZE,
     };
+
+    #[test]
+    fn ignored_local_path_covers_os_junk_and_editor_temps() {
+        // Editor/office temp & lock files (the DBSYNC-55 fix — must be excluded
+        // from the full scan, not just the fs watcher).
+        for p in [
+            "~$report.docx",
+            "sub/~$sheet.xlsx",
+            "doc.txt.tmp",
+            "~WRD0001.tmp",
+            "a.swp",
+            "video.crdownload",
+            "dl.part",
+            "notes.txt~",
+        ] {
+            assert!(is_ignored_local_path(p), "should ignore {p:?}");
+        }
+        // OS junk still ignored.
+        assert!(is_ignored_local_path(".DS_Store"));
+        assert!(is_ignored_local_path("dir/._resource"));
+        // Real user files are NOT ignored.
+        for p in ["report.docx", "dir/photo.jpg", "notes.txt"] {
+            assert!(!is_ignored_local_path(p), "should not ignore {p:?}");
+        }
+    }
 
     // ---------------------------------------------------------------------------
     // Helper: compute the Dropbox content_hash for an in-memory byte slice so

--- a/apps/desktop/src-tauri/src/sync_pipeline.rs
+++ b/apps/desktop/src-tauri/src/sync_pipeline.rs
@@ -12,8 +12,8 @@ use crate::dropbox_transfer::{
 use crate::error::{AppError, AppResult};
 use crate::models::SyncTickResult;
 use crate::path_util::{
-    backoff_seconds, create_conflicted_copy, hash_file, normalize_dropbox_path,
-    should_ignore_local_path,
+    backoff_seconds, create_conflicted_copy, hash_file, is_editor_temp_path, is_ignored_local_path,
+    normalize_dropbox_path, safe_join,
 };
 use crate::remote_index::refresh_remote_index_and_enqueue_downloads_internal;
 use crate::overlay_state;
@@ -209,7 +209,7 @@ pub(crate) fn process_changed_paths(state: &AppState, paths: &[String]) -> AppRe
     for p in paths {
         let rel = p.replace('\\', "/");
         let rel = rel.trim_start_matches('/').to_string();
-        if rel.is_empty() || rel.ends_with(".cloudsc") || should_ignore_local_path(&rel) {
+        if rel.is_empty() || rel.ends_with(".cloudsc") || is_ignored_local_path(&rel) {
             continue;
         }
         if seen.insert(rel.clone()) {
@@ -254,7 +254,7 @@ pub(crate) fn process_changed_paths(state: &AppState, paths: &[String]) -> AppRe
                         Ok(r) => r.to_string_lossy().replace('\\', "/"),
                         Err(_) => continue,
                     };
-                    if child_rel.ends_with(".cloudsc") || should_ignore_local_path(&child_rel) {
+                    if child_rel.ends_with(".cloudsc") || is_ignored_local_path(&child_rel) {
                         continue;
                     }
                     enqueued += process_local_file_change(
@@ -313,7 +313,7 @@ fn enqueue_targeted_deletions(
         }
         if prev.relative_path.starts_with(&prefix)
             && !prev.relative_path.ends_with(".cloudsc")
-            && !should_ignore_local_path(&prev.relative_path)
+            && !is_ignored_local_path(&prev.relative_path)
         {
             enqueued += process_local_file_deletion(state, tracked_root, &prev.relative_path)?;
         }
@@ -391,7 +391,7 @@ pub(crate) fn scan_local_changes_internal(state: &AppState) -> AppResult<usize> 
         if relative.ends_with(".cloudsc") {
             continue;
         }
-        if should_ignore_local_path(&relative) {
+        if is_ignored_local_path(&relative) {
             continue;
         }
 
@@ -413,7 +413,7 @@ pub(crate) fn scan_local_changes_internal(state: &AppState) -> AppResult<usize> 
             if prev.relative_path.ends_with(".cloudsc") {
                 continue;
             }
-            if should_ignore_local_path(&prev.relative_path) {
+            if is_ignored_local_path(&prev.relative_path) {
                 continue;
             }
             if !seen_paths.contains(&prev.relative_path) {
@@ -452,7 +452,7 @@ pub(crate) fn scan_local_changes_internal(state: &AppState) -> AppResult<usize> 
         if relative.is_empty() {
             continue; // skip the sync root itself
         }
-        if should_ignore_local_path(&relative) {
+        if is_ignored_local_path(&relative) {
             continue;
         }
 
@@ -465,6 +465,13 @@ pub(crate) fn scan_local_changes_internal(state: &AppState) -> AppResult<usize> 
     // of deletions.
     if !walk_had_error {
         for rel in state.db.list_known_folders()? {
+            // Never propagate a "deletion" for an ignored/temp-named folder: it is
+            // skipped by the walk above (so never in `seen_dirs`), and a stale row
+            // from an older build would otherwise trigger a RECURSIVE remote delete
+            // of a folder that still exists (DBSYNC-55).
+            if is_ignored_local_path(&rel) {
+                continue;
+            }
             if !seen_dirs.contains(&rel) {
                 enqueued_jobs += process_known_folder_deletion(state, &tracked_root, &rel)?;
             }
@@ -620,6 +627,61 @@ pub(crate) fn process_sync_queue_internal(state: &AppState) -> AppResult<bool> {
     Ok(true)
 }
 
+/// Startup cleanup (DBSYNC-55): forget editor-temp files a previous build tracked,
+/// and resolve failed `upload` jobs whose source is a temp file or no longer
+/// exists, so a phantom "Error" clears without a manual reset. Returns the number
+/// of rows/jobs cleaned.
+pub(crate) fn cleanup_stale_upload_state(state: &AppState) -> AppResult<usize> {
+    let mut cleaned = 0usize;
+
+    // 1) Drop tracked editor-temp index rows + known-folder rows — they should
+    //    never have been tracked (and a stale temp-named folder row could trigger a
+    //    recursive remote delete).
+    for row in state.db.list_local_files()? {
+        if is_ignored_local_path(&row.relative_path) {
+            state.db.remove_local_file(&row.relative_path)?;
+            cleaned += 1;
+        }
+    }
+    for folder_rel in state.db.list_known_folders()? {
+        if is_ignored_local_path(&folder_rel) {
+            state.db.remove_known_folder(&folder_rel)?;
+            cleaned += 1;
+        }
+    }
+
+    // 2) Resolve failed upload jobs whose source is a temp file or is gone on disk
+    //    (a genuine failure with an existing, non-temp source is left alone to retry).
+    //    Only trust "missing" when the sync root is actually mounted — otherwise an
+    //    unmounted removable/network drive would look like "everything deleted" and
+    //    we'd wrongly resolve real failures (whose optimistic index rows would then
+    //    never re-detect the un-uploaded edit).
+    let folder = state.db.get_sync_folder()?;
+    let root_mounted = folder
+        .as_deref()
+        .map(|f| Path::new(f).is_dir())
+        .unwrap_or(false);
+    for job in state.db.list_recent_jobs(10_000)? {
+        if job.job_type != "upload" || job.status != "failed" {
+            continue;
+        }
+        let Some(src) = job.source_path.as_deref() else {
+            continue;
+        };
+        let missing = root_mounted
+            && folder
+                .as_deref()
+                .and_then(|f| safe_join(Path::new(f), src).ok())
+                .map(|p| !p.exists())
+                .unwrap_or(false);
+        if is_editor_temp_path(src) || missing {
+            state.db.mark_job_completed(job.id)?;
+            cleaned += 1;
+        }
+    }
+    Ok(cleaned)
+}
+
 pub(crate) fn run_sync_tick_internal(state: &AppState) -> AppResult<SyncTickResult> {
     let enqueued_jobs = scan_local_changes_internal(state)?;
     if enqueued_jobs > 0 {
@@ -672,7 +734,9 @@ mod tests {
     use chrono::{Duration, Utc};
     use tempfile::tempdir;
 
-    use super::{process_changed_paths, run_sync_tick_internal, SYNC_BATCH_CAP};
+    use super::{
+        cleanup_stale_upload_state, process_changed_paths, run_sync_tick_internal, SYNC_BATCH_CAP,
+    };
     use crate::state::AppState;
     use crate::storage::db::Db;
     use crate::storage::secure_store::SecureStore;
@@ -922,5 +986,130 @@ mod tests {
         let n = process_changed_paths(&state, &["a.txt".to_string()]).expect("process");
         assert_eq!(n, 0, "a missing root must never be read as a mass deletion");
         assert!(state.db.list_recent_jobs(50).unwrap().is_empty());
+    }
+
+    // ---- DBSYNC-55: editor-temp / vanished-source handling ----
+
+    fn delete_jobs(state: &AppState) -> Vec<String> {
+        state
+            .db
+            .list_recent_jobs(50)
+            .unwrap()
+            .into_iter()
+            .filter(|j| j.job_type == "delete")
+            .filter_map(|j| j.target_path)
+            .collect()
+    }
+
+    #[test]
+    fn upload_of_a_vanished_source_is_a_noop_not_a_failure() {
+        let tmp = tempdir().expect("tempdir");
+        let state = build_state(tmp.path());
+        // Tracked but never on remote (e.g. an editor temp) and gone from disk.
+        state.db.upsert_local_file("~$doc.docx", "h", 1, 0).unwrap();
+
+        // No token / network needed: the missing-file branch returns before auth.
+        crate::dropbox_transfer::upload_local_file_internal(&state, "~$doc.docx", 1)
+            .expect("vanished upload must not error");
+
+        assert!(
+            state.db.get_local_file("~$doc.docx").unwrap().is_none(),
+            "the vanished file is forgotten"
+        );
+        assert!(
+            delete_jobs(&state).is_empty(),
+            "nothing on remote → no delete propagated"
+        );
+    }
+
+    #[test]
+    fn upload_of_a_vanished_synced_file_defers_to_the_guarded_deletion_path() {
+        let tmp = tempdir().expect("tempdir");
+        let state = build_state(tmp.path());
+        // A real synced file (present on remote) whose upload source is absent.
+        state.db.upsert_local_file("report.docx", "h2", 1, 0).unwrap();
+        state.db.upsert_remote_file("report.docx", "h1", "rev", 0).unwrap();
+
+        crate::dropbox_transfer::upload_local_file_internal(&state, "report.docx", 1)
+            .expect("must not error");
+
+        // MUST NOT enqueue a remote delete from this racy check (that could wipe a
+        // live file during an atomic save). The index row is left so the guarded
+        // deletion-detection path (classify_path NotFound-only + re-stat) decides.
+        assert!(
+            delete_jobs(&state).is_empty(),
+            "no remote delete may be enqueued from the upload path"
+        );
+        assert!(
+            state.db.get_local_file("report.docx").unwrap().is_some(),
+            "the index row is kept for the guarded deletion path"
+        );
+    }
+
+    #[test]
+    fn scan_never_recursively_deletes_a_temp_named_folder() {
+        let tmp = tempdir().expect("tempdir");
+        let state = build_state(tmp.path());
+        // A stale known-folder row from an older build whose leaf matches a temp
+        // pattern, no longer present in the (empty) sync dir → must NOT be deleted.
+        state.db.upsert_known_folder("backup.tmp").unwrap();
+
+        run_sync_tick_internal(&state).expect("tick");
+
+        let deletes: Vec<String> = state
+            .db
+            .list_recent_jobs(50)
+            .unwrap()
+            .into_iter()
+            .filter(|j| j.job_type == "delete")
+            .filter_map(|j| j.target_path)
+            .collect();
+        assert!(
+            deletes.is_empty(),
+            "a temp-named folder must never trigger a recursive remote delete, got {deletes:?}"
+        );
+    }
+
+    #[test]
+    fn cleanup_clears_editor_temp_rows_and_phantom_failed_jobs() {
+        let tmp = tempdir().expect("tempdir");
+        let state = build_state(tmp.path());
+        let sync = tmp.path().join("synced");
+
+        // A tracked editor-temp row that should never have existed.
+        state.db.upsert_local_file("~$doc.docx", "h", 1, 0).unwrap();
+        // Three failed upload jobs: a temp file, a missing regular file, and a real
+        // one that still exists on disk (a genuine failure — must be left alone).
+        std::fs::write(sync.join("real.txt"), b"x").unwrap();
+        for src in ["~$doc.docx", "gone.txt", "real.txt"] {
+            state.db.enqueue_job("upload", Some(src), Some(src)).unwrap();
+            let id = state
+                .db
+                .list_recent_jobs(50)
+                .unwrap()
+                .into_iter()
+                .find(|j| j.source_path.as_deref() == Some(src))
+                .unwrap()
+                .id;
+            state.db.mark_job_failed(id, 5, Some("boom")).unwrap();
+        }
+
+        let cleaned = cleanup_stale_upload_state(&state).expect("cleanup");
+        assert_eq!(cleaned, 3, "temp row + temp job + missing-source job");
+
+        assert!(state.db.get_local_file("~$doc.docx").unwrap().is_none());
+        let failed: Vec<String> = state
+            .db
+            .list_recent_jobs(50)
+            .unwrap()
+            .into_iter()
+            .filter(|j| j.status == "failed")
+            .filter_map(|j| j.source_path)
+            .collect();
+        assert_eq!(
+            failed,
+            vec!["real.txt".to_string()],
+            "a genuine failure with an existing, non-temp source is kept"
+        );
     }
 }


### PR DESCRIPTION
Opening a Word doc in the sync folder creates an owner/temp file (`~$name.docx`, `~WRD####.tmp`). The full scan enqueued an upload for it **and** tracked it; Word deleted it on close; the upload ran, the file was gone → job `failed` → tray/window stuck on **Error** with a "retry errored" button that couldn't clear.

### Fix (A + B + C)
- **A** — one ignore predicate `is_ignored_local_path = should_ignore_local_path || is_editor_temp_path`, used at every enqueue/track/delete site in `sync_pipeline.rs`. The fs watcher already ignored editor temps; the **full scan** didn't. Now they're never enqueued or tracked.
- **B** — a vanished upload source is a no-op, not a failure (`dropbox_transfer.rs`). Acts **only on a confirmed `NotFound`** (a transient stat error → `Err` → retry) and **never enqueues a remote delete** from that racy check — an atomic save's unlink→rename window must not wipe a live Dropbox file. Forgets the index row only when nothing is on remote to reconcile; for a synced file it leaves the row and defers deletion to the already-guarded deletion-detection path (`classify_path` NotFound-only + re-stat).
- **C** — startup cleanup (`cleanup_stale_upload_state`, wired in setup) drops tracked editor-temp index + `known_folders` rows and resolves phantom failed upload jobs (temp or missing source), **gated on the sync root being mounted** so a genuine failure on an unmounted drive is never dropped. Clears the user's already-stuck Error on next launch.

Also filters the folder-deletion loop so a stale temp-named `known_folders` row from an older build can't trigger a **recursive** remote delete.

### CTO review trail
Round 1 caught two data-safety BLOCKERs (B could enqueue a remote delete of a live file during an atomic save; the folder-deletion loop wasn't filtered → recursive delete of a temp-named folder) and a WARNING (cleanup could drop real failures on an unmounted drive). Round 2 confirmed all three resolved with no remaining blockers. One narrow non-blocking WARNING (silent lost edit if a synced file vanishes-and-returns byte-identical exactly during the upload drain) is tracked as a follow-up.

### Tests
7 new (ignore predicate; vanished-source no-op; vanished-synced defers to deletion path; temp-named folder never recursively deleted; cleanup clears temp rows + phantom failed jobs, keeps genuine failures). Full suite **117 pass**, clippy `-D warnings` clean.