### PR TITLE
feat(conflicts): resolve conflicts with keep local / use remote / keep both (#DBSYNC-35)

### DIFF
--- a/apps/desktop/src-tauri/src/commands.rs
+++ b/apps/desktop/src-tauri/src/commands.rs
@@ -400,6 +400,20 @@ pub fn retry_failed_jobs(state: tauri::State<AppState>) -> Result<usize, String>
     Ok(requeued)
 }
 
+/// Resolve a sync conflict with the user's choice (DBSYNC-35): `keep_local`,
+/// `use_remote`, or `keep_both`. See `resolve_conflict_internal` for the per-scenario
+/// semantics and data-safety guarantees.
+#[tauri::command]
+pub fn resolve_conflict(
+    state: tauri::State<AppState>,
+    id: i64,
+    action: String,
+) -> Result<(), String> {
+    let action = crate::sync_pipeline::ConflictAction::parse(&action)?;
+    crate::sync_pipeline::resolve_conflict_internal(state.inner(), id, action)?;
+    Ok(())
+}
+
 #[tauri::command]
 pub fn scan_local_changes(state: tauri::State<AppState>) -> Result<usize, String> {
     scan_local_changes_internal(state.inner()).map_err(String::from)

--- a/apps/desktop/src-tauri/src/dropbox_transfer.rs
+++ b/apps/desktop/src-tauri/src/dropbox_transfer.rs
@@ -1019,7 +1019,9 @@ pub(crate) fn download_remote_file_internal(state: &AppState, path_display: &str
             let reason = format!(
                 "remote download would overwrite unsynced local changes; local copy preserved as {conflicted_rel}"
             );
-            state.db.add_conflict(&relative, &relative, &reason)?;
+            state
+                .db
+                .add_conflict(&relative, &relative, &reason, Some(&conflicted_rel), false)?;
             if let Ok(mut engine) = state.sync_engine.lock() {
                 engine.record_conflict();
             }
@@ -1029,6 +1031,7 @@ pub(crate) fn download_remote_file_internal(state: &AppState, path_display: &str
                 "sync conflict: local copy preserved before remote overwrite"
             );
             emit_sync_conflict(&relative, &conflicted_rel, &reason);
+            crate::sharing::notify_conflict(&relative);
         }
     }
 

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -373,6 +373,7 @@ pub fn run() {
             commands::get_sync_status,
             commands::get_sync_dashboard,
             commands::retry_failed_jobs,
+            commands::resolve_conflict,
             commands::scan_local_changes,
             commands::process_sync_queue,
             commands::sync_tick,

--- a/apps/desktop/src-tauri/src/remote_index.rs
+++ b/apps/desktop/src-tauri/src/remote_index.rs
@@ -337,13 +337,18 @@ pub(crate) fn reconcile_remote_absent(state: &AppState, rel: &str) -> AppResult<
         Ok(1)
     } else {
         // Local was modified while the remote was deleted: keep it, flag conflict.
-        state
-            .db
-            .add_conflict(rel, rel, "remote deleted while local had unsynced changes")?;
+        state.db.add_conflict(
+            rel,
+            rel,
+            "remote deleted while local had unsynced changes",
+            None,
+            true,
+        )?;
         state.db.remove_remote_file(rel)?;
         if let Ok(mut engine) = state.sync_engine.lock() {
             engine.record_conflict();
         }
+        crate::sharing::notify_conflict(rel);
         Ok(0)
     }
 }

--- a/apps/desktop/src-tauri/src/sharing.rs
+++ b/apps/desktop/src-tauri/src/sharing.rs
@@ -124,6 +124,16 @@ pub(crate) fn notify(title: &str, body: &str) {
 #[cfg(test)]
 pub(crate) fn notify(_title: &str, _body: &str) {}
 
+/// OS notification for a newly detected sync conflict (DBSYNC-35). Delegates to
+/// `notify`, so it is fire-and-forget and a no-op in tests / before the app handle
+/// exists. Conflict creation is de-duplicated at each call site, so this never spams.
+pub(crate) fn notify_conflict(rel: &str) {
+    notify(
+        "DropboxSync",
+        &format!("Sync conflict on {rel} — open the app to resolve it"),
+    );
+}
+
 #[cfg(test)]
 mod tests {
     use super::remote_rel_from_item;

--- a/apps/desktop/src-tauri/src/storage/db.rs
+++ b/apps/desktop/src-tauri/src/storage/db.rs
@@ -44,6 +44,13 @@ pub struct ConflictRow {
     pub local_path: String,
     pub remote_path: String,
     pub reason: String,
+    /// Sibling copy holding the *local* content the auto-resolve preserved
+    /// (`<name> (conflicted copy <ts>).<ext>`), relative to the sync root. `None`
+    /// for the remote-deleted scenario, where only the local primary survives.
+    pub conflicted_copy_path: Option<String>,
+    /// True when the conflict is "remote deleted while local diverged" — there is
+    /// no remote content to fall back to, so `Use Remote` means discarding local.
+    pub remote_deleted: bool,
     pub created_at: String,
 }
 
@@ -756,21 +763,39 @@ impl Db {
         Ok(n)
     }
 
-    pub fn add_conflict(&self, local_path: &str, remote_path: &str, reason: &str) -> AppResult<()> {
+    pub fn add_conflict(
+        &self,
+        local_path: &str,
+        remote_path: &str,
+        reason: &str,
+        conflicted_copy_path: Option<&str>,
+        remote_deleted: bool,
+    ) -> AppResult<()> {
         let conn = self
             .write
             .lock()
             .map_err(|_| AppError::Storage("db write lock poisoned".into()))?;
         conn.execute(
             "
-                INSERT INTO sync_conflicts(local_path, remote_path, reason, resolved, created_at)
-                VALUES(?1, ?2, ?3, 0, ?4)
+                INSERT INTO sync_conflicts
+                    (local_path, remote_path, reason, conflicted_copy_path, remote_deleted, resolved, created_at)
+                VALUES(?1, ?2, ?3, ?4, ?5, 0, ?6)
                 ",
-            params![local_path, remote_path, reason, Utc::now().to_rfc3339()],
+            params![
+                local_path,
+                remote_path,
+                reason,
+                conflicted_copy_path,
+                remote_deleted as i64,
+                Utc::now().to_rfc3339()
+            ],
         )?;
         Ok(())
     }
 
+    /// Only UNRESOLVED conflicts — this backs the actionable list in the UI. Once a
+    /// conflict is resolved (`mark_conflict_resolved`) it drops off here and the
+    /// overlay stops flagging its path (`list_unresolved_conflict_local_paths`).
     pub fn list_recent_conflicts(&self, limit: i64) -> AppResult<Vec<ConflictRow>> {
         let conn = self
             .read
@@ -778,8 +803,10 @@ impl Db {
             .map_err(|_| AppError::Storage("db read lock poisoned".into()))?;
         let mut stmt = conn.prepare(
             "
-                SELECT id, local_path, remote_path, reason, created_at
+                SELECT id, local_path, remote_path, reason, conflicted_copy_path,
+                       remote_deleted, created_at
                 FROM sync_conflicts
+                WHERE resolved = 0
                 ORDER BY id DESC
                 LIMIT ?1
                 ",
@@ -791,11 +818,56 @@ impl Db {
                 local_path: row.get(1)?,
                 remote_path: row.get(2)?,
                 reason: row.get(3)?,
-                created_at: row.get(4)?,
+                conflicted_copy_path: row.get(4)?,
+                remote_deleted: row.get::<_, i64>(5)? != 0,
+                created_at: row.get(6)?,
             })
         })?;
 
         Ok(rows.collect::<Result<Vec<_>, _>>()?)
+    }
+
+    /// Fetch a single unresolved conflict by id (for the resolver). Returns `None`
+    /// if it doesn't exist or was already resolved — so a double-click resolves once.
+    pub fn get_unresolved_conflict(&self, id: i64) -> AppResult<Option<ConflictRow>> {
+        let conn = self
+            .read
+            .lock()
+            .map_err(|_| AppError::Storage("db read lock poisoned".into()))?;
+        let mut stmt = conn.prepare(
+            "
+                SELECT id, local_path, remote_path, reason, conflicted_copy_path,
+                       remote_deleted, created_at
+                FROM sync_conflicts
+                WHERE id = ?1 AND resolved = 0
+                ",
+        )?;
+        let mut rows = stmt.query(params![id])?;
+        if let Some(row) = rows.next()? {
+            return Ok(Some(ConflictRow {
+                id: row.get(0)?,
+                local_path: row.get(1)?,
+                remote_path: row.get(2)?,
+                reason: row.get(3)?,
+                conflicted_copy_path: row.get(4)?,
+                remote_deleted: row.get::<_, i64>(5)? != 0,
+                created_at: row.get(6)?,
+            }));
+        }
+        Ok(None)
+    }
+
+    /// Marks a conflict row resolved. Idempotent (a no-op if already resolved).
+    pub fn mark_conflict_resolved(&self, id: i64) -> AppResult<()> {
+        let conn = self
+            .write
+            .lock()
+            .map_err(|_| AppError::Storage("db write lock poisoned".into()))?;
+        conn.execute(
+            "UPDATE sync_conflicts SET resolved = 1 WHERE id = ?1",
+            params![id],
+        )?;
+        Ok(())
     }
 
     pub fn list_unresolved_conflict_local_paths(&self) -> AppResult<Vec<String>> {
@@ -842,6 +914,8 @@ fn migrate(conn: &Connection) -> AppResult<()> {
             local_path TEXT NOT NULL,
             remote_path TEXT NOT NULL,
             reason TEXT NOT NULL,
+            conflicted_copy_path TEXT,
+            remote_deleted INTEGER NOT NULL DEFAULT 0,
             resolved INTEGER NOT NULL DEFAULT 0,
             created_at TEXT NOT NULL
         );
@@ -875,6 +949,17 @@ fn migrate(conn: &Connection) -> AppResult<()> {
     add_column_if_missing(conn, "sync_jobs", "upload_session_offset", "INTEGER")?;
     add_column_if_missing(conn, "sync_jobs", "upload_session_file_len", "INTEGER")?;
     add_column_if_missing(conn, "sync_jobs", "upload_session_file_mtime", "INTEGER")?;
+
+    // DBSYNC-35: structured fields for conflict resolution — the sibling copy holding
+    // the preserved local content, and a flag for the remote-deleted scenario. Both
+    // have constant defaults, so ADD COLUMN is safe on existing rows.
+    add_column_if_missing(conn, "sync_conflicts", "conflicted_copy_path", "TEXT")?;
+    add_column_if_missing(
+        conn,
+        "sync_conflicts",
+        "remote_deleted",
+        "INTEGER NOT NULL DEFAULT 0",
+    )?;
 
     // DBSYNC-45: canonicalize path separators in the index tables to '/'. Rows
     // written from the local scan used OS-native '\' on Windows while remote/

--- a/apps/desktop/src-tauri/src/sync_pipeline.rs
+++ b/apps/desktop/src-tauri/src/sync_pipeline.rs
@@ -119,6 +119,8 @@ fn process_local_file_change(
                     relative,
                     relative,
                     "concurrent local update while job pending",
+                    Some(&conflicted_rel),
+                    false,
                 )?;
                 state
                     .db
@@ -129,6 +131,7 @@ fn process_local_file_change(
                 if let Ok(mut engine) = state.sync_engine.lock() {
                     engine.record_conflict();
                 }
+                crate::sharing::notify_conflict(relative);
                 Ok(1)
             } else {
                 state.db.enqueue_job("upload", Some(relative), Some(relative))?;
@@ -758,6 +761,130 @@ pub(crate) fn cleanup_stale_upload_state(state: &AppState) -> AppResult<usize> {
     Ok(cleaned)
 }
 
+/// User's choice for resolving a conflict (DBSYNC-35). Parsed from the IPC string.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum ConflictAction {
+    KeepLocal,
+    UseRemote,
+    KeepBoth,
+}
+
+impl ConflictAction {
+    pub(crate) fn parse(s: &str) -> AppResult<Self> {
+        match s {
+            "keep_local" => Ok(Self::KeepLocal),
+            "use_remote" => Ok(Self::UseRemote),
+            "keep_both" => Ok(Self::KeepBoth),
+            other => Err(AppError::Sync(format!("unknown conflict action: {other}"))),
+        }
+    }
+}
+
+/// Resolve one conflict per the user's choice (DBSYNC-35). Acts on the copies the
+/// auto-resolver already produced, so no version is ever the only casualty — except
+/// `UseRemote` in the remote-deleted scenario, which the UI double-confirms.
+///
+/// Data-safety: local deletions untrack the index row BEFORE removing the file
+/// (mirrors dehydrate) so a racing scan never reads the removal as a tracked-file
+/// deletion and propagates a spurious Dropbox delete. Remote mutations go through
+/// the job queue (retries + the dehydration-suppression guard). A double click is a
+/// no-op — `get_unresolved_conflict` returns `None` once the row is resolved.
+pub(crate) fn resolve_conflict_internal(
+    state: &AppState,
+    id: i64,
+    action: ConflictAction,
+) -> AppResult<()> {
+    let Some(conflict) = state.db.get_unresolved_conflict(id)? else {
+        return Ok(());
+    };
+    let folder = state
+        .db
+        .get_sync_folder()?
+        .ok_or_else(|| AppError::Sync("sync folder not configured".to_string()))?;
+    let root = Path::new(&folder);
+    let primary_rel = conflict.local_path.as_str();
+    let copy_rel = conflict.conflicted_copy_path.as_deref();
+
+    match (action, copy_rel, conflict.remote_deleted) {
+        // ── Keep Local ──────────────────────────────────────────────────────────
+        // Promote the preserved local edit (the conflicted copy) over the primary and
+        // push it to Dropbox, then drop the now-redundant copy from the remote.
+        (ConflictAction::KeepLocal, Some(copy_rel), _) => {
+            let copy_abs = safe_join(root, copy_rel)?;
+            let primary_abs = safe_join(root, primary_rel)?;
+            if copy_abs.exists() {
+                std::fs::rename(&copy_abs, &primary_abs)
+                    .map_err(|e| AppError::Io(format!("failed promoting conflicted copy: {e}")))?;
+                state.db.remove_local_file(copy_rel)?;
+            }
+            state
+                .db
+                .enqueue_job("upload", Some(primary_rel), Some(primary_rel))?;
+            if state.db.get_remote_file(copy_rel)?.is_some() {
+                state.db.enqueue_job("delete", Some(copy_rel), Some(copy_rel))?;
+            }
+        }
+        // No copy (remote-deleted scenario): the local primary IS the version to keep
+        // — re-upload it to restore the remote.
+        (ConflictAction::KeepLocal, None, _) => {
+            state
+                .db
+                .enqueue_job("upload", Some(primary_rel), Some(primary_rel))?;
+        }
+
+        // ── Use Remote ──────────────────────────────────────────────────────────
+        // Copy exists → the primary already holds the remote content; discard the
+        // preserved local edit (delete the copy locally, and remotely if uploaded).
+        (ConflictAction::UseRemote, Some(copy_rel), _) => {
+            let copy_abs = safe_join(root, copy_rel)?;
+            state.db.remove_local_file(copy_rel)?; // untrack before delete
+            if copy_abs.exists() {
+                std::fs::remove_file(&copy_abs)
+                    .map_err(|e| AppError::Io(format!("failed removing conflicted copy: {e}")))?;
+            }
+            if state.db.get_remote_file(copy_rel)?.is_some() {
+                state.db.enqueue_job("delete", Some(copy_rel), Some(copy_rel))?;
+            }
+        }
+        // Remote was deleted and there is no copy: "follow remote" means discarding the
+        // diverged local file. The UI double-confirms this destructive choice.
+        (ConflictAction::UseRemote, None, true) => {
+            let primary_abs = safe_join(root, primary_rel)?;
+            state.db.remove_local_file(primary_rel)?; // untrack before delete
+            state.db.remove_remote_file(primary_rel)?;
+            if primary_abs.exists() {
+                std::fs::remove_file(&primary_abs)
+                    .map_err(|e| AppError::Io(format!("failed removing local file: {e}")))?;
+            }
+        }
+        // Remote present, no copy: the primary already equals the remote — nothing to
+        // discard.
+        (ConflictAction::UseRemote, None, false) => {}
+
+        // ── Keep Both ───────────────────────────────────────────────────────────
+        // Copy exists: both versions live on disk; upload the copy so both reach
+        // Dropbox promptly (the scan would eventually do this anyway).
+        (ConflictAction::KeepBoth, Some(copy_rel), _) => {
+            if safe_join(root, copy_rel)?.exists() {
+                state.db.enqueue_job("upload", Some(copy_rel), Some(copy_rel))?;
+            }
+        }
+        // Remote deleted, no copy: there is no second version to keep — restore the
+        // remote from the local primary (degenerates to Keep Local).
+        (ConflictAction::KeepBoth, None, true) => {
+            state
+                .db
+                .enqueue_job("upload", Some(primary_rel), Some(primary_rel))?;
+        }
+        (ConflictAction::KeepBoth, None, false) => {}
+    }
+
+    state.db.mark_conflict_resolved(id)?;
+    // Recompute error/overlay state so the resolved path stops being flagged.
+    refresh_queue_depth_internal(state)?;
+    Ok(())
+}
+
 pub(crate) fn run_sync_tick_internal(state: &AppState) -> AppResult<SyncTickResult> {
     let enqueued_jobs = scan_local_changes_internal(state)?;
     if enqueued_jobs > 0 {
@@ -811,7 +938,8 @@ mod tests {
     use tempfile::tempdir;
 
     use super::{
-        cleanup_stale_upload_state, process_changed_paths, run_sync_tick_internal, SYNC_BATCH_CAP,
+        cleanup_stale_upload_state, process_changed_paths, resolve_conflict_internal,
+        run_sync_tick_internal, ConflictAction, SYNC_BATCH_CAP,
     };
     use crate::state::AppState;
     use crate::storage::db::Db;
@@ -1205,5 +1333,166 @@ mod tests {
             vec!["real.txt".to_string()],
             "a genuine failure with an existing, non-temp source is kept"
         );
+    }
+
+    // ── DBSYNC-35: conflict resolution ──────────────────────────────────────
+
+    /// Writes `content` to `<sync_folder>/<rel>` and returns the absolute path.
+    fn write_synced(state: &AppState, rel: &str, content: &str) -> std::path::PathBuf {
+        let folder = state.db.get_sync_folder().unwrap().unwrap();
+        let abs = std::path::Path::new(&folder).join(rel);
+        if let Some(p) = abs.parent() {
+            std::fs::create_dir_all(p).unwrap();
+        }
+        std::fs::write(&abs, content).unwrap();
+        abs
+    }
+
+    fn first_conflict_id(state: &AppState) -> i64 {
+        state.db.list_recent_conflicts(1).unwrap()[0].id
+    }
+
+    fn unresolved_count(state: &AppState) -> usize {
+        state.db.list_recent_conflicts(100).unwrap().len()
+    }
+
+    const COPY_REL: &str = "doc (conflicted copy 20260101000000).txt";
+
+    #[test]
+    fn keep_local_promotes_copy_over_primary_and_uploads() {
+        let tmp = tempdir().expect("tempdir");
+        let state = build_state(tmp.path());
+
+        let primary = write_synced(&state, "doc.txt", "REMOTE");
+        let copy = write_synced(&state, COPY_REL, "LOCAL_EDIT");
+        state
+            .db
+            .add_conflict("doc.txt", "doc.txt", "r", Some(COPY_REL), false)
+            .unwrap();
+
+        resolve_conflict_internal(&state, first_conflict_id(&state), ConflictAction::KeepLocal)
+            .unwrap();
+
+        assert_eq!(
+            std::fs::read_to_string(&primary).unwrap(),
+            "LOCAL_EDIT",
+            "the local edit must win at the primary path"
+        );
+        assert!(!copy.exists(), "the conflicted copy is consumed by the promotion");
+        assert_eq!(job_targets(&state, "upload"), vec!["doc.txt".to_string()]);
+        assert!(
+            job_targets(&state, "delete").is_empty(),
+            "copy was never on the remote → no remote delete"
+        );
+        assert_eq!(unresolved_count(&state), 0, "conflict must be marked resolved");
+    }
+
+    #[test]
+    fn keep_local_deletes_remote_copy_when_it_was_uploaded() {
+        let tmp = tempdir().expect("tempdir");
+        let state = build_state(tmp.path());
+        write_synced(&state, "doc.txt", "REMOTE");
+        write_synced(&state, COPY_REL, "LOCAL_EDIT");
+        state.db.upsert_remote_file(COPY_REL, "h", "rev1", 1).unwrap();
+        state
+            .db
+            .add_conflict("doc.txt", "doc.txt", "r", Some(COPY_REL), false)
+            .unwrap();
+
+        resolve_conflict_internal(&state, first_conflict_id(&state), ConflictAction::KeepLocal)
+            .unwrap();
+
+        assert_eq!(
+            job_targets(&state, "delete"),
+            vec![COPY_REL.to_string()],
+            "a copy that reached Dropbox must be cleaned up remotely"
+        );
+    }
+
+    #[test]
+    fn use_remote_discards_local_copy_keeps_primary() {
+        let tmp = tempdir().expect("tempdir");
+        let state = build_state(tmp.path());
+        let primary = write_synced(&state, "doc.txt", "REMOTE");
+        let copy = write_synced(&state, COPY_REL, "LOCAL_EDIT");
+        state
+            .db
+            .add_conflict("doc.txt", "doc.txt", "r", Some(COPY_REL), false)
+            .unwrap();
+
+        resolve_conflict_internal(&state, first_conflict_id(&state), ConflictAction::UseRemote)
+            .unwrap();
+
+        assert_eq!(
+            std::fs::read_to_string(&primary).unwrap(),
+            "REMOTE",
+            "the remote-content primary is preserved untouched"
+        );
+        assert!(!copy.exists(), "the discarded local copy is deleted");
+        assert_eq!(unresolved_count(&state), 0);
+    }
+
+    #[test]
+    fn use_remote_when_remote_deleted_discards_local_primary() {
+        let tmp = tempdir().expect("tempdir");
+        let state = build_state(tmp.path());
+        let primary = write_synced(&state, "doc.txt", "LOCAL_ONLY");
+        // Simulate the file having been tracked locally before the remote delete.
+        state.db.upsert_local_file("doc.txt", "h", 10, 1).unwrap();
+        state
+            .db
+            .add_conflict("doc.txt", "doc.txt", "r", None, true)
+            .unwrap();
+
+        resolve_conflict_internal(&state, first_conflict_id(&state), ConflictAction::UseRemote)
+            .unwrap();
+
+        assert!(!primary.exists(), "following the deleted remote removes the local file");
+        assert!(
+            state.db.get_local_file("doc.txt").unwrap().is_none(),
+            "the local index row must be untracked so the scan sees no tracked-file deletion"
+        );
+        assert_eq!(unresolved_count(&state), 0);
+    }
+
+    #[test]
+    fn keep_both_keeps_files_and_uploads_the_copy() {
+        let tmp = tempdir().expect("tempdir");
+        let state = build_state(tmp.path());
+        let primary = write_synced(&state, "doc.txt", "REMOTE");
+        let copy = write_synced(&state, COPY_REL, "LOCAL_EDIT");
+        state
+            .db
+            .add_conflict("doc.txt", "doc.txt", "r", Some(COPY_REL), false)
+            .unwrap();
+
+        resolve_conflict_internal(&state, first_conflict_id(&state), ConflictAction::KeepBoth)
+            .unwrap();
+
+        assert!(primary.exists() && copy.exists(), "both versions are kept on disk");
+        assert_eq!(
+            job_targets(&state, "upload"),
+            vec![COPY_REL.to_string()],
+            "the preserved copy is pushed to Dropbox so both versions sync"
+        );
+        assert_eq!(unresolved_count(&state), 0);
+    }
+
+    #[test]
+    fn resolving_twice_is_a_safe_no_op() {
+        let tmp = tempdir().expect("tempdir");
+        let state = build_state(tmp.path());
+        write_synced(&state, "doc.txt", "LOCAL_ONLY");
+        state
+            .db
+            .add_conflict("doc.txt", "doc.txt", "r", None, false)
+            .unwrap();
+        let id = first_conflict_id(&state);
+
+        resolve_conflict_internal(&state, id, ConflictAction::KeepLocal).unwrap();
+        // Second call finds no unresolved row → returns Ok without touching anything.
+        resolve_conflict_internal(&state, id, ConflictAction::UseRemote).unwrap();
+
+        assert_eq!(unresolved_count(&state), 0);
     }
 }

--- a/apps/desktop/src/components/FlyoutApp.css
+++ b/apps/desktop/src/components/FlyoutApp.css
@@ -257,6 +257,40 @@ html, body, #root {
   color: var(--flyout-error);
 }
 
+/* DBSYNC-35: conflict resolution actions */
+.conflict-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin-top: 6px;
+}
+
+.conflict-btn {
+  background: var(--flyout-panel);
+  color: var(--flyout-text);
+  border: 1px solid var(--flyout-border);
+  border-radius: 6px;
+  padding: 3px 9px;
+  font-size: 10.5px;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.conflict-btn:hover {
+  border-color: var(--flyout-accent);
+  color: var(--flyout-accent);
+}
+
+.conflict-btn.danger {
+  color: var(--flyout-error);
+  border-color: var(--flyout-error-soft);
+}
+
+.conflict-btn.danger:hover {
+  border-color: var(--flyout-error);
+  color: var(--flyout-error);
+}
+
 .flyout-footer {
   flex: 0 0 auto;
   display: flex;

--- a/apps/desktop/src/components/FlyoutApp.tsx
+++ b/apps/desktop/src/components/FlyoutApp.tsx
@@ -6,7 +6,7 @@ import { useSyncDashboard } from "../hooks/useSyncDashboard";
 import { useTransferProgress } from "../hooks/useTransferProgress";
 import { usePlaceholderEvents } from "../hooks/usePlaceholderEvents";
 import { formatBytes, formatSpeed } from "../format";
-import type { ActiveTransfer, ActivityEntry, SyncJob } from "../types";
+import type { ActiveTransfer, ActivityEntry, SyncConflict, SyncJob } from "../types";
 import "./FlyoutApp.css";
 
 type Section = "home" | "folders" | "activity";
@@ -284,9 +284,24 @@ function buildActivityFeed(jobs: SyncJob[], activity: ActivityEntry[]): Activity
 function FlyoutApp() {
   const { activity, pushLog } = useActivityLog();
   const { startupLoading, authOk, syncFolderOk, syncFolder } = useStartupRequirements(pushLog);
-  const { status, jobs, conflicts, retryFailedJobs } = useSyncDashboard(pushLog);
+  const { status, jobs, conflicts, retryFailedJobs, resolveConflict } = useSyncDashboard(pushLog);
   const { activeTransfer } = useTransferProgress();
   usePlaceholderEvents(pushLog);
+
+  // DBSYNC-35: apply a conflict decision. "Utiliser distant" on a remote-deleted
+  // conflict discards the local file for good, so it gets a double-confirm.
+  const onResolveConflict = (
+    conflict: SyncConflict,
+    action: "keep_local" | "use_remote" | "keep_both",
+  ) => {
+    if (action === "use_remote" && conflict.remoteDeleted) {
+      const ok = window.confirm(
+        `Le distant a été supprimé. « Utiliser distant » supprimera définitivement le fichier local « ${conflict.localPath} ». Continuer ?`,
+      );
+      if (!ok) return;
+    }
+    void resolveConflict(conflict.id, action);
+  };
 
   const [section, setSection] = useState<Section>("home");
   const schedulerStartedRef = useRef(false);
@@ -457,11 +472,36 @@ function FlyoutApp() {
             <ul className="flyout-list compact">
               {conflicts.length === 0 && <li className="muted">No conflicts.</li>}
               {conflicts.map((conflict) => (
-                <li key={conflict.id} className="activity-row">
+                <li key={conflict.id} className="activity-row conflict-row">
                   <EventIcon kind="conflict" />
                   <div className="activity-row-body">
                     <div className="row-main">{conflict.localPath}</div>
                     <div className="row-sub error">{conflict.reason}</div>
+                    <div className="conflict-actions">
+                      <button
+                        type="button"
+                        className="conflict-btn"
+                        onClick={() => onResolveConflict(conflict, "keep_local")}
+                      >
+                        Garder local
+                      </button>
+                      <button
+                        type="button"
+                        className={`conflict-btn${conflict.remoteDeleted ? " danger" : ""}`}
+                        onClick={() => onResolveConflict(conflict, "use_remote")}
+                      >
+                        {conflict.remoteDeleted ? "Supprimer local" : "Utiliser distant"}
+                      </button>
+                      {!conflict.remoteDeleted && (
+                        <button
+                          type="button"
+                          className="conflict-btn"
+                          onClick={() => onResolveConflict(conflict, "keep_both")}
+                        >
+                          Garder les deux
+                        </button>
+                      )}
+                    </div>
                   </div>
                 </li>
               ))}

--- a/apps/desktop/src/hooks/useSyncDashboard.ts
+++ b/apps/desktop/src/hooks/useSyncDashboard.ts
@@ -40,6 +40,22 @@ export function useSyncDashboard(pushLog: (line: string) => void) {
     }
   }, [pushLog, refreshDashboard]);
 
+  // DBSYNC-35: apply the user's conflict decision (keep_local / use_remote / keep_both).
+  // Optimistically drop the row so it disappears immediately, then reconcile from the DB.
+  const resolveConflict = useCallback(
+    async (id: number, action: "keep_local" | "use_remote" | "keep_both") => {
+      setConflicts((prev) => prev.filter((c) => c.id !== id));
+      try {
+        await invoke("resolve_conflict", { id, action });
+        pushLog(`Conflict ${id} resolved (${action}).`);
+      } catch (error) {
+        pushLog(`Resolve conflict error: ${String(error)}`);
+      }
+      await refreshDashboard();
+    },
+    [pushLog, refreshDashboard],
+  );
+
   useEffect(() => {
     void refreshDashboard();
   }, [refreshDashboard]);
@@ -123,5 +139,5 @@ export function useSyncDashboard(pushLog: (line: string) => void) {
     prevSyncRunningRef.current = status.syncRunning;
   }, [status.syncRunning, status.lastError, status.lastScanAt, refreshDashboard, pushLog]);
 
-  return { status, jobs, conflicts, refreshDashboard, retryFailedJobs };
+  return { status, jobs, conflicts, refreshDashboard, retryFailedJobs, resolveConflict };
 }

--- a/apps/desktop/src/types.ts
+++ b/apps/desktop/src/types.ts
@@ -31,7 +31,14 @@ export type SyncJob = {
 export type SyncConflict = {
   id: number;
   localPath: string;
+  remotePath: string;
   reason: string;
+  /** Sibling copy preserving the local content, relative to the sync root.
+   *  Absent for the remote-deleted scenario (only the local primary survives). */
+  conflictedCopyPath?: string | null;
+  /** True when the remote was deleted while local diverged — "Use Remote" then
+   *  means discarding the local file (guarded by a confirm in the UI). */
+  remoteDeleted: boolean;
   createdAt: string;
 };
 


### PR DESCRIPTION
## DBSYNC-35 — Conflict resolution UI

The sync engine already **auto-resolves** every conflict by preserving the local edit as a `<name> (conflicted copy <ts>)` sibling (remote becomes primary). This ticket adds a UI + backend so the user can pick the final outcome on those already-safe copies — no version is ever the only casualty.

### Backend
- **Schema**: `sync_conflicts` gains `conflicted_copy_path` + `remote_deleted` (idempotent `ADD COLUMN`); the 3 conflict-creation sites populate them. `list_recent_conflicts` returns only **unresolved** rows; new `mark_conflict_resolved` + `get_unresolved_conflict`.
  - Fixes a **latent overlay bug**: nothing ever set `resolved=1`, so conflicted paths never cleared from the Explorer status column.
- **`resolve_conflict(id, action)`** command → `resolve_conflict_internal`, per-scenario:

  | Action | Copy exists (remote present) | Remote deleted (local-only) |
  |---|---|---|
  | Keep Local | promote copy over primary → upload → drop remote copy | re-upload local (restore remote) |
  | Use Remote | discard the local copy (delete local + remote) | **discard local file** (UI double-confirms) |
  | Keep Both | upload the copy so both sync | = Keep Local |

  Reuses the job queue + the DBSYNC-45 dehydration-suppression guard; local deletes **untrack the index row before removing the file** so a racing scan never propagates a spurious Dropbox delete. Double-click is a safe no-op.
- **6 unit tests** cover the data-safety matrix (promote / discard-copy / discard-local / keep-both / remote-delete-cleanup / double-resolve).
- OS **notification** on newly detected conflicts (`notify_conflict`, fire-and-forget, de-duplicated).

### Frontend
- **Keep local / Use remote / Keep both** buttons per conflict in the Activité list, with a **double-confirm** on the destructive remote-deleted "discard local" case. Optimistic removal + dashboard refresh. Theme-aware styles.

### Checks
128 lib tests pass · clippy clean · `tsc` clean · frontend build OK · DB migration applied live (Win11 26200) and columns verified.

### Note (not in scope)
Separately identified a **pre-existing CfAPI hydration gap** (DBSYNC-59): a dehydrated placeholder's recorded size can go stale vs the remote → `stream_range` under-transfer can hang the open; plus a spurious post-hydration upload. Not touched here — candidate for its own bug ticket.

https://claude.ai/code/session_016NTD4Qhq5ygTiGwrPoVEqB