### PR TITLE
feat(settings): tray Settings entry + user local ignore patterns (#DBSYNC-36)

### DIFF
--- a/apps/desktop/src-tauri/src/cloudsc_ops.rs
+++ b/apps/desktop/src-tauri/src/cloudsc_ops.rs
@@ -15,8 +15,8 @@ use crate::models::{
     CloudscMeta, CloudscPlaceholderInfo, DropboxListFolderResponse,
 };
 use crate::path_util::{
-    hash_file, is_path_allowed, normalize_dropbox_path, parse_prefix_csv, relpath_under, safe_join,
-    should_ignore_local_path,
+    hash_file, is_ignored_local_path, is_path_allowed, normalize_dropbox_path, parse_prefix_csv,
+    relpath_under, safe_join,
 };
 use crate::state::AppState;
 
@@ -770,7 +770,7 @@ fn dehydrate_folder_cfapi(state: &AppState, root: &Path, folder_rel: &str) -> Ap
             Ok(r) => r.to_string_lossy().replace('\\', "/"),
             Err(_) => continue,
         };
-        if file_rel.ends_with(".cloudsc") || should_ignore_local_path(&file_rel) {
+        if file_rel.ends_with(".cloudsc") || is_ignored_local_path(&file_rel) {
             continue;
         }
         // Already cloud-only — never re-hash it (that would hydrate it).
@@ -851,7 +851,7 @@ fn dehydrate_folder_collapse(
             cloudsc_children.push(entry.path().to_path_buf());
             continue;
         }
-        if should_ignore_local_path(&file_rel) {
+        if is_ignored_local_path(&file_rel) {
             continue; // ignored/ephemeral — not deleted; blocks the collapse (→ degrade)
         }
         if !is_file_fully_synced(state, root, &file_rel)? {

--- a/apps/desktop/src-tauri/src/commands.rs
+++ b/apps/desktop/src-tauri/src/commands.rs
@@ -19,6 +19,7 @@ use crate::dropbox_transfer::{download_remote_file_internal, hydrate_remote_fold
 use crate::error::AppResult;
 use crate::models::*;
 use crate::oauth_listener::{start_oauth_callback_listener, stop_oauth_listener};
+use crate::path_util::{parse_ignore_globs_csv, set_user_ignore_globs};
 use crate::state::AppState;
 use crate::sync::engine::SyncStatus;
 use crate::sync_pipeline::{
@@ -46,6 +47,19 @@ pub fn set_selective_sync_filters(
 ) -> Result<(), String> {
     state.db.set_include_prefixes_csv(&include_csv)?;
     state.db.set_exclude_prefixes_csv(&exclude_csv)?;
+    Ok(())
+}
+
+#[tauri::command]
+pub fn get_ignore_globs(state: tauri::State<AppState>) -> Result<IgnoreGlobs, String> {
+    let csv = state.db.get_ignore_globs_csv()?.unwrap_or_default();
+    Ok(IgnoreGlobs { csv })
+}
+
+#[tauri::command]
+pub fn set_ignore_globs(state: tauri::State<AppState>, csv: String) -> Result<(), String> {
+    state.db.set_ignore_globs_csv(&csv)?;
+    set_user_ignore_globs(parse_ignore_globs_csv(Some(csv)));
     Ok(())
 }
 

--- a/apps/desktop/src-tauri/src/fs_watcher.rs
+++ b/apps/desktop/src-tauri/src/fs_watcher.rs
@@ -15,7 +15,7 @@ use notify_debouncer_mini::notify::{RecommendedWatcher, RecursiveMode};
 use notify_debouncer_mini::{new_debouncer, DebounceEventResult, Debouncer};
 
 use crate::error::{AppError, AppResult};
-use crate::path_util::{is_editor_temp_path, should_ignore_local_path, validate_relative};
+use crate::path_util::{is_ignored_local_path, validate_relative};
 use crate::state::AppState;
 
 /// Keeps the debouncer (its OS watch + worker thread) alive for the app's
@@ -159,11 +159,7 @@ pub(crate) fn map_event_path(
 
     let rel = rel.to_string_lossy().replace('\\', "/");
     let rel = rel.trim_start_matches('/').to_string();
-    if rel.is_empty()
-        || rel.ends_with(".cloudsc")
-        || should_ignore_local_path(&rel)
-        || is_editor_temp_path(&rel)
-    {
+    if rel.is_empty() || rel.ends_with(".cloudsc") || is_ignored_local_path(&rel) {
         return None;
     }
     if validate_relative(&rel).is_err() {

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -246,9 +246,10 @@ pub fn run() {
 
             // "Open Dashboard" is gone: the tray icon itself now toggles the `main`
             // flyout on a single left click (see `on_tray_icon_event` below); the menu
-            // only needs Exit.
+            // needs Settings (DBSYNC-36, opens the `setup` window) and Exit.
+            let settings = MenuItem::with_id(app, "settings", "Settings", true, None::<&str>)?;
             let quit = MenuItem::with_id(app, "quit", "Exit", true, None::<&str>)?;
-            let menu = Menu::with_items(app, &[&quit])?;
+            let menu = Menu::with_items(app, &[&settings, &quit])?;
             // DBSYNC-32: start on the idle brand icon; update_tray_tooltip swaps the glyph
             // (sync/error) live. Not a template — we keep the brand blue in every state.
             let tray_image = Image::from_bytes(include_bytes!("icons/tray-idle.png"))
@@ -284,6 +285,12 @@ pub fn run() {
                 .on_menu_event(move |app, event| {
                     if event.id.as_ref() == "quit" {
                         app.exit(0);
+                    } else if event.id.as_ref() == "settings" {
+                        if let Some(window) = app.get_webview_window("setup") {
+                            let _ = window.show();
+                            let _ = window.unminimize();
+                            let _ = window.set_focus();
+                        }
                     }
                 });
 
@@ -328,6 +335,19 @@ pub fn run() {
                 }
 
                 crate::overlay_state::refresh_overlay_state_internal(state.inner());
+
+                // DBSYNC-36: the ignore-glob predicate is backed by a process-wide
+                // static (`path_util::USER_IGNORE_GLOBS`), so the persisted CSV must be
+                // loaded into it here — otherwise saved patterns stay inactive until the
+                // user re-saves the settings panel this session.
+                match state.db.get_ignore_globs_csv() {
+                    Ok(csv) => {
+                        crate::path_util::set_user_ignore_globs(
+                            crate::path_util::parse_ignore_globs_csv(csv),
+                        );
+                    }
+                    Err(e) => tracing::error!(error = %e, "failed to load ignore globs at startup"),
+                }
 
                 if crate::commands::should_show_main_window_for_onboarding(state.inner()) {
                     if let Some(setup_window) = app.get_webview_window("setup") {
@@ -385,7 +405,9 @@ pub fn run() {
             commands::list_cloudsc_placeholders,
             commands::trigger_hydrate_cloudsc_placeholder,
             commands::get_selective_sync_filters,
-            commands::set_selective_sync_filters
+            commands::set_selective_sync_filters,
+            commands::get_ignore_globs,
+            commands::set_ignore_globs
         ])
         .build(tauri::generate_context!())
         .expect("error while building tauri application");

--- a/apps/desktop/src-tauri/src/models.rs
+++ b/apps/desktop/src-tauri/src/models.rs
@@ -145,3 +145,9 @@ pub(crate) struct SelectiveSyncFilters {
     pub include_csv: String,
     pub exclude_csv: String,
 }
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct IgnoreGlobs {
+    pub csv: String,
+}

--- a/apps/desktop/src-tauri/src/path_util.rs
+++ b/apps/desktop/src-tauri/src/path_util.rs
@@ -1,6 +1,7 @@
 use std::fs::{self, File};
 use std::io::Read;
 use std::path::{Path, PathBuf};
+use std::sync::{OnceLock, RwLock};
 
 use chrono::Utc;
 use sha2::{Digest, Sha256};
@@ -9,7 +10,12 @@ use crate::error::{AppError, AppResult};
 
 pub(crate) fn should_ignore_local_path(relative: &str) -> bool {
     let p = relative.replace('\\', "/");
-    p == ".DS_Store" || p.ends_with("/.DS_Store") || p.starts_with("._") || p.contains("/._")
+    p == ".DS_Store"
+        || p.ends_with("/.DS_Store")
+        || p.starts_with("._")
+        || p.contains("/._")
+        || p == "Thumbs.db"
+        || p.ends_with("/Thumbs.db")
 }
 
 /// True if the path looks like an editor/download temp or lock file that should
@@ -32,13 +38,93 @@ pub(crate) fn is_editor_temp_path(relative: &str) -> bool {
         || (name.starts_with(".~lock.") && name.ends_with('#')) // LibreOffice lock
 }
 
+/// True if `relative` matches any of `globs` (DBSYNC-36 user-defined ignore
+/// patterns). Pure/side-effect-free — takes the pattern list as an argument so it
+/// is trivially unit-testable without touching the process-wide
+/// [`USER_IGNORE_GLOBS`] static.
+///
+/// KISS matching, case-insensitive, three forms (no real `**`/glob crate):
+/// - Exact basename, e.g. `Thumbs.db` — matches the last path component only.
+/// - `*`-prefixed suffix, e.g. `*.log` — matches if the whole relative path ends
+///   with the suffix (so it also matches nested files like `sub/app.log`).
+/// - Exact relative path (contains `/`), e.g. `Notes/scratch.txt` — matches only
+///   that exact path, not any other file with the same basename.
+pub(crate) fn matches_ignore_globs(relative: &str, globs: &[String]) -> bool {
+    let rel_lower = relative.replace('\\', "/").to_ascii_lowercase();
+    let basename_lower = rel_lower.rsplit('/').next().unwrap_or(&rel_lower);
+
+    globs.iter().any(|pattern| {
+        let pattern = pattern.trim();
+        if pattern.is_empty() {
+            return false;
+        }
+        let pattern_lower = pattern.to_ascii_lowercase();
+        if let Some(suffix) = pattern_lower.strip_prefix('*') {
+            !suffix.is_empty() && rel_lower.ends_with(suffix)
+        } else if pattern_lower.contains('/') {
+            rel_lower == pattern_lower
+        } else {
+            basename_lower == pattern_lower
+        }
+    })
+}
+
+/// Process-wide store of the user-defined ignore globs (DBSYNC-36), set once at
+/// startup from the persisted `ignore_globs_csv` app_config value and again
+/// whenever the user saves the settings panel ([`set_user_ignore_globs`]).
+/// `RwLock` because the predicate is read on every scan/watch event but written
+/// rarely (a settings save).
+static USER_IGNORE_GLOBS: OnceLock<RwLock<Vec<String>>> = OnceLock::new();
+
+fn user_ignore_globs_cell() -> &'static RwLock<Vec<String>> {
+    USER_IGNORE_GLOBS.get_or_init(|| RwLock::new(Vec::new()))
+}
+
+/// Replaces the active set of user-defined ignore globs. Called at startup (with
+/// the persisted value) and after the user saves the settings panel.
+pub(crate) fn set_user_ignore_globs(globs: Vec<String>) {
+    if let Ok(mut guard) = user_ignore_globs_cell().write() {
+        *guard = globs;
+    }
+}
+
+/// Checks `relative` against the current process-wide user ignore globs. A
+/// poisoned lock fails open to "not ignored" rather than panicking or wedging the
+/// sync pipeline.
+fn user_ignore_globs_match(relative: &str) -> bool {
+    match user_ignore_globs_cell().read() {
+        Ok(guard) => matches_ignore_globs(relative, &guard),
+        Err(_) => false,
+    }
+}
+
+/// Parses the comma-separated `ignore_globs_csv` app_config value into a list of
+/// trimmed, non-empty patterns. Mirrors [`parse_prefix_csv`] but does not strip a
+/// leading `/` — ignore patterns are basenames/suffixes/relative paths, not
+/// selective-sync prefixes.
+pub(crate) fn parse_ignore_globs_csv(csv: Option<String>) -> Vec<String> {
+    match csv {
+        None => Vec::new(),
+        Some(s) => s
+            .split(',')
+            .map(|p| p.trim())
+            .filter(|p| !p.is_empty())
+            .map(|p| p.to_string())
+            .collect(),
+    }
+}
+
 /// Single "never sync this local path" predicate for the whole pipeline: OS junk
 /// ([`should_ignore_local_path`]) plus editor/download temp & lock files
-/// ([`is_editor_temp_path`]). Editor temps must be excluded from the full scan too
-/// — not just the fs watcher — or an `~$doc.docx` the scan sees gets enqueued and
-/// tracked, then fails the upload when the editor deletes it (DBSYNC-55).
+/// ([`is_editor_temp_path`]) plus user-defined ignore globs
+/// ([`set_user_ignore_globs`], DBSYNC-36). Editor temps must be excluded from the
+/// full scan too — not just the fs watcher — or an `~$doc.docx` the scan sees gets
+/// enqueued and tracked, then fails the upload when the editor deletes it
+/// (DBSYNC-55).
 pub(crate) fn is_ignored_local_path(relative: &str) -> bool {
-    should_ignore_local_path(relative) || is_editor_temp_path(relative)
+    should_ignore_local_path(relative)
+        || is_editor_temp_path(relative)
+        || user_ignore_globs_match(relative)
 }
 
 /// True if `abs` is a Windows CfAPI dehydrated (online-only) placeholder — a real
@@ -290,7 +376,8 @@ mod tests {
 
     use super::{
         backoff_seconds, hash_file, is_dehydrated_placeholder, is_ignored_local_path,
-        normalize_dropbox_path, safe_join, validate_relative, DROPBOX_BLOCK_SIZE,
+        matches_ignore_globs, normalize_dropbox_path, safe_join, set_user_ignore_globs,
+        should_ignore_local_path, validate_relative, DROPBOX_BLOCK_SIZE,
     };
 
     #[test]
@@ -329,6 +416,47 @@ mod tests {
         for p in ["report.docx", "dir/photo.jpg", "notes.txt"] {
             assert!(!is_ignored_local_path(p), "should not ignore {p:?}");
         }
+    }
+
+    #[test]
+    fn thumbs_db_is_ignored_by_default() {
+        assert!(should_ignore_local_path("Thumbs.db"));
+        assert!(should_ignore_local_path("sub/Thumbs.db"));
+    }
+
+    #[test]
+    fn matches_ignore_globs_suffix_form() {
+        let globs = vec!["*.log".to_string()];
+        assert!(matches_ignore_globs("app.log", &globs));
+        assert!(matches_ignore_globs("sub/app.log", &globs));
+        assert!(!matches_ignore_globs("app.txt", &globs));
+    }
+
+    #[test]
+    fn matches_ignore_globs_exact_basename_form() {
+        let globs = vec!["secret.key".to_string()];
+        assert!(matches_ignore_globs("dir/secret.key", &globs));
+        assert!(matches_ignore_globs("secret.key", &globs));
+        assert!(!matches_ignore_globs("dir/other.key", &globs));
+    }
+
+    #[test]
+    fn matches_ignore_globs_exact_relative_path_form() {
+        let globs = vec!["Notes/scratch.txt".to_string()];
+        assert!(matches_ignore_globs("Notes/scratch.txt", &globs));
+        // Same basename elsewhere is NOT matched — the pattern is a full relative path.
+        assert!(!matches_ignore_globs("Other/scratch.txt", &globs));
+        assert!(!matches_ignore_globs("scratch.txt", &globs));
+    }
+
+    #[test]
+    fn user_ignore_globs_apply_through_is_ignored_local_path() {
+        // The static is process-wide and cargo tests run in parallel — reset it to
+        // empty when done so other tests in this file aren't affected.
+        set_user_ignore_globs(vec!["*.log".to_string()]);
+        assert!(is_ignored_local_path("a.log"));
+        set_user_ignore_globs(Vec::new());
+        assert!(!is_ignored_local_path("a.log"));
     }
 
     // ---------------------------------------------------------------------------

--- a/apps/desktop/src-tauri/src/path_util.rs
+++ b/apps/desktop/src-tauri/src/path_util.rs
@@ -114,17 +114,26 @@ pub(crate) fn parse_ignore_globs_csv(csv: Option<String>) -> Vec<String> {
     }
 }
 
-/// Single "never sync this local path" predicate for the whole pipeline: OS junk
+/// The BUILT-IN "never sync this path" predicate: OS junk
 /// ([`should_ignore_local_path`]) plus editor/download temp & lock files
-/// ([`is_editor_temp_path`]) plus user-defined ignore globs
-/// ([`set_user_ignore_globs`], DBSYNC-36). Editor temps must be excluded from the
-/// full scan too — not just the fs watcher — or an `~$doc.docx` the scan sees gets
-/// enqueued and tracked, then fails the upload when the editor deletes it
+/// ([`is_editor_temp_path`]), WITHOUT the user's own ignore globs (DBSYNC-36). Use
+/// this — not [`is_ignored_local_path`] — at any site whose meaning is "a path that
+/// should never have been tracked" (e.g. startup `cleanup_stale_upload_state`), so a
+/// user ignoring a real, already-synced file can never make that site drop the
+/// file's index row (which would make it look "new" and re-download/churn). Keeps
+/// such sites decoupled from user-glob load ordering.
+pub(crate) fn is_builtin_ignored_local_path(relative: &str) -> bool {
+    should_ignore_local_path(relative) || is_editor_temp_path(relative)
+}
+
+/// Single "never sync this local path" predicate for the whole pipeline: the
+/// built-in ignores ([`is_builtin_ignored_local_path`]) plus user-defined ignore
+/// globs ([`set_user_ignore_globs`], DBSYNC-36). Editor temps must be excluded from
+/// the full scan too — not just the fs watcher — or an `~$doc.docx` the scan sees
+/// gets enqueued and tracked, then fails the upload when the editor deletes it
 /// (DBSYNC-55).
 pub(crate) fn is_ignored_local_path(relative: &str) -> bool {
-    should_ignore_local_path(relative)
-        || is_editor_temp_path(relative)
-        || user_ignore_globs_match(relative)
+    is_builtin_ignored_local_path(relative) || user_ignore_globs_match(relative)
 }
 
 /// True if `abs` is a Windows CfAPI dehydrated (online-only) placeholder — a real
@@ -375,9 +384,9 @@ mod tests {
     use std::path::Path;
 
     use super::{
-        backoff_seconds, hash_file, is_dehydrated_placeholder, is_ignored_local_path,
-        matches_ignore_globs, normalize_dropbox_path, safe_join, set_user_ignore_globs,
-        should_ignore_local_path, validate_relative, DROPBOX_BLOCK_SIZE,
+        backoff_seconds, hash_file, is_builtin_ignored_local_path, is_dehydrated_placeholder,
+        is_ignored_local_path, matches_ignore_globs, normalize_dropbox_path, safe_join,
+        set_user_ignore_globs, should_ignore_local_path, validate_relative, DROPBOX_BLOCK_SIZE,
     };
 
     #[test]
@@ -457,6 +466,22 @@ mod tests {
         assert!(is_ignored_local_path("a.log"));
         set_user_ignore_globs(Vec::new());
         assert!(!is_ignored_local_path("a.log"));
+    }
+
+    #[test]
+    fn builtin_ignore_predicate_excludes_user_globs() {
+        // The startup cleanup uses the BUILT-IN predicate so a user ignoring a real,
+        // already-synced file never makes cleanup drop that file's index row. Even
+        // while `*.log` is an active user glob, `is_builtin_ignored_local_path` must
+        // NOT match `a.log` (only the combined predicate does). Built-in junk still
+        // matches. Reset the process-wide static when done (parallel tests).
+        set_user_ignore_globs(vec!["*.log".to_string()]);
+        assert!(!is_builtin_ignored_local_path("a.log"));
+        assert!(is_ignored_local_path("a.log"));
+        set_user_ignore_globs(Vec::new());
+        assert!(is_builtin_ignored_local_path("Thumbs.db"));
+        assert!(is_builtin_ignored_local_path("~$doc.docx"));
+        assert!(!is_builtin_ignored_local_path("a.log"));
     }
 
     // ---------------------------------------------------------------------------

--- a/apps/desktop/src-tauri/src/storage/db.rs
+++ b/apps/desktop/src-tauri/src/storage/db.rs
@@ -238,6 +238,16 @@ impl Db {
         self.get_app_config("exclude_prefixes_csv")
     }
 
+    // User-defined local ignore globs (DBSYNC-36). CSV of basename / `*.ext` /
+    // relative-path patterns (e.g. "Thumbs.db,*.log,Notes/scratch.txt").
+    pub fn set_ignore_globs_csv(&self, csv: &str) -> AppResult<()> {
+        self.set_app_config("ignore_globs_csv", csv)
+    }
+
+    pub fn get_ignore_globs_csv(&self) -> AppResult<Option<String>> {
+        self.get_app_config("ignore_globs_csv")
+    }
+
     pub fn list_local_files(&self) -> AppResult<Vec<FileIndexRow>> {
         let conn = self
             .read
@@ -1489,5 +1499,18 @@ mod tests {
             .list_known_folders()
             .expect("list after reset")
             .is_empty());
+    }
+
+    #[test]
+    fn ignore_globs_csv_round_trip() {
+        let db = Db::new_at(&unique_db_path()).expect("db init");
+        assert_eq!(db.get_ignore_globs_csv().expect("get before set"), None);
+
+        db.set_ignore_globs_csv("Thumbs.db,*.log")
+            .expect("set ignore globs");
+        assert_eq!(
+            db.get_ignore_globs_csv().expect("get after set"),
+            Some("Thumbs.db,*.log".to_string())
+        );
     }
 }

--- a/apps/desktop/src-tauri/src/sync_pipeline.rs
+++ b/apps/desktop/src-tauri/src/sync_pipeline.rs
@@ -12,7 +12,8 @@ use crate::dropbox_transfer::{
 use crate::error::{AppError, AppResult};
 use crate::models::SyncTickResult;
 use crate::path_util::{
-    backoff_seconds, create_conflicted_copy, hash_file, is_editor_temp_path, is_ignored_local_path,
+    backoff_seconds, create_conflicted_copy, hash_file, is_builtin_ignored_local_path,
+    is_editor_temp_path, is_ignored_local_path,
     normalize_dropbox_path, safe_join,
 };
 use crate::remote_index::refresh_remote_index_and_enqueue_downloads_internal;
@@ -689,15 +690,19 @@ pub(crate) fn cleanup_stale_upload_state(state: &AppState) -> AppResult<usize> {
 
     // 1) Drop tracked editor-temp index rows + known-folder rows — they should
     //    never have been tracked (and a stale temp-named folder row could trigger a
-    //    recursive remote delete).
+    //    recursive remote delete). Use the BUILT-IN ignore predicate (OS junk +
+    //    editor temps), NOT the combined one: a user-defined ignore glob (DBSYNC-36)
+    //    can match a real, already-synced file, and this cleanup must never strip
+    //    such a file's index row (that would make it look "new" and re-download/
+    //    churn). This also decouples the cleanup from user-glob load ordering.
     for row in state.db.list_local_files()? {
-        if is_ignored_local_path(&row.relative_path) {
+        if is_builtin_ignored_local_path(&row.relative_path) {
             state.db.remove_local_file(&row.relative_path)?;
             cleaned += 1;
         }
     }
     for folder_rel in state.db.list_known_folders()? {
-        if is_ignored_local_path(&folder_rel) {
+        if is_builtin_ignored_local_path(&folder_rel) {
             state.db.remove_known_folder(&folder_rel)?;
             cleaned += 1;
         }

--- a/apps/desktop/src/components/SetupApp.tsx
+++ b/apps/desktop/src/components/SetupApp.tsx
@@ -5,6 +5,7 @@ import { useActivityLog } from "../hooks/useActivityLog";
 import { useStartupRequirements } from "../hooks/useStartupRequirements";
 import { useAuthFlow } from "../hooks/useAuthFlow";
 import { useSelectiveSync } from "../hooks/useSelectiveSync";
+import { useIgnoreGlobs } from "../hooks/useIgnoreGlobs";
 import "../App.css";
 
 /**
@@ -37,6 +38,7 @@ function SetupApp() {
   });
   const { includeCsv, setIncludeCsv, excludeCsv, setExcludeCsv, saveSelectiveSync } =
     useSelectiveSync(pushLog);
+  const { ignoreGlobsCsv, setIgnoreGlobsCsv, saveIgnoreGlobs } = useIgnoreGlobs(pushLog);
 
   const [showFolderSetup, setShowFolderSetup] = useState(false);
 
@@ -201,6 +203,30 @@ function SetupApp() {
               placeholder="Exclude prefixes (CSV), e.g. Videos/Secret"
             />
             <button onClick={() => void saveSelectiveSync()}>Save selective sync</button>
+          </div>
+
+          <h3>Ignored files</h3>
+          <p style={{ fontSize: "0.85rem", color: "#64748b", marginTop: -4, marginBottom: 8 }}>
+            Local-only filters — matching files are skipped on this device only (Dropbox and your
+            other devices are unaffected). <code>Thumbs.db</code> and <code>.DS_Store</code> are
+            already ignored by default.
+          </p>
+          <div
+            style={{
+              display: "grid",
+              gap: 8,
+              padding: 10,
+              background: "#f8fafc",
+              border: "1px dashed #c5d1e3",
+              borderRadius: 10,
+            }}
+          >
+            <input
+              value={ignoreGlobsCsv}
+              onChange={(e) => setIgnoreGlobsCsv(e.currentTarget.value)}
+              placeholder="Ignore patterns (CSV), e.g. *.log,Notes/scratch.txt"
+            />
+            <button onClick={() => void saveIgnoreGlobs()}>Save ignored files</button>
           </div>
         </section>
       )}

--- a/apps/desktop/src/hooks/useIgnoreGlobs.ts
+++ b/apps/desktop/src/hooks/useIgnoreGlobs.ts
@@ -1,0 +1,29 @@
+import { useCallback, useEffect, useState } from "react";
+import { invoke } from "@tauri-apps/api/core";
+import type { IgnoreGlobs } from "../types";
+
+/** User-defined local ignore glob patterns (device-local concern, distinct from
+ *  remote selective sync). Persisting also activates the patterns immediately. */
+export function useIgnoreGlobs(pushLog: (line: string) => void) {
+  const [ignoreGlobsCsv, setIgnoreGlobsCsv] = useState("");
+
+  useEffect(() => {
+    invoke<IgnoreGlobs>("get_ignore_globs")
+      .then((globs) => {
+        setIgnoreGlobsCsv(globs.csv ?? "");
+      })
+      .catch((e) => pushLog(`Failed to load ignore globs: ${String(e)}`));
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const saveIgnoreGlobs = useCallback(async () => {
+    try {
+      await invoke("set_ignore_globs", { csv: ignoreGlobsCsv });
+      pushLog("Ignored files patterns saved.");
+    } catch (e) {
+      pushLog(`Failed to save ignore globs: ${String(e)}`);
+    }
+  }, [ignoreGlobsCsv, pushLog]);
+
+  return { ignoreGlobsCsv, setIgnoreGlobsCsv, saveIgnoreGlobs };
+}

--- a/apps/desktop/src/types.ts
+++ b/apps/desktop/src/types.ts
@@ -66,6 +66,12 @@ export type SelectiveSyncFilters = {
   excludeCsv: string;
 };
 
+/** User-defined local ignore glob patterns (device-local only, distinct from
+ *  remote selective sync). See Rust `path_util::matches_ignore_globs`. */
+export type IgnoreGlobs = {
+  csv: string;
+};
+
 export type TriggerActionResponse = {
   accepted: boolean;
 };


### PR DESCRIPTION
## Summary
DBSYNC-36 slices **S1 + S2** (the two AFK slices). S3 (disconnect) and S4 (startup-at-login) follow in their own PRs.

**S1 — tray Settings entry**: the tray menu gains a "Settings" item above "Exit" that opens (and focuses — no duplicate window) the existing `setup` window, which already renders the Dropbox account / sync folder / selective-sync settings panel.

**S2 — user-defined local ignore patterns**:
- `Thumbs.db` now ignored by default alongside `.DS_Store` / editor temps.
- Users add extra patterns, persisted in `app_config` as `ignore_globs_csv` (**no schema change**), OR'd into the single `is_ignored_local_path` predicate.
- KISS hand-rolled matching (no new crate): case-insensitive **exact basename**, **`*`-suffix**, or **exact relative path**. Real `**/` globs are out of scope.
- Folded `fs_watcher` + `cloudsc_ops` onto the combined predicate so user patterns apply to both the full scan and the fs watcher.
- Frontend **"Ignored files"** section (local-only), visually distinct from the remote selective-sync control.

## Stack
desktop-tauri

## Jira Ticket
DBSYNC-36 (In Review)

## Test Plan
- [x] `cargo test --lib` — 134 pass (5 new path_util + 1 db), `cargo clippy --lib` clean
- [x] `tsc` + `vite build` pass
- [x] desktop-tauri: exercised affected commands; built + launched, tray "Settings" opens the panel, "Ignored files" saves; no terminal errors

### Notes
- Local ignore (this PR) is a distinct axis from remote selective-sync (`exclude_prefixes_csv`) — kept separate in storage and UI.
- Out of scope (own tickets/PRs): bandwidth throttle (de-scoped), S3 disconnect, S4 startup-at-login.

🤖 Generated with Claude Code
https://claude.ai/code/session_016NTD4Qhq5ygTiGwrPoVEqB