### PR TITLE
feat(windows): sparse package for package identity (#DBSYNC-58)

### DIFF
--- a/apps/desktop/native/windows/sparse-package/AppxManifest.xml
+++ b/apps/desktop/native/windows/sparse-package/AppxManifest.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Sparse (external-location) package that grants the unpackaged DropboxSync exe a
+  package IDENTITY, so the app can call WinRT StorageProviderSyncRootManager.Register
+  (Cloud Files API sync root / Explorer status column, DBSYNC-57) without hitting
+  APPMODEL_ERROR_NO_PACKAGE. Per-user, no admin at install (the code-signing cert
+  must be trusted once — see build-and-install.ps1).
+
+  `Publisher` MUST match the signing certificate subject exactly. `Executable` is
+  found in the external location passed to Add-AppxPackage -ExternalLocation (the
+  app's install dir; for dev, target/release with dropbox_sync_desktop.exe).
+-->
+<Package
+  xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10"
+  xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10"
+  xmlns:uap10="http://schemas.microsoft.com/appx/manifest/uap/windows10/10"
+  xmlns:rescap="http://schemas.microsoft.com/appx/manifest/foundation/windows10/restrictedcapabilities"
+  IgnorableNamespaces="uap uap10 rescap">
+
+  <Identity
+    Name="DropboxSyncDesktop"
+    Publisher="CN=DropboxSync Dev"
+    Version="1.0.0.0"
+    ProcessorArchitecture="x64" />
+
+  <Properties>
+    <DisplayName>DropboxSync</DisplayName>
+    <PublisherDisplayName>DropboxSync</PublisherDisplayName>
+    <Logo>Assets\StoreLogo.png</Logo>
+    <uap10:AllowExternalContent>true</uap10:AllowExternalContent>
+  </Properties>
+
+  <Dependencies>
+    <TargetDeviceFamily Name="Windows.Desktop" MinVersion="10.0.19041.0" MaxVersionTested="10.0.26100.0" />
+  </Dependencies>
+
+  <Resources>
+    <Resource Language="en-us" />
+  </Resources>
+
+  <Applications>
+    <Application
+      Id="DropboxSyncDesktop"
+      Executable="dropbox_sync_desktop.exe"
+      uap10:TrustLevel="mediumIL"
+      uap10:RuntimeBehavior="win32App">
+      <uap:VisualElements
+        DisplayName="DropboxSync"
+        Description="Self-hosted Dropbox-like desktop sync client"
+        BackgroundColor="transparent"
+        Square150x150Logo="Assets\Square150x150Logo.png"
+        Square44x44Logo="Assets\Square44x44Logo.png" />
+    </Application>
+  </Applications>
+
+  <Capabilities>
+    <rescap:Capability Name="runFullTrust" />
+    <rescap:Capability Name="unvirtualizedResources" />
+  </Capabilities>
+</Package>

--- a/apps/desktop/native/windows/sparse-package/README.md
+++ b/apps/desktop/native/windows/sparse-package/README.md
@@ -1,0 +1,64 @@
+# Sparse package (Windows package identity)
+
+Grants the unpackaged DropboxSync exe a **package identity** via a **sparse
+package** (an MSIX that contains only the manifest + logos; the exe stays external).
+Identity is required for the WinRT **Cloud Files API** sync-root registration
+(`StorageProviderSyncRootManager.Register`) that drives the Explorer **status
+column** (epic DBSYNC-57) — without it that call throws `APPMODEL_ERROR_NO_PACKAGE`.
+
+Per-user install, no admin **at runtime**; the one-time step that needs elevation is
+**trusting the dev code-signing cert** (production ships a real cert / MSIX installer).
+
+## Files
+- `AppxManifest.xml` — the sparse-package manifest. `Publisher` MUST match the
+  signing cert subject (`CN=DropboxSync Dev`); `AllowExternalContent` + the
+  `unvirtualizedResources` capability make it an external-location package;
+  `Executable` = `dropbox_sync_desktop.exe` (the dev exe under `target/release`).
+- `build-and-install.ps1` — creates/reuses a self-signed cert, trusts it, packs
+  (MakeAppx), signs (SignTool), and installs (`Add-AppxPackage -ExternalLocation`).
+
+## Dev usage
+```powershell
+# 1) build the release exe (must exist at the external location)
+npm --workspace apps/desktop run bundle:win
+
+# 2) build + sign + install the sparse package (ELEVATED — trusts the dev cert)
+powershell -ExecutionPolicy Bypass -File native\windows\sparse-package\build-and-install.ps1
+
+# 3) launch WITH identity — `npm run dev:win` auto-detects the package and
+#    launches via the app model. Verify: startup log shows package_identity=true.
+npm --workspace apps/desktop run dev:win
+```
+
+## IMPORTANT: launch method grants identity, not the exe path
+The exe gets package identity **only when launched through the app model** (the
+package AUMID / Start-menu tile) — a **direct exe launch does NOT** get identity.
+- Dev: `npm run dev:win` detects the installed package and launches via
+  `explorer.exe shell:AppsFolder\<PackageFamilyName>!DropboxSyncDesktop`.
+- Manual: `explorer.exe shell:AppsFolder\DropboxSyncDesktop_<hash>!DropboxSyncDesktop`
+  (the build script prints the exact AUMID).
+- **Auto-start on login** (when wired) must also go through the app model — use a
+  packaged `windows.startupTask` extension in the manifest, or a launcher that
+  invokes the AUMID — otherwise the auto-started instance has no identity and the
+  CfAPI column silently disables.
+
+## Uninstall
+```powershell
+Get-AppxPackage -Name DropboxSyncDesktop | Remove-AppxPackage
+# Also remove the dev trust anchor (elevated) — it trusts anything signed by that
+# self-signed key for 5 years; don't leave it lying around:
+Get-ChildItem Cert:\LocalMachine\Root,Cert:\LocalMachine\TrustedPeople |
+  Where-Object Subject -eq 'CN=DropboxSync Dev' | Remove-Item
+```
+
+## Production
+Fold the manifest + assets into the eventual MSIX installer (real code-signing
+cert), or ship the sparse package alongside the installed exe. The `Executable`
+becomes the bundled name (`DropboxSyncDesktop.exe`) and the external location the
+install dir.
+
+## Notes
+- `unvirtualizedResources` + `runFullTrust` capabilities are required for an
+  external-location full-trust win32 app.
+- The app detects identity at runtime (`src/windows_identity.rs`) and disables the
+  CfAPI features cleanly when the sparse package isn't installed.

--- a/apps/desktop/native/windows/sparse-package/build-and-install.ps1
+++ b/apps/desktop/native/windows/sparse-package/build-and-install.ps1
@@ -1,0 +1,93 @@
+<#
+  DBSYNC-58: build, sign and install the sparse (external-location) package that
+  grants the DropboxSync exe a package identity (needed for the WinRT Cloud Files
+  API sync-root registration, DBSYNC-57).
+
+  Run ELEVATED (it trusts the dev code-signing cert in LocalMachine). Per-user
+  install. Uninstall with:  Get-AppxPackage -Name DropboxSyncDesktop | Remove-AppxPackage
+#>
+param(
+  [string]$ExeDir  = (Join-Path $PSScriptRoot '..\..\..\src-tauri\target\release'),
+  [string]$OutMsix = (Join-Path $env:TEMP 'DropboxSyncSparse.msix')
+)
+$ErrorActionPreference = 'Stop'
+
+function Require-Admin {
+  $id = [Security.Principal.WindowsIdentity]::GetCurrent()
+  if (-not ([Security.Principal.WindowsPrincipal]$id).IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)) {
+    throw 'Run this script ELEVATED (it trusts the dev cert in LocalMachine).'
+  }
+}
+Require-Admin
+
+$ExeDir = (Resolve-Path $ExeDir).Path
+$exe = Join-Path $ExeDir 'dropbox_sync_desktop.exe'
+if (-not (Test-Path $exe)) { throw "exe not found: $exe  (build it first: npm run bundle:win)" }
+
+# Derive the signing subject from the manifest <Identity Publisher> so the cert
+# and the package publisher always match (Add-AppxPackage fails cryptically on a
+# publisher/signature mismatch).
+$manifestPath = Join-Path $PSScriptRoot 'AppxManifest.xml'
+$CertSubject = ([xml](Get-Content -Raw $manifestPath)).Package.Identity.Publisher
+Write-Host "Signing subject (from manifest Publisher): $CertSubject"
+
+# 1. Self-signed code-signing cert (reused across runs). Subject MUST match the
+#    manifest <Identity Publisher>.
+$cert = Get-ChildItem Cert:\CurrentUser\My | Where-Object { $_.Subject -eq $CertSubject } | Select-Object -First 1
+if (-not $cert) {
+  Write-Host "Creating self-signed code-signing cert: $CertSubject"
+  $cert = New-SelfSignedCertificate -Type CodeSigningCert -Subject $CertSubject `
+            -CertStoreLocation Cert:\CurrentUser\My -KeyUsage DigitalSignature `
+            -FriendlyName 'DropboxSync Dev Signing' -NotAfter (Get-Date).AddYears(5)
+}
+$thumb = $cert.Thumbprint
+
+# 2. Trust it (machine-wide, so AppX deployment accepts the signature).
+$cer = Join-Path $env:TEMP 'DropboxSyncDev.cer'
+Export-Certificate -Cert $cert -FilePath $cer | Out-Null
+Import-Certificate -FilePath $cer -CertStoreLocation Cert:\LocalMachine\Root        | Out-Null
+Import-Certificate -FilePath $cer -CertStoreLocation Cert:\LocalMachine\TrustedPeople | Out-Null
+
+# 3. Stage manifest + logos (reused from the app's MSIX icons).
+$stage = Join-Path $env:TEMP 'DropboxSyncSparseStage'
+Remove-Item $stage -Recurse -Force -ErrorAction SilentlyContinue
+New-Item -ItemType Directory -Path (Join-Path $stage 'Assets') -Force | Out-Null
+Copy-Item (Join-Path $PSScriptRoot 'AppxManifest.xml') (Join-Path $stage 'AppxManifest.xml')
+$icons = Join-Path $PSScriptRoot '..\..\..\src-tauri\icons'
+foreach ($a in 'StoreLogo.png','Square150x150Logo.png','Square44x44Logo.png') {
+  Copy-Item (Join-Path $icons $a) (Join-Path $stage "Assets\$a")
+}
+
+# 4. Locate the SDK tools.
+$kit = 'C:\Program Files (x86)\Windows Kits\10\bin'
+$makeappx = (Get-ChildItem $kit -Recurse -Filter makeappx.exe | Where-Object FullName -like '*x64*' | Sort-Object FullName -Descending | Select-Object -First 1).FullName
+$signtool = (Get-ChildItem $kit -Recurse -Filter signtool.exe | Where-Object FullName -like '*x64*' | Sort-Object FullName -Descending | Select-Object -First 1).FullName
+if (-not $makeappx) { throw 'MakeAppx.exe not found - install the Windows 10/11 SDK.' }
+if (-not $signtool) { throw 'SignTool.exe not found - install the Windows 10/11 SDK.' }
+
+# 5. Pack the sparse package (no exe inside - it lives at the external location).
+Remove-Item $OutMsix -Force -ErrorAction SilentlyContinue
+& $makeappx pack /d $stage /p $OutMsix /nv /o
+if ($LASTEXITCODE -ne 0) { throw 'makeappx pack failed' }
+
+# 6. Sign with the trusted dev cert.
+& $signtool sign /fd SHA256 /sha1 $thumb $OutMsix
+if ($LASTEXITCODE -ne 0) { throw 'signtool sign failed' }
+
+# 7. Install with the external location = the exe's folder.
+Get-AppxPackage -Name DropboxSyncDesktop | Remove-AppxPackage -ErrorAction SilentlyContinue
+Add-AppxPackage -Path $OutMsix -ExternalLocation $ExeDir
+
+# 8. Verify.
+$pkg = Get-AppxPackage -Name DropboxSyncDesktop
+if (-not $pkg) { throw 'install verification failed (no package registered)' }
+$aumid = "$($pkg.PackageFamilyName)!DropboxSyncDesktop"
+Write-Host ""
+Write-Host "Installed sparse package: $($pkg.PackageFullName)"
+Write-Host "External location:        $ExeDir"
+Write-Host "AUMID:                    $aumid"
+Write-Host ""
+Write-Host "IMPORTANT: the exe gets package identity ONLY when launched via the app"
+Write-Host "model (a direct exe launch does NOT). Use 'npm run dev:win' (auto-detects"
+Write-Host "the package), the Start-menu tile, or:"
+Write-Host "  explorer.exe shell:AppsFolder\$aumid"

--- a/apps/desktop/scripts/run-windows-release.mjs
+++ b/apps/desktop/scripts/run-windows-release.mjs
@@ -1,8 +1,13 @@
 /**
  * Launches the release binary after `tauri build` (Windows only).
- * Cargo binary name matches [package].name in src-tauri/Cargo.toml.
+ *
+ * Prefers launching through the sparse-package **app model** (via the package
+ * AUMID) so the process gets **package identity** — required for the Cloud Files
+ * API status column (DBSYNC-57/58). A direct exe launch does NOT grant identity.
+ * Falls back to a direct exe launch (identity-less; CfAPI features disable
+ * themselves) when the sparse package isn't installed.
  */
-import { spawn } from "node:child_process";
+import { spawn, execFileSync } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -28,9 +33,43 @@ if (!fs.existsSync(exePath)) {
   process.exit(1);
 }
 
-const child = spawn(exePath, [], {
-  detached: true,
-  stdio: "ignore",
-  windowsHide: false,
-});
-child.unref();
+/** Package family name of the installed sparse package, or null if not installed. */
+function packageFamilyName() {
+  try {
+    const out = execFileSync(
+      "powershell",
+      [
+        "-NoProfile",
+        "-Command",
+        "(Get-AppxPackage -Name DropboxSyncDesktop).PackageFamilyName",
+      ],
+      { encoding: "utf8" },
+    ).trim();
+    return out || null;
+  } catch {
+    return null;
+  }
+}
+
+const family = packageFamilyName();
+if (family) {
+  // Launch through the shell app model → the process runs with package identity.
+  const aumid = `${family}!DropboxSyncDesktop`;
+  console.log(`Launching with package identity: ${aumid}`);
+  const child = spawn("explorer.exe", [`shell:AppsFolder\\${aumid}`], {
+    detached: true,
+    stdio: "ignore",
+  });
+  child.unref();
+} else {
+  console.log(
+    "Sparse package not installed — launching exe directly (no package identity; CfAPI features disabled).\n" +
+      "Install it for the status column: native/windows/sparse-package/build-and-install.ps1 (elevated).",
+  );
+  const child = spawn(exePath, [], {
+    detached: true,
+    stdio: "ignore",
+    windowsHide: false,
+  });
+  child.unref();
+}

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -43,4 +43,8 @@ tempfile = "3"
 
 [target.'cfg(windows)'.dependencies]
 winreg = "0.55"
-windows-sys = { version = "0.59", features = ["Win32_Storage_FileSystem"] }
+windows-sys = { version = "0.59", features = [
+    "Win32_Foundation",
+    "Win32_Storage_FileSystem",
+    "Win32_Storage_Packaging_Appx",
+] }

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -24,6 +24,8 @@ mod sync_pipeline;
 #[cfg(windows)]
 mod windows_file_assoc;
 #[cfg(windows)]
+mod windows_identity;
+#[cfg(windows)]
 mod windows_shell_menu;
 
 use std::sync::atomic::AtomicBool;
@@ -210,6 +212,13 @@ pub fn run() {
                     // is deployed next to the exe (replaces the legacy flyout).
                     crate::windows_shell_menu::sync_shell_menu_registration();
                 }
+
+                // DBSYNC-58: CfAPI shell integration (the Explorer status column,
+                // DBSYNC-57) needs package identity from the sparse package.
+                tracing::info!(
+                    package_identity = crate::windows_identity::has_package_identity(),
+                    "windows package identity"
+                );
             }
 
             // Windows/Linux: double-clicking `.cloudsc` runs `app.exe "path\to\file.cloudsc"`; there is no

--- a/apps/desktop/src-tauri/src/windows_identity.rs
+++ b/apps/desktop/src-tauri/src/windows_identity.rs
@@ -1,0 +1,20 @@
+//! DBSYNC-58: detect whether the running process has a **package identity** (from
+//! the sparse package — see `native/windows/sparse-package/`). The Cloud Files API
+//! shell integration (DBSYNC-57) needs identity for the WinRT
+//! `StorageProviderSyncRootManager.Register`; without it, those features must
+//! no-op. During plain `cargo run`/dev without the sparse package installed, this
+//! returns false and the app runs normally.
+#![cfg(windows)]
+
+use windows_sys::Win32::Foundation::APPMODEL_ERROR_NO_PACKAGE;
+use windows_sys::Win32::Storage::Packaging::Appx::GetCurrentPackageFullName;
+
+/// True if the process is running with a package identity (a sparse/MSIX package
+/// is installed and associated with this exe).
+pub(crate) fn has_package_identity() -> bool {
+    let mut len: u32 = 0;
+    // SAFETY: with a null buffer and length 0 the API writes nothing; it only
+    // distinguishes "no package" from "buffer too small" via the return code.
+    let rc = unsafe { GetCurrentPackageFullName(&mut len, std::ptr::null_mut()) };
+    rc != APPMODEL_ERROR_NO_PACKAGE
+}


### PR DESCRIPTION
Slice 1 of the Windows Cloud Files API epic (#DBSYNC-57). Gives the unpackaged exe a **package identity** via a **sparse (external-location) package**, so the WinRT `StorageProviderSyncRootManager.Register` (which surfaces Explorer's status column) works — it otherwise throws `APPMODEL_ERROR_NO_PACKAGE`. Per-user, no admin at runtime.

### What
- **`native/windows/sparse-package/`**: `AppxManifest.xml` (external-location, `AllowExternalContent` + `runFullTrust` + `unvirtualizedResources`) + `build-and-install.ps1` (self-signed dev cert derived from the manifest Publisher, MakeAppx pack, SignTool sign, `Add-AppxPackage -ExternalLocation`) + README.
- **`src/windows_identity.rs`**: `has_package_identity()` (`GetCurrentPackageFullName` probe), logged at startup. The app **fails soft** — no identity → CfAPI features disable themselves, app runs normally.
- **`run-windows-release.mjs`** (`dev:win`): launches via the package **AUMID** when the sparse package is installed (so the process gets identity — a direct exe launch does NOT), else falls back to a direct exe launch.

### Key finding (documented)
The exe gets identity **only when launched through the app model** (AUMID / Start-menu tile), never by direct path. `dev:win` handles this; auto-start (when wired) must too.

### Validated live
Sparse package installs; launched via the AUMID the app logs `package_identity=true` (direct launch → false, expected).

### CTO review
No blockers. Two dev-hygiene WARNINGs fixed (cert subject now derived from the manifest Publisher so they can't drift; SDK-absent guard; cert-teardown added to the uninstall docs).

### Verification
118 tests + clippy `-D warnings` clean. No sync/data paths touched.