### PR TITLE
feat(sharing): copy a Dropbox share link from the context menu (#DBSYNC-52)

### DIFF
--- a/apps/desktop/native/windows/shell-menu/src/command.rs
+++ b/apps/desktop/native/windows/shell-menu/src/command.rs
@@ -22,6 +22,8 @@ pub enum CommandKind {
     FreeUpSpace,
     /// "Synchroniser sur le disque" — hydrate a `.cloudsc` placeholder.
     Hydrate,
+    /// "Copier le lien Dropbox" — copy a shared link for any synced item.
+    CopyLink,
 }
 
 #[implement(IExplorerCommand)]
@@ -51,6 +53,7 @@ impl IExplorerCommand_Impl for DropboxSyncCommand_Impl {
                 CommandKind::Parent => "DropboxSync", // brand — untranslated
                 CommandKind::FreeUpSpace => labels::label_free_up_space(&lang),
                 CommandKind::Hydrate => labels::label_sync_to_disk(&lang),
+                CommandKind::CopyLink => labels::label_copy_link(&lang),
             };
             util::alloc_wide(title)
         })
@@ -78,8 +81,13 @@ impl IExplorerCommand_Impl for DropboxSyncCommand_Impl {
         util::guard(Ok(ECS_HIDDEN.0 as u32), move || {
             let paths = util::collect_paths(items.as_ref());
             let targets = scope::classify(&paths);
+            let under_root = targets.any_free_up_space || targets.any_hydrate;
             let visible = match kind {
-                CommandKind::Parent => targets.any_free_up_space || targets.any_hydrate,
+                CommandKind::Parent => under_root,
+                // Copy-link targets the single-value clipboard, so only offer it for
+                // a single selected item (a multi-select would race N links onto the
+                // clipboard and fire N notifications).
+                CommandKind::CopyLink => under_root && paths.len() == 1,
                 CommandKind::FreeUpSpace => targets.any_free_up_space,
                 CommandKind::Hydrate => targets.any_hydrate,
             };
@@ -94,17 +102,21 @@ impl IExplorerCommand_Impl for DropboxSyncCommand_Impl {
     fn Invoke(&self, items: Ref<'_, IShellItemArray>, _bind_ctx: Ref<'_, IBindCtx>) -> Result<()> {
         let kind = self.kind;
         util::guard(Ok(()), move || {
-            let (action, want): (&str, Target) = match kind {
-                CommandKind::FreeUpSpace => ("free_up_space", Target::FreeUpSpace),
-                CommandKind::Hydrate => ("hydrate", Target::Hydrate),
-                CommandKind::Parent => return Ok(()),
-            };
-            // Only act on the items that actually qualify for this child, so a
-            // mixed selection never dehydrates a `.cloudsc` or hydrates a plain file.
+            // Launch the app once per qualifying item. A mixed selection never
+            // dehydrates a `.cloudsc` or hydrates a plain file; copy-link acts on
+            // any item under the sync root (file/folder, hydrated or `.cloudsc`).
             for path in util::collect_paths(items.as_ref()) {
-                if scope::target_for(&path) == want {
-                    util::launch_app(action, &path);
+                let target = scope::target_for(&path);
+                if target == Target::None {
+                    continue;
                 }
+                let action = match kind {
+                    CommandKind::CopyLink => "copy_link",
+                    CommandKind::FreeUpSpace if target == Target::FreeUpSpace => "free_up_space",
+                    CommandKind::Hydrate if target == Target::Hydrate => "hydrate",
+                    _ => continue, // Parent, or a child that doesn't match this item
+                };
+                util::launch_app(action, &path);
             }
             Ok(())
         })

--- a/apps/desktop/native/windows/shell-menu/src/enumerator.rs
+++ b/apps/desktop/native/windows/shell-menu/src/enumerator.rs
@@ -13,7 +13,11 @@ use windows::Win32::UI::Shell::{
 use crate::command::{CommandKind, DropboxSyncCommand};
 use crate::OBJECT_COUNT;
 
-const CHILDREN: [CommandKind; 2] = [CommandKind::FreeUpSpace, CommandKind::Hydrate];
+const CHILDREN: [CommandKind; 3] = [
+    CommandKind::FreeUpSpace,
+    CommandKind::Hydrate,
+    CommandKind::CopyLink,
+];
 
 #[implement(IEnumExplorerCommand)]
 pub struct SubCommands {

--- a/apps/desktop/native/windows/shell-menu/src/labels.rs
+++ b/apps/desktop/native/windows/shell-menu/src/labels.rs
@@ -42,6 +42,18 @@ pub fn label_free_up_space(lang: &str) -> &'static str {
     }
 }
 
+/// "Copy a Dropbox shared link for this item to the clipboard."
+pub fn label_copy_link(lang: &str) -> &'static str {
+    match lang {
+        "fr" => "Copier le lien Dropbox",
+        "es" => "Copiar enlace de Dropbox",
+        "de" => "Dropbox-Link kopieren",
+        "it" => "Copia link di Dropbox",
+        "pt" => "Copiar link do Dropbox",
+        _ => "Copy Dropbox link",
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -54,5 +66,8 @@ mod tests {
         assert_eq!(label_free_up_space("xx"), "Free up space");
         assert_eq!(label_sync_to_disk("fr"), "Synchroniser sur le disque");
         assert_eq!(label_sync_to_disk("zz"), "Sync to disk");
+        assert_eq!(label_copy_link("fr"), "Copier le lien Dropbox");
+        assert_eq!(label_copy_link("es"), "Copiar enlace de Dropbox");
+        assert_eq!(label_copy_link("xx"), "Copy Dropbox link");
     }
 }

--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -60,6 +60,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "arboard"
+version = "3.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0348a1c054491f4bfe6ab86a7b6ab1e44e45d899005de92f58b3df180b36ddaf"
+dependencies = [
+ "clipboard-win",
+ "log",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-foundation",
+ "parking_lot",
+ "percent-encoding",
+ "windows-sys 0.60.2",
+ "x11rb",
+]
+
+[[package]]
 name = "ashpd"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -529,6 +546,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "clipboard-win"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bde03770d3df201d4fb868f2c9c59e66a3e4e2bd06692a0fe701e7103c7e84d4"
+dependencies = [
+ "error-code",
+]
+
+[[package]]
 name = "combine"
 version = "4.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -916,6 +942,7 @@ dependencies = [
 name = "dropbox_sync_desktop"
 version = "0.1.0"
 dependencies = [
+ "arboard",
  "base64 0.22.1",
  "chrono",
  "keyring",
@@ -929,6 +956,7 @@ dependencies = [
  "sha2",
  "tauri",
  "tauri-build",
+ "tauri-plugin-notification",
  "tauri-plugin-opener",
  "tauri-plugin-single-instance",
  "tempfile",
@@ -1044,6 +1072,12 @@ dependencies = [
  "libc",
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "error-code"
+version = "3.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dea2df4cf52843e0452895c455a1a2cfbb842a1e7329671acf418fdc53ed4c59"
 
 [[package]]
 name = "event-listener"
@@ -1393,6 +1427,16 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
+]
+
+[[package]]
+name = "gethostname"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bd49230192a3797a9a4d6abe9b3eed6f7fa4c8a8a4947977c6f80025f92cbd8"
+dependencies = [
+ "rustix",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -2323,6 +2367,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c41e0c4fef86961ac6d6f8a82609f55f31b05e4fce149ac5710e439df7619ba4"
 
 [[package]]
+name = "mac-notification-sys"
+version = "0.6.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd604973958ddcc11b561193c0fb96ba146506ef2f231ef2e7c35fd2cbc9beca"
+dependencies = [
+ "cc",
+ "log",
+ "objc2",
+ "objc2-foundation",
+ "time",
+ "uuid",
+]
+
+[[package]]
 name = "malloc_buf"
 version = "0.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2542,6 +2600,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "notify-rust"
+version = "4.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5b4c1b4f2aa9f25f63a7a49d3dd0ed567b3670da15330a66b29434be899b891"
+dependencies = [
+ "futures-lite",
+ "log",
+ "mac-notification-sys",
+ "serde",
+ "tauri-winrt-notification",
+ "zbus 5.14.0",
+]
+
+[[package]]
 name = "notify-types"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2636,6 +2708,7 @@ dependencies = [
  "block2",
  "objc2",
  "objc2-core-foundation",
+ "objc2-core-graphics",
  "objc2-foundation",
 ]
 
@@ -2686,6 +2759,7 @@ checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
 dependencies = [
  "bitflags 2.11.0",
  "block2",
+ "libc",
  "objc2",
  "objc2-core-foundation",
 ]
@@ -4540,6 +4614,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-plugin-notification"
+version = "2.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01fc2c5ff41105bd1f7242d8201fdf3efd70749b82fa013a17f2126357d194cc"
+dependencies = [
+ "log",
+ "notify-rust",
+ "rand 0.9.2",
+ "serde",
+ "serde_json",
+ "serde_repr",
+ "tauri",
+ "tauri-plugin",
+ "thiserror 2.0.18",
+ "time",
+ "url",
+]
+
+[[package]]
 name = "tauri-plugin-opener"
 version = "2.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4675,6 +4768,17 @@ dependencies = [
  "dunce",
  "embed-resource",
  "toml 0.9.12+spec-1.1.0",
+]
+
+[[package]]
+name = "tauri-winrt-notification"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed071c670382e85fc2f48ae706492d8c338f4f89bf72520d32f8abfe880aade"
+dependencies = [
+ "thiserror 2.0.18",
+ "windows",
+ "windows-version",
 ]
 
 [[package]]
@@ -6265,6 +6369,23 @@ dependencies = [
  "once_cell",
  "pkg-config",
 ]
+
+[[package]]
+name = "x11rb"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9993aa5be5a26815fe2c3eacfc1fde061fc1a1f094bf1ad2a18bf9c495dd7414"
+dependencies = [
+ "gethostname",
+ "rustix",
+ "x11rb-protocol",
+]
+
+[[package]]
+name = "x11rb-protocol"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea6fc2961e4ef194dcbfe56bb845534d0dc8098940c7e5c012a258bfec6701bd"
 
 [[package]]
 name = "xdg-home"

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -17,6 +17,7 @@ base64 = "0.22"
 chrono = { version = "0.4", features = ["serde"] }
 keyring = { version = "3", features = ["apple-native", "windows-native", "sync-secret-service"] }
 notify-debouncer-mini = "0.7.0"
+arboard = { version = "3", default-features = false }
 rand = "0.8"
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls", "blocking"] }
 rfd = "0.14"
@@ -25,6 +26,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 sha2 = "0.10"
 tauri = { version = "2", features = ["tray-icon", "image-png", "config-json5"] }
+tauri-plugin-notification = "2"
 tauri-plugin-opener = "2"
 tauri-plugin-single-instance = "2"
 thiserror = "1"

--- a/apps/desktop/src-tauri/capabilities/default.json
+++ b/apps/desktop/src-tauri/capabilities/default.json
@@ -6,6 +6,7 @@
   "permissions": [
     "core:default",
     "core:event:default",
-    "opener:default"
+    "opener:default",
+    "notification:default"
   ]
 }

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -15,6 +15,7 @@ mod path_util;
 mod remote_index;
 mod remote_longpoll;
 mod run_events;
+mod sharing;
 mod shell_actions;
 mod state;
 mod storage;
@@ -142,6 +143,16 @@ pub fn run() {
     let mut builder = tauri::Builder::default()
         .manage(app_state)
         .plugin(tauri_plugin_opener::init());
+
+    // The notification plugin pulls WinRT `windows`-crate imports that make the
+    // lib *test* binary fail to load on Windows (STATUS_ENTRYPOINT_NOT_FOUND — a
+    // known Tauri/windows-rs cargo-test issue; the real app binary is unaffected).
+    // Gating it out of `cfg(test)` lets the linker drop those imports from the
+    // test binary while the shipped app keeps native notifications (DBSYNC-52).
+    #[cfg(not(test))]
+    {
+        builder = builder.plugin(tauri_plugin_notification::init());
+    }
 
     #[cfg(desktop)]
     {

--- a/apps/desktop/src-tauri/src/sharing.rs
+++ b/apps/desktop/src-tauri/src/sharing.rs
@@ -1,0 +1,139 @@
+//! DBSYNC-52: generate a Dropbox shared link for a synced item and copy it to
+//! the clipboard, triggered from the shell context menu (`copy_link` action).
+
+use serde::Deserialize;
+
+use crate::auth_session::get_access_token;
+use crate::error::{AppError, AppResult};
+use crate::path_util::normalize_dropbox_path;
+use crate::state::AppState;
+
+#[derive(Deserialize)]
+struct SharedLinkMetadata {
+    url: String,
+}
+
+#[derive(Deserialize)]
+struct ListSharedLinksResult {
+    links: Vec<SharedLinkMetadata>,
+}
+
+/// Create a Dropbox shared link for `remote_rel` (a `/`-relative path under the
+/// sync root, WITHOUT any `.cloudsc` suffix), or return the existing one if a
+/// link already exists. Returns the public `https://www.dropbox.com/...` URL.
+pub(crate) fn create_or_get_shared_link(state: &AppState, remote_rel: &str) -> AppResult<String> {
+    let token = get_access_token(state)?;
+    let dropbox_path = normalize_dropbox_path(remote_rel)?;
+    let client = &state.http_client;
+
+    let resp = client
+        .post("https://api.dropboxapi.com/2/sharing/create_shared_link_with_settings")
+        .bearer_auth(token.as_str())
+        .json(&serde_json::json!({ "path": dropbox_path }))
+        .send()
+        .map_err(|e| AppError::Network(format!("create_shared_link request failed: {e}")))?;
+
+    if resp.status().is_success() {
+        let meta: SharedLinkMetadata = resp
+            .json()
+            .map_err(|e| AppError::Other(format!("create_shared_link parse failed: {e}")))?;
+        return Ok(meta.url);
+    }
+
+    let status = resp.status();
+    let body = resp
+        .text()
+        .unwrap_or_else(|_| "<unreadable body>".to_string());
+    // A link already exists for this path → fetch and return it (the common case
+    // for a file shared before).
+    if body.contains("shared_link_already_exists") {
+        return existing_shared_link(state, token.as_str(), &dropbox_path);
+    }
+    Err(AppError::Dropbox {
+        status: status.as_u16(),
+        message: format!("create_shared_link for {dropbox_path}: {body}"),
+    })
+}
+
+fn existing_shared_link(state: &AppState, token: &str, dropbox_path: &str) -> AppResult<String> {
+    let resp = state
+        .http_client
+        .post("https://api.dropboxapi.com/2/sharing/list_shared_links")
+        .bearer_auth(token)
+        .json(&serde_json::json!({ "path": dropbox_path, "direct_only": true }))
+        .send()
+        .map_err(|e| AppError::Network(format!("list_shared_links request failed: {e}")))?;
+
+    if !resp.status().is_success() {
+        let status = resp.status();
+        let body = resp
+            .text()
+            .unwrap_or_else(|_| "<unreadable body>".to_string());
+        return Err(AppError::Dropbox {
+            status: status.as_u16(),
+            message: format!("list_shared_links for {dropbox_path}: {body}"),
+        });
+    }
+    let result: ListSharedLinksResult = resp
+        .json()
+        .map_err(|e| AppError::Other(format!("list_shared_links parse failed: {e}")))?;
+    result
+        .links
+        .into_iter()
+        .next()
+        .map(|l| l.url)
+        .ok_or_else(|| AppError::Sync(format!("no shared link found for {dropbox_path}")))
+}
+
+/// The remote path to share for a selected item: a `.cloudsc` placeholder shares
+/// its underlying REMOTE file (`name`), not the placeholder (`name.cloudsc`).
+pub(crate) fn remote_rel_from_item(rel: &str) -> &str {
+    rel.strip_suffix(".cloudsc").unwrap_or(rel)
+}
+
+/// Put `text` on the OS clipboard.
+pub(crate) fn copy_to_clipboard(text: &str) -> AppResult<()> {
+    let mut clipboard = arboard::Clipboard::new()
+        .map_err(|e| AppError::Other(format!("clipboard unavailable: {e}")))?;
+    clipboard
+        .set_text(text.to_string())
+        .map_err(|e| AppError::Other(format!("clipboard write failed: {e}")))
+}
+
+/// Show a native OS notification (best-effort; no-ops if no `AppHandle` is set).
+///
+/// Gated out of `cfg(test)` so the `tauri-plugin-notification` WinRT imports don't
+/// get linked into the lib test binary (see the note in `lib.rs::run`).
+#[cfg(not(test))]
+pub(crate) fn notify(title: &str, body: &str) {
+    use tauri_plugin_notification::NotificationExt;
+    let Some(handle) = crate::state::APP_HANDLE.get() else {
+        return;
+    };
+    if let Err(e) = handle
+        .notification()
+        .builder()
+        .title(title)
+        .body(body)
+        .show()
+    {
+        tracing::warn!(error = %e, "failed to show notification");
+    }
+}
+
+#[cfg(test)]
+pub(crate) fn notify(_title: &str, _body: &str) {}
+
+#[cfg(test)]
+mod tests {
+    use super::remote_rel_from_item;
+
+    #[test]
+    fn cloudsc_item_maps_to_its_remote_path() {
+        assert_eq!(remote_rel_from_item("dir/report.docx.cloudsc"), "dir/report.docx");
+        assert_eq!(remote_rel_from_item("report.docx"), "report.docx");
+        assert_eq!(remote_rel_from_item("folder.cloudsc"), "folder");
+        // Only a trailing suffix is stripped.
+        assert_eq!(remote_rel_from_item("a.cloudsc/b.txt"), "a.cloudsc/b.txt");
+    }
+}

--- a/apps/desktop/src-tauri/src/shell_actions.rs
+++ b/apps/desktop/src-tauri/src/shell_actions.rs
@@ -73,11 +73,29 @@ pub(crate) fn dispatch_action(state: &AppState, action: &str, abs_path: &Path) -
             tracing::info!(action = "free_up_space", path = %rel, count = n, "shell action done");
             Ok(false) // immediate; nothing to drain
         }
+        // DBSYNC-52: generate a Dropbox shared link for the item and copy it to the
+        // clipboard. A `.cloudsc` placeholder shares its REMOTE file (`name`), not
+        // `name.cloudsc`. Errors are surfaced non-fatally (logged + a notification).
         "copy_link" => {
-            let _rel = validate_under_root(state, abs_path)?;
-            Err(AppError::Sync(
-                "copy_link not yet implemented (DBSYNC-52)".to_string(),
-            ))
+            let rel = validate_under_root(state, abs_path)?;
+            let remote_rel = crate::sharing::remote_rel_from_item(&rel).to_string();
+            // Generate the link AND copy it as one fallible step, so a clipboard
+            // failure (another app holding the clipboard open) surfaces the same
+            // error notification as a link-generation failure — never silent.
+            let result = crate::sharing::create_or_get_shared_link(state, &remote_rel)
+                .and_then(|url| crate::sharing::copy_to_clipboard(&url));
+            match result {
+                Ok(()) => {
+                    tracing::info!(action = "copy_link", path = %remote_rel, "share link copied to clipboard");
+                    crate::sharing::notify("DropboxSync", "Link copied to clipboard");
+                    Ok(false)
+                }
+                Err(e) => {
+                    tracing::warn!(action = "copy_link", path = %remote_rel, error = %e, "copy link failed");
+                    crate::sharing::notify("DropboxSync", "Couldn't copy the Dropbox link");
+                    Err(e)
+                }
+            }
         }
         other => Err(AppError::Sync(format!("unknown shell action: {other}"))),
     }


### PR DESCRIPTION
Right-click a synced item in Explorer → **DropboxSync ▸ "Copier le lien Dropbox"** generates a Dropbox shared link, copies it to the clipboard, and shows a native notification. Child of the native-shell epic (DBSYNC-50).

### What
- **`sharing.rs` (new):** `create_shared_link_with_settings`, falling back to `list_shared_links` (direct_only) on a `shared_link_already_exists` error → returns the `https://www.dropbox.com/...` URL. Clipboard via `arboard` (text-only, `default-features = false`). Native notification via `tauri-plugin-notification`. A `.cloudsc` placeholder shares its **remote** file (`name`), not `name.cloudsc`.
- **`shell_actions` `copy_link`:** link-generate + clipboard as one fallible step, so a clipboard failure (another app holding the clipboard) surfaces the same error notification — never silent.
- **COM DLL:** third child `CopyLink`, visible for any **single** synced item under the sync root (regular file, folder, or `.cloudsc`); hidden outside the root and for multi-select (the clipboard holds one value). Localized label (fr/es/de/it/pt + English).

### Notification workaround (Windows)
`tauri-plugin-notification` pulls WinRT `windows`-crate imports that make the **lib test binary** fail to load on Windows (`STATUS_ENTRYPOINT_NOT_FOUND` — a known Tauri/windows-rs `cargo test` issue; the **real app binary is unaffected**, verified by running it). Fix: the plugin is registered only under `#[cfg(not(test))]` and `notify()` has a `#[cfg(not(test))]` real impl + a `#[cfg(test)]` no-op — the linker then drops the WinRT imports from the test binary while the shipped app keeps native notifications.

### CTO review
No blockers (read-only feature — no local/remote deletion). Two UX WARNINGs fixed pre-merge: (1) a clipboard-write failure was silent (the `?` bypassed the error notification); (2) multi-select fanned out N links/notifications/clipboard races → CopyLink is now single-select only.

### Tests
Pure logic covered (localized labels; `.cloudsc`→remote mapping). Network calls untested (codebase norm). Full suite **118** + DLL **6** pass, clippy `-D warnings` clean.

> ⚠️ Windows toast notifications for an unpackaged/portable exe may require an AppUserModelID/installer to display; the clipboard (the AC deliverable) works regardless.