### PR TITLE
feat(settings): disconnect / sign-out from Dropbox (#DBSYNC-36)

### DIFF
--- a/apps/desktop/src-tauri/src/auth_session.rs
+++ b/apps/desktop/src-tauri/src/auth_session.rs
@@ -240,6 +240,37 @@ pub(crate) fn verify_dropbox_token_internal(state: &AppState) -> AppResult<bool>
     Ok(true)
 }
 
+/// Best-effort revoke of the current Dropbox access token (DBSYNC-36 disconnect).
+/// MUST be called before the local session is cleared — it needs the still-valid
+/// token to identify which grant to revoke. Never panics, never logs the token
+/// value; a failure (no stored session, network error, non-2xx) only produces a
+/// warning log since local sign-out proceeds either way.
+pub(crate) fn revoke_dropbox_token_best_effort(state: &AppState) {
+    let session = match state.secure_store.get_session() {
+        Ok(s) => s,
+        Err(_) => return, // nothing to revoke
+    };
+
+    let result = state
+        .http_client
+        .post("https://api.dropboxapi.com/2/auth/token/revoke")
+        .bearer_auth(session.access_token.as_str())
+        .json(&serde_json::json!({}))
+        .send();
+
+    match result {
+        Ok(resp) if resp.status().is_success() => {
+            tracing::info!("dropbox access token revoked");
+        }
+        Ok(resp) => {
+            tracing::warn!(status = %resp.status(), "dropbox token revoke returned non-success");
+        }
+        Err(e) => {
+            tracing::warn!(error = %e, "dropbox token revoke request failed");
+        }
+    }
+}
+
 pub(crate) fn current_tray_status_label(state: &AppState) -> String {
     if state.sync_running.load(Ordering::Acquire) {
         return "Syncing".to_string();

--- a/apps/desktop/src-tauri/src/commands.rs
+++ b/apps/desktop/src-tauri/src/commands.rs
@@ -138,13 +138,14 @@ pub fn pick_sync_folder_dialog() -> Result<Option<String>, String> {
 
 /// Disconnects Dropbox and returns the app to a pre-onboarding state (DBSYNC-36).
 /// Order matters: the token is revoked with Dropbox BEFORE any local credential is
-/// cleared (revoke needs a still-valid token); the in-memory cache is cleared before
-/// the keyring so a concurrent reader can't resurrect a stale session from the cache
-/// after the keyring copy is gone. A keyring clear failure is logged and does NOT
-/// abort the rest of disconnect — leaving the DB/engine connected while only the
-/// cache is cleared would be a worse, more confusing half-state than a leftover
-/// (already-revoked) keyring entry that a later `has_stored_credentials` check may
-/// still pick up.
+/// cleared (revoke needs a still-valid token), then the in-memory cache, then the
+/// keyring, then the DB/engine state. The cache→keyring→DB window is not fully
+/// atomic — a concurrent sync tick could reload the cache from the still-present
+/// keyring in between — but that self-heals: the reloaded token is already revoked,
+/// so its next use 401s and `force_refresh` finds an empty keyring and fails clean.
+/// A keyring clear failure is logged and does NOT abort the rest of disconnect —
+/// leaving the DB/engine connected while only the cache is cleared would be a worse,
+/// more confusing half-state than a leftover (already-revoked) keyring entry.
 #[tauri::command]
 pub fn disconnect_dropbox(state: tauri::State<AppState>) -> Result<(), String> {
     revoke_dropbox_token_best_effort(state.inner());

--- a/apps/desktop/src-tauri/src/commands.rs
+++ b/apps/desktop/src-tauri/src/commands.rs
@@ -8,8 +8,8 @@ use tauri::{AppHandle, Manager};
 use crate::auth::oauth::start_oauth;
 use crate::auth::oauth_complete::complete_oauth_internal;
 use crate::auth_session::{
-    current_tray_status_label, has_stored_credentials, update_tray_tooltip,
-    verify_dropbox_token_internal,
+    current_tray_status_label, has_stored_credentials, revoke_dropbox_token_best_effort,
+    update_tray_tooltip, verify_dropbox_token_internal,
 };
 use crate::cloudsc_ops::{
     hydrate_cloudsc_placeholder_internal,
@@ -134,6 +134,41 @@ pub fn set_sync_folder(state: tauri::State<AppState>, folder: String) -> Result<
 pub fn pick_sync_folder_dialog() -> Result<Option<String>, String> {
     let picked = rfd::FileDialog::new().pick_folder();
     Ok(picked.map(|p| p.to_string_lossy().to_string()))
+}
+
+/// Disconnects Dropbox and returns the app to a pre-onboarding state (DBSYNC-36).
+/// Order matters: the token is revoked with Dropbox BEFORE any local credential is
+/// cleared (revoke needs a still-valid token); the in-memory cache is cleared before
+/// the keyring so a concurrent reader can't resurrect a stale session from the cache
+/// after the keyring copy is gone. A keyring clear failure is logged and does NOT
+/// abort the rest of disconnect — leaving the DB/engine connected while only the
+/// cache is cleared would be a worse, more confusing half-state than a leftover
+/// (already-revoked) keyring entry that a later `has_stored_credentials` check may
+/// still pick up.
+#[tauri::command]
+pub fn disconnect_dropbox(state: tauri::State<AppState>) -> Result<(), String> {
+    revoke_dropbox_token_best_effort(state.inner());
+
+    if let Ok(mut cache) = state.token_cache.lock() {
+        *cache = None;
+    }
+
+    if let Err(e) = state.secure_store.clear_session() {
+        tracing::warn!(error = %e, "failed to fully clear dropbox session from keyring");
+    }
+
+    state.db.reset_sync_state()?;
+    state.db.clear_sync_folder()?;
+
+    {
+        let mut engine = state
+            .sync_engine
+            .lock()
+            .map_err(|_| "sync engine lock poisoned".to_string())?;
+        engine.clear_tracked_path();
+    }
+
+    Ok(())
 }
 
 /// Same logic as [`get_startup_requirements`] for use from Rust (e.g. window visibility).

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -407,7 +407,8 @@ pub fn run() {
             commands::get_selective_sync_filters,
             commands::set_selective_sync_filters,
             commands::get_ignore_globs,
-            commands::set_ignore_globs
+            commands::set_ignore_globs,
+            commands::disconnect_dropbox
         ])
         .build(tauri::generate_context!())
         .expect("error while building tauri application");

--- a/apps/desktop/src-tauri/src/storage/db.rs
+++ b/apps/desktop/src-tauri/src/storage/db.rs
@@ -173,6 +173,18 @@ impl Db {
         Ok(())
     }
 
+    /// Removes the `sync_folder` app_config key (DBSYNC-36 disconnect). Local
+    /// preferences (selective-sync prefixes, ignore globs) are deliberately left
+    /// untouched — only `reset_sync_state` + this together represent "sign out".
+    pub fn clear_sync_folder(&self) -> AppResult<()> {
+        let conn = self
+            .write
+            .lock()
+            .map_err(|_| AppError::Storage("db write lock poisoned".into()))?;
+        conn.execute("DELETE FROM app_config WHERE key = 'sync_folder'", [])?;
+        Ok(())
+    }
+
     pub fn get_sync_folder(&self) -> AppResult<Option<String>> {
         let conn = self
             .read
@@ -1499,6 +1511,25 @@ mod tests {
             .list_known_folders()
             .expect("list after reset")
             .is_empty());
+    }
+
+    #[test]
+    fn disconnect_clears_sync_folder_but_keeps_local_prefs() {
+        let db = Db::new_at(&unique_db_path()).expect("db init");
+        db.set_sync_folder("/tmp/folder").expect("set folder");
+        db.set_include_prefixes_csv("Fotos,Videos/2024")
+            .expect("set include prefixes");
+
+        // Mirror the `disconnect_dropbox` command's DB-side clears.
+        db.reset_sync_state().expect("reset");
+        db.clear_sync_folder().expect("clear sync folder");
+
+        assert_eq!(db.get_sync_folder().expect("get after clear"), None);
+        assert_eq!(
+            db.get_include_prefixes_csv().expect("get prefixes after clear"),
+            Some("Fotos,Videos/2024".to_string()),
+            "local prefs must survive disconnect"
+        );
     }
 
     #[test]

--- a/apps/desktop/src-tauri/src/storage/secure_store.rs
+++ b/apps/desktop/src-tauri/src/storage/secure_store.rs
@@ -110,15 +110,30 @@ impl SecureStore {
     /// Deletes every credential `has_stored_credentials` (see `auth_session.rs`) can
     /// find: the chunked session keys, the expiry marker, the legacy single-blob
     /// session, and the legacy single-token entry used by [`get_token`](Self::get_token).
-    /// Best-effort per key (a missing entry is not an error) — never logs token
-    /// values, only that a clear was attempted.
+    ///
+    /// A MISSING entry is success (`NoEntry`), but a genuine keyring failure on a
+    /// primary key is surfaced: every delete is attempted (so we clear as much as
+    /// possible), and the FIRST real error is returned. Callers can then warn — a
+    /// silent partial clear would leave a session that resurrects on restart, which
+    /// is exactly what disconnect must prevent. Never logs token values.
     pub fn clear_session(&self) -> Result<(), keyring::Error> {
-        let _ = clear_chunked_key(SESSION_ACCESS);
-        let _ = clear_chunked_key(SESSION_REFRESH);
-        let _ = Entry::new(SERVICE, SESSION_EXPIRES).and_then(|e| e.delete_credential());
-        let _ = Entry::new(SERVICE, LEGACY_SESSION_KEY).and_then(|e| e.delete_credential());
-        let _ = Entry::new(SERVICE, "dropbox-access-token").and_then(|e| e.delete_credential());
-        Ok(())
+        let mut first_err: Option<keyring::Error> = None;
+        let mut record = |result: Result<(), keyring::Error>| {
+            if let Err(e) = result {
+                if first_err.is_none() {
+                    first_err = Some(e);
+                }
+            }
+        };
+        record(clear_chunked_key(SESSION_ACCESS));
+        record(clear_chunked_key(SESSION_REFRESH));
+        record(delete_credential_if_present(SESSION_EXPIRES));
+        record(delete_credential_if_present(LEGACY_SESSION_KEY));
+        record(delete_credential_if_present("dropbox-access-token"));
+        match first_err {
+            Some(e) => Err(e),
+            None => Ok(()),
+        }
     }
 }
 
@@ -154,6 +169,16 @@ fn chunk_part_key(base: &str, i: usize) -> String {
 }
 
 /// Deletes `base.start_idx`, `base.start_idx+1`, … (best-effort) to trim old chunk parts.
+/// Deletes a single credential entry, treating a MISSING entry (`NoEntry`) as
+/// success and surfacing any other keyring error. Used by the clear paths so a
+/// genuine failure isn't silently swallowed.
+fn delete_credential_if_present(key: &str) -> Result<(), keyring::Error> {
+    match Entry::new(SERVICE, key)?.delete_credential() {
+        Ok(()) | Err(keyring::Error::NoEntry) => Ok(()),
+        Err(e) => Err(e),
+    }
+}
+
 fn clear_overflow_parts(base: &str, start_idx: usize) {
     for i in start_idx..start_idx + 64 {
         let _ = Entry::new(SERVICE, &chunk_part_key(base, i)).and_then(|e| e.delete_credential());
@@ -195,7 +220,9 @@ fn load_value_chunked(base: &str) -> Result<String, keyring::Error> {
 }
 
 fn clear_chunked_key(base: &str) -> Result<(), keyring::Error> {
-    let _ = Entry::new(SERVICE, base)?.delete_credential();
+    // Deleting the base key alone prevents resurrection (a chunked read starts from
+    // it), so surface a real failure there; the overflow parts stay best-effort.
+    let base_result = delete_credential_if_present(base);
     clear_overflow_parts(base, 0);
-    Ok(())
+    base_result
 }

--- a/apps/desktop/src-tauri/src/storage/secure_store.rs
+++ b/apps/desktop/src-tauri/src/storage/secure_store.rs
@@ -106,6 +106,20 @@ impl SecureStore {
         self.store_session(&session)?;
         Ok(session)
     }
+
+    /// Deletes every credential `has_stored_credentials` (see `auth_session.rs`) can
+    /// find: the chunked session keys, the expiry marker, the legacy single-blob
+    /// session, and the legacy single-token entry used by [`get_token`](Self::get_token).
+    /// Best-effort per key (a missing entry is not an error) — never logs token
+    /// values, only that a clear was attempted.
+    pub fn clear_session(&self) -> Result<(), keyring::Error> {
+        let _ = clear_chunked_key(SESSION_ACCESS);
+        let _ = clear_chunked_key(SESSION_REFRESH);
+        let _ = Entry::new(SERVICE, SESSION_EXPIRES).and_then(|e| e.delete_credential());
+        let _ = Entry::new(SERVICE, LEGACY_SESSION_KEY).and_then(|e| e.delete_credential());
+        let _ = Entry::new(SERVICE, "dropbox-access-token").and_then(|e| e.delete_credential());
+        Ok(())
+    }
 }
 
 fn utf16_payload_bytes(s: &str) -> usize {

--- a/apps/desktop/src-tauri/src/sync/engine.rs
+++ b/apps/desktop/src-tauri/src/sync/engine.rs
@@ -68,6 +68,14 @@ impl SyncEngine {
         self.tracked_path = Some(path);
     }
 
+    /// Clears the in-memory tracked path (DBSYNC-36 disconnect). Sets `None`
+    /// rather than `Some(String::new())` so `SyncStatus.tracked_path` — and any
+    /// caller checking it — unambiguously reports "no sync folder", matching
+    /// `Db::get_sync_folder`'s `None` after `clear_sync_folder`.
+    pub fn clear_tracked_path(&mut self) {
+        self.tracked_path = None;
+    }
+
     pub fn set_queue_depth(&mut self, queue_depth: usize) {
         self.queue_depth = queue_depth;
     }

--- a/apps/desktop/src/components/SetupApp.tsx
+++ b/apps/desktop/src/components/SetupApp.tsx
@@ -6,6 +6,7 @@ import { useStartupRequirements } from "../hooks/useStartupRequirements";
 import { useAuthFlow } from "../hooks/useAuthFlow";
 import { useSelectiveSync } from "../hooks/useSelectiveSync";
 import { useIgnoreGlobs } from "../hooks/useIgnoreGlobs";
+import { useDisconnect } from "../hooks/useDisconnect";
 import "../App.css";
 
 /**
@@ -39,6 +40,7 @@ function SetupApp() {
   const { includeCsv, setIncludeCsv, excludeCsv, setExcludeCsv, saveSelectiveSync } =
     useSelectiveSync(pushLog);
   const { ignoreGlobsCsv, setIgnoreGlobsCsv, saveIgnoreGlobs } = useIgnoreGlobs(pushLog);
+  const { disconnecting, disconnect } = useDisconnect(pushLog, refreshStartupRequirements);
 
   const [showFolderSetup, setShowFolderSetup] = useState(false);
 
@@ -78,6 +80,14 @@ function SetupApp() {
     } catch (e) {
       pushLog(`Failed to save sync folder: ${String(e)}`);
     }
+  };
+
+  const handleDisconnect = () => {
+    const ok = window.confirm(
+      "Disconnect Dropbox? This signs you out and clears local sync state. Your files on Dropbox are not affected.",
+    );
+    if (!ok) return;
+    void disconnect();
   };
 
   const pickFolder = async () => {
@@ -167,6 +177,9 @@ function SetupApp() {
                 Cancel OAuth
               </button>
             )}
+            <button type="button" disabled={disconnecting} onClick={handleDisconnect}>
+              {disconnecting ? "Disconnecting..." : "Disconnect"}
+            </button>
           </div>
           {authUrl && (
             <p>

--- a/apps/desktop/src/hooks/useDisconnect.ts
+++ b/apps/desktop/src/hooks/useDisconnect.ts
@@ -1,0 +1,33 @@
+import { useCallback, useState } from "react";
+import { invoke } from "@tauri-apps/api/core";
+
+/**
+ * Disconnects Dropbox (DBSYNC-36 S3): the backend revokes the token and clears the
+ * local session + sync-folder config (see `commands::disconnect_dropbox`). Once it
+ * resolves, `get_startup_requirements` reports authOk=false / syncFolderOk=false, so
+ * refreshing startup requirements is what actually routes `SetupApp` back to
+ * onboarding — the caller must pass its `refreshStartupRequirements` in.
+ */
+export function useDisconnect(
+  pushLog: (line: string) => void,
+  refreshStartupRequirements: () => Promise<void>,
+) {
+  const [disconnecting, setDisconnecting] = useState(false);
+
+  const disconnect = useCallback(async () => {
+    setDisconnecting(true);
+    try {
+      await invoke("disconnect_dropbox");
+      pushLog("Disconnected from Dropbox.");
+    } catch (e) {
+      pushLog(`Failed to disconnect: ${String(e)}`);
+    } finally {
+      // Refresh even on error so the UI reflects whatever the backend state ended
+      // up in (partial failures still clear enough state to fail authOk).
+      await refreshStartupRequirements();
+      setDisconnecting(false);
+    }
+  }, [pushLog, refreshStartupRequirements]);
+
+  return { disconnecting, disconnect };
+}


### PR DESCRIPTION
## Summary
DBSYNC-36 slice **S3** (security-reviewed). Adds a **Disconnect** action to the Settings panel's Dropbox-account section, behind a confirmation, that fully signs the user out and returns the app to onboarding — **without touching the user's files on Dropbox**.

`disconnect_dropbox` runs in a deliberate, data-safe order:
1. Best-effort `POST /2/auth/token/revoke` (needs the token → **before** clearing; a network/API failure is logged and never blocks local sign-out).
2. Clear the in-memory token cache.
3. `SecureStore::clear_session()` — deletes every credential `has_stored_credentials` checks (chunked session keys, expires, legacy session blob, legacy access token). **Log-and-continue** on keyring error so local state is always cleared.
4. `reset_sync_state` + new `clear_sync_folder` → fresh onboarding. Local prefs (include/exclude/ignore CSV) **kept**.
5. Clear the sync engine's in-memory tracked path (new `clear_tracked_path` → `None`).

After disconnect, `has_stored_credentials` is false and `get_sync_folder` is None, so the existing startup-requirements refresh auto-routes to onboarding. Never logs token values.

## Stack
desktop-tauri

## Jira Ticket
DBSYNC-36 (S3 of 4; S1+S2 merged in #62; S4 startup-at-login follows)

## Test Plan
- [x] `cargo test --lib` — 136 pass (new: disconnect clears sync_folder but keeps local prefs), `cargo clippy --lib` clean
- [x] `tsc` + `vite build` pass
- [ ] **Manual/HITL (deferred to reviewer/PO)**: sign out end-to-end — session gone after app restart (no auto-resurrect), UI back at onboarding, best-effort revoke observed, user's Dropbox files untouched. Keyring clear is not headless-testable.

## Security notes
- Revoke-before-clear ordering; log-and-continue keyring clear (never a half-cleared state that leaves the session but drops the cache); token values never logged.
- Disconnect clears credentials + sync state only — never deletes synced files.

🤖 Generated with Claude Code
https://claude.ai/code/session_016NTD4Qhq5ygTiGwrPoVEqB