### PR TITLE
fix(windows): never propagate placeholder eviction as Dropbox deletes (#DBSYNC-62)

### DIFF
--- a/apps/desktop/src-tauri/src/cloud_filter.rs
+++ b/apps/desktop/src-tauri/src/cloud_filter.rs
@@ -28,6 +28,7 @@ use std::collections::{HashMap, HashSet};
 use std::io::{Read, Seek, SeekFrom};
 use std::path::{Path, PathBuf};
 use std::sync::{Mutex, OnceLock};
+use std::time::{Duration, Instant};
 
 use windows::core::{GUID, HSTRING, PCWSTR, PWSTR};
 use windows::Security::Cryptography::CryptographicBuffer;
@@ -73,6 +74,42 @@ static APPLIED: OnceLock<Mutex<HashMap<String, bool>>> = OnceLock::new();
 /// converting once is enough — under PopulationPolicy=AlwaysFull the shell then
 /// tracks the folder's aggregate status from its children automatically.
 static APPLIED_FOLDERS: OnceLock<Mutex<HashSet<String>>> = OnceLock::new();
+
+/// Timestamp of the last sync-root (un)registration. Registering a sync root does an
+/// `Unregister` + `Register`, and `Unregister` **evicts the dehydrated placeholders
+/// from disk** — the files vanish locally. Without a guard the sync engine reads that
+/// mass disappearance as user deletes and propagates them to Dropbox (the DBSYNC-62
+/// data-loss incident). Deletion propagation is therefore suppressed for a grace
+/// window after any real (re)registration (see `in_post_registration_grace`), during
+/// which the indexer re-materializes the evicted placeholders. This has zero effect on
+/// normal launches, which REUSE the existing registration and never (re)register.
+static LAST_REGISTRATION_AT: OnceLock<Mutex<Option<Instant>>> = OnceLock::new();
+
+/// Grace window after a (re)registration during which remote-delete propagation is
+/// suppressed. Comfortably longer than the 5-min reconciliation sweep so the indexer
+/// re-creates the evicted placeholders before deletes could resume.
+const POST_REGISTRATION_GRACE: Duration = Duration::from_secs(15 * 60);
+
+/// Record that a sync-root (un)registration just happened (starts the grace window).
+fn mark_registration_activity() {
+    if let Ok(mut g) = LAST_REGISTRATION_AT
+        .get_or_init(|| Mutex::new(None))
+        .lock()
+    {
+        *g = Some(Instant::now());
+    }
+}
+
+/// True while within [`POST_REGISTRATION_GRACE`] of the last (un)registration — the
+/// shell may still be evicting placeholders, so a locally-vanished tracked file must
+/// NOT be propagated as a Dropbox delete. Checked by the sync pipeline's delete paths.
+pub(crate) fn in_post_registration_grace() -> bool {
+    LAST_REGISTRATION_AT
+        .get()
+        .and_then(|m| m.lock().ok().and_then(|g| *g))
+        .map(|t| t.elapsed() < POST_REGISTRATION_GRACE)
+        .unwrap_or(false)
+}
 
 fn to_wide(s: &str) -> Vec<u16> {
     s.encode_utf16().chain(std::iter::once(0)).collect()
@@ -792,6 +829,10 @@ macro_rules! step {
 }
 
 fn register_winrt(folder: &str) -> windows::core::Result<()> {
+    // Start the delete-suppression grace window NOW: the Unregister below evicts the
+    // dehydrated placeholders from disk, and that mass disappearance must never be read
+    // as user deletes (DBSYNC-62).
+    mark_registration_activity();
     let id = sync_root_id();
     tracing::info!(sync_root_id = %id, folder, "cfapi register: begin");
     let info = step!("new", StorageProviderSyncRootInfo::new());
@@ -842,6 +883,9 @@ fn register_winrt(folder: &str) -> windows::core::Result<()> {
 }
 
 fn unregister() -> windows::core::Result<()> {
+    // Unregister evicts placeholders from disk — open the grace window so the resulting
+    // disappearances aren't propagated as Dropbox deletes (DBSYNC-62).
+    mark_registration_activity();
     StorageProviderSyncRootManager::Unregister(&HSTRING::from(sync_root_id()))
 }
 

--- a/apps/desktop/src-tauri/src/sync_pipeline.rs
+++ b/apps/desktop/src-tauri/src/sync_pipeline.rs
@@ -61,6 +61,12 @@ fn placeholder_exists(tracked_root: &std::path::Path, rel: &str) -> bool {
 /// placeholder. Best-effort: if the sync folder can't be read we do NOT suppress, so
 /// a genuine user deletion still propagates.
 fn delete_suppressed_by_dehydration(state: &AppState, rel: &str) -> bool {
+    // DBSYNC-62 backstop at execution time: never run a remote delete while within the
+    // sync-root registration grace window (placeholder eviction, not a user delete).
+    #[cfg(windows)]
+    if crate::cloud_filter::in_post_registration_grace() {
+        return true;
+    }
     let Ok(Some(folder)) = state.db.get_sync_folder() else {
         return false;
     };
@@ -145,6 +151,15 @@ fn process_local_file_deletion(
     tracked_root: &Path,
     prev_rel: &str,
 ) -> AppResult<usize> {
+    // DBSYNC-62: within the sync-root (re)registration grace window, a locally-vanished
+    // tracked file is almost certainly a placeholder the shell EVICTED (Unregister), not
+    // a user delete — never propagate it. Keep the index row; the indexer re-materializes
+    // the placeholder. (Zero effect in normal operation, which never re-registers.)
+    #[cfg(windows)]
+    if crate::cloud_filter::in_post_registration_grace() {
+        tracing::warn!(rel = %prev_rel, "remote delete suppressed: sync-root registration grace (placeholder eviction, not a user delete)");
+        return Ok(0);
+    }
     if placeholder_exists(tracked_root, prev_rel) {
         state.db.remove_local_file(prev_rel)?;
         return Ok(0);
@@ -161,6 +176,13 @@ fn process_known_folder_deletion(
     tracked_root: &Path,
     rel: &str,
 ) -> AppResult<usize> {
+    // DBSYNC-62: suppress folder deletes during the registration grace window too — a
+    // sync-root Unregister can strip a whole placeholder subtree at once.
+    #[cfg(windows)]
+    if crate::cloud_filter::in_post_registration_grace() {
+        tracing::warn!(rel, "remote folder delete suppressed: sync-root registration grace (eviction, not a user delete)");
+        return Ok(0);
+    }
     if placeholder_exists(tracked_root, rel) {
         state.db.remove_known_folder(rel)?;
         return Ok(0);


### PR DESCRIPTION
## Data-loss incident + fix

**What happened.** During the DBSYNC-62 spike (an `AllowPinning=false` experiment) the CfAPI sync root was re-registered. Registering does `Unregister` + `Register`, and **`Unregister` evicts the dehydrated placeholders from disk** — the cloud-only files vanish locally. The sync engine's deletion detection read that mass disappearance as user deletes and propagated **22 files** to Dropbox. They were soft-deleted (`delete_v2`) and fully recovered from Dropbox's deleted files.

**Root cause.** The existing dehydration guard only protects a placeholder that is still PRESENT (`is_dehydrated_placeholder` / `.cloudsc` check). It cannot protect one the shell made vanish.

## Fix — post-(re)registration grace window
- `register_winrt` and `unregister` stamp a timestamp (`mark_registration_activity`).
- While within `POST_REGISTRATION_GRACE` (15 min), the sync pipeline **suppresses ALL remote-delete propagation**:
  - at **enqueue** — `process_local_file_deletion` / `process_known_folder_deletion` return early and KEEP the index row;
  - at **execution** — backstop in `delete_suppressed_by_dehydration`.
- The 5-min indexer re-materializes the evicted placeholders within the window, so nothing is lost and no delete resumes.

**Zero effect on normal operation:** launches REUSE the existing registration and never re-register, so the grace window is never active outside install / folder-change / policy-bump.

## Validation
- `cargo test`: 120 green; `cargo clippy` clean.
- **Live on Windows 11:** a forced re-register produced **zero delete jobs** (was 22 before the fix); restored placeholders re-materialized automatically.

## Follow-up (not in this PR)
- A general mass-delete circuit breaker for non-registration causes (drive unmount, AV quarantine).
- Register CfAPI `NOTIFY_DELETE` to positively distinguish a user delete of a cloud-only file from an eviction (the correct long-term architecture).

https://claude.ai/code/session_016NTD4Qhq5ygTiGwrPoVEqB