### PR TITLE
feat(settings): package-aware startup-at-login toggle (#DBSYNC-36)

### DIFF
--- a/apps/desktop/native/windows/sparse-package/AppxManifest.xml
+++ b/apps/desktop/native/windows/sparse-package/AppxManifest.xml
@@ -14,10 +14,11 @@
   xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10"
   xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10"
   xmlns:uap10="http://schemas.microsoft.com/appx/manifest/uap/windows10/10"
+  xmlns:uap5="http://schemas.microsoft.com/appx/manifest/uap/windows10/5"
   xmlns:rescap="http://schemas.microsoft.com/appx/manifest/foundation/windows10/restrictedcapabilities"
   xmlns:com="http://schemas.microsoft.com/appx/manifest/com/windows10"
   xmlns:desktop3="http://schemas.microsoft.com/appx/manifest/desktop/windows10/3"
-  IgnorableNamespaces="uap uap10 rescap">
+  IgnorableNamespaces="uap uap10 uap5 rescap">
 
   <Identity
     Name="DropboxSyncDesktop"
@@ -80,6 +81,14 @@
             </desktop3:CloudFilesContextMenus>
           </desktop3:CloudFiles>
         </desktop3:Extension>
+        <!-- DBSYNC-36 S4: registers the "DropboxSyncStartup" startup task consumed by
+             WinRT Windows.ApplicationModel.StartupTask (windows_startup.rs). TaskId
+             MUST match STARTUP_TASK_ID there. Enabled="false" is only the initial
+             manifest state; the actual on/off state is toggled at runtime via
+             RequestEnableAsync/Disable and is NOT re-read from here after install. -->
+        <uap5:Extension Category="windows.startupTask">
+          <uap5:StartupTask TaskId="DropboxSyncStartup" Enabled="false" DisplayName="DropboxSync" />
+        </uap5:Extension>
       </Extensions>
     </Application>
   </Applications>

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -49,6 +49,7 @@ windows-sys = { version = "0.59", features = [
     "Win32_Storage_Packaging_Appx",
 ] }
 windows = { version = "0.61", features = [
+    "ApplicationModel",
     "Foundation",
     "Security_Cryptography",
     "Storage",

--- a/apps/desktop/src-tauri/src/commands.rs
+++ b/apps/desktop/src-tauri/src/commands.rs
@@ -633,3 +633,33 @@ pub fn trigger_hydrate_remote_folder(
 
     Ok(TriggerActionResponse { accepted: true })
 }
+
+/// DBSYNC-36 S4: whether the app is registered to start at login. WinRT
+/// `StartupTaskState` is the sole source of truth (no local mirror) — this
+/// queries live and only succeeds with package identity (DBSYNC-58).
+#[cfg(windows)]
+#[tauri::command]
+pub fn get_startup_at_login() -> Result<bool, String> {
+    crate::windows_startup::get_startup_enabled()
+}
+
+#[cfg(not(windows))]
+#[tauri::command]
+pub fn get_startup_at_login() -> Result<bool, String> {
+    Err("startup-at-login is only supported on Windows".into())
+}
+
+/// DBSYNC-36 S4: enable/disable starting at login. Returns the resulting
+/// enabled state per WinRT (may differ from the request, e.g. if the user or
+/// policy disabled it).
+#[cfg(windows)]
+#[tauri::command]
+pub fn set_startup_at_login(enabled: bool) -> Result<bool, String> {
+    crate::windows_startup::set_startup_enabled(enabled)
+}
+
+#[cfg(not(windows))]
+#[tauri::command]
+pub fn set_startup_at_login(_enabled: bool) -> Result<bool, String> {
+    Err("startup-at-login is only supported on Windows".into())
+}

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -29,6 +29,8 @@ mod windows_file_assoc;
 mod windows_identity;
 #[cfg(windows)]
 mod windows_shell_menu;
+#[cfg(windows)]
+mod windows_startup;
 
 use std::sync::atomic::AtomicBool;
 use std::sync::{Arc, Mutex};
@@ -408,7 +410,9 @@ pub fn run() {
             commands::set_selective_sync_filters,
             commands::get_ignore_globs,
             commands::set_ignore_globs,
-            commands::disconnect_dropbox
+            commands::disconnect_dropbox,
+            commands::get_startup_at_login,
+            commands::set_startup_at_login
         ])
         .build(tauri::generate_context!())
         .expect("error while building tauri application");

--- a/apps/desktop/src-tauri/src/windows_startup.rs
+++ b/apps/desktop/src-tauri/src/windows_startup.rs
@@ -1,0 +1,99 @@
+//! DBSYNC-36 Slice S4: "Start at login" toggle backed by the WinRT
+//! `Windows.ApplicationModel.StartupTask` API. The task itself is declared in
+//! the sparse package manifest (`native/windows/sparse-package/AppxManifest.xml`,
+//! `uap5:StartupTask` extension) — `StartupTask::GetAsync` only resolves a task
+//! that a package manifest registered, so this (like the CfAPI sync root and the
+//! shell status column) needs package identity (DBSYNC-58).
+//!
+//! Decision (KISS, see DBSYNC-36 plan): the WinRT `StartupTaskState` is the SOLE
+//! source of truth. There is no `app_config` mirror — `get_startup_enabled`
+//! always queries live.
+#![cfg(windows)]
+
+use windows::ApplicationModel::{StartupTask, StartupTaskState};
+use windows::core::HSTRING;
+
+/// Must equal the `TaskId` of the `uap5:StartupTask` extension in
+/// `native/windows/sparse-package/AppxManifest.xml`. Never change once shipped
+/// — Windows keys the Settings > Startup Apps entry (and the task itself) by
+/// this id.
+const STARTUP_TASK_ID: &str = "DropboxSyncStartup";
+
+/// True if the startup task is currently `Enabled` or `EnabledByPolicy`.
+/// Errs (without a package identity, or on a WinRT failure) rather than
+/// silently reporting `false`, so the frontend can distinguish "off" from
+/// "unsupported/unknown".
+pub(crate) fn get_startup_enabled() -> Result<bool, String> {
+    require_package_identity()?;
+    let state = run_on_mta(|| {
+        let task = get_task()?;
+        task.State().map_err(win_err)
+    })?;
+    Ok(is_enabled(state))
+}
+
+/// Enable or disable the startup task and return the resulting enabled state
+/// (per `StartupTaskState`, not merely "request accepted" — e.g. a user- or
+/// policy-disabled task may not actually turn on).
+pub(crate) fn set_startup_enabled(enabled: bool) -> Result<bool, String> {
+    require_package_identity()?;
+    let state = run_on_mta(move || {
+        let task = get_task()?;
+        if enabled {
+            let op = task.RequestEnableAsync().map_err(win_err)?;
+            op.get().map_err(win_err)
+        } else {
+            task.Disable().map_err(win_err)?;
+            task.State().map_err(win_err)
+        }
+    })?;
+    Ok(is_enabled(state))
+}
+
+fn require_package_identity() -> Result<(), String> {
+    if crate::windows_identity::has_package_identity() {
+        Ok(())
+    } else {
+        Err("startup-at-login requires package identity".to_string())
+    }
+}
+
+fn get_task() -> Result<StartupTask, String> {
+    let op = StartupTask::GetAsync(&HSTRING::from(STARTUP_TASK_ID)).map_err(win_err)?;
+    op.get().map_err(win_err)
+}
+
+fn is_enabled(state: StartupTaskState) -> bool {
+    state == StartupTaskState::Enabled || state == StartupTaskState::EnabledByPolicy
+}
+
+fn win_err(err: windows::core::Error) -> String {
+    tracing::warn!(error = %err, "startup-at-login: WinRT call failed");
+    err.to_string()
+}
+
+/// Run a WinRT closure on a dedicated MTA thread — the async `.get()` calls
+/// above must not run on the app's STA main thread (mirrors
+/// `cloud_filter.rs::run_on_mta`). Bounded by a timeout so a stuck WinRT call
+/// (e.g. `RequestEnableAsync` waiting on a consent prompt that never appears)
+/// can't hang the IPC caller.
+fn run_on_mta<F>(f: F) -> Result<StartupTaskState, String>
+where
+    F: FnOnce() -> Result<StartupTaskState, String> + Send + 'static,
+{
+    use windows::Win32::System::Com::{CoInitializeEx, COINIT_MULTITHREADED};
+
+    let (tx, rx) = std::sync::mpsc::channel();
+    std::thread::spawn(move || {
+        // SAFETY: a fresh thread; MTA is fine for these APIs. Ignore the
+        // result (S_FALSE = already initialised is not an error here).
+        unsafe {
+            let _ = CoInitializeEx(None, COINIT_MULTITHREADED);
+        }
+        let _ = tx.send(f());
+    });
+    match rx.recv_timeout(std::time::Duration::from_secs(20)) {
+        Ok(result) => result,
+        Err(_) => Err("startup-at-login: WinRT call timed out".to_string()),
+    }
+}

--- a/apps/desktop/src/components/SetupApp.tsx
+++ b/apps/desktop/src/components/SetupApp.tsx
@@ -7,6 +7,7 @@ import { useAuthFlow } from "../hooks/useAuthFlow";
 import { useSelectiveSync } from "../hooks/useSelectiveSync";
 import { useIgnoreGlobs } from "../hooks/useIgnoreGlobs";
 import { useDisconnect } from "../hooks/useDisconnect";
+import { useStartupAtLogin } from "../hooks/useStartupAtLogin";
 import "../App.css";
 
 /**
@@ -41,6 +42,12 @@ function SetupApp() {
     useSelectiveSync(pushLog);
   const { ignoreGlobsCsv, setIgnoreGlobsCsv, saveIgnoreGlobs } = useIgnoreGlobs(pushLog);
   const { disconnecting, disconnect } = useDisconnect(pushLog, refreshStartupRequirements);
+  const {
+    supported: startupAtLoginSupported,
+    enabled: startupAtLoginEnabled,
+    busy: startupAtLoginBusy,
+    toggle: toggleStartupAtLogin,
+  } = useStartupAtLogin(pushLog);
 
   const [showFolderSetup, setShowFolderSetup] = useState(false);
 
@@ -241,6 +248,24 @@ function SetupApp() {
             />
             <button onClick={() => void saveIgnoreGlobs()}>Save ignored files</button>
           </div>
+
+          {startupAtLoginSupported && (
+            <>
+              <h3>Start at login</h3>
+              <p style={{ fontSize: "0.85rem", color: "#64748b", marginTop: -4, marginBottom: 8 }}>
+                Start DropboxSync automatically when you sign in to Windows.
+              </p>
+              <label style={{ display: "flex", gap: 8, alignItems: "center" }}>
+                <input
+                  type="checkbox"
+                  checked={startupAtLoginEnabled}
+                  disabled={startupAtLoginBusy}
+                  onChange={() => void toggleStartupAtLogin()}
+                />
+                Start at login
+              </label>
+            </>
+          )}
         </section>
       )}
     </main>

--- a/apps/desktop/src/hooks/useStartupAtLogin.ts
+++ b/apps/desktop/src/hooks/useStartupAtLogin.ts
@@ -1,0 +1,43 @@
+import { useCallback, useEffect, useState } from "react";
+import { invoke } from "@tauri-apps/api/core";
+
+/**
+ * Start-at-login toggle (DBSYNC-36 S4), backed by the Windows StartupTask API
+ * (`commands::get_startup_at_login` / `set_startup_at_login`). The backend rejects
+ * on non-Windows platforms and on unpackaged dev builds that lack package identity —
+ * that's an expected condition, not an error, so we quietly flip `supported` to
+ * false (only a debug pushLog line) instead of surfacing it to the user. Callers
+ * should hide the toggle entirely when `supported` is false.
+ */
+export function useStartupAtLogin(pushLog: (line: string) => void) {
+  const [supported, setSupported] = useState(false);
+  const [enabled, setEnabled] = useState(false);
+  const [busy, setBusy] = useState(false);
+
+  useEffect(() => {
+    invoke<boolean>("get_startup_at_login")
+      .then((result) => {
+        setSupported(true);
+        setEnabled(result);
+      })
+      .catch((e) => {
+        setSupported(false);
+        pushLog(`Start at login unavailable: ${String(e)}`);
+      });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const toggle = useCallback(async () => {
+    setBusy(true);
+    try {
+      const result = await invoke<boolean>("set_startup_at_login", { enabled: !enabled });
+      setEnabled(result);
+    } catch (e) {
+      pushLog(`Failed to change start at login: ${String(e)}`);
+    } finally {
+      setBusy(false);
+    }
+  }, [enabled, pushLog]);
+
+  return { supported, enabled, busy, toggle };
+}


### PR DESCRIPTION
## Summary
DBSYNC-36 slice **S4** (final). A "Start at login" toggle in the Settings panel enables/disables auto-start via the WinRT **StartupTask** API — package-identity-preserving, so it does **not** break CfAPI (no raw `HKCU\Run` key, no `tauri-plugin-autostart` launching the bare exe).

- `windows_startup.rs` (Windows-only): get/set StartupTask state, gated on `has_package_identity()`. WinRT async on a dedicated MTA thread (mirrors `cloud_filter.rs`) with a timeout.
- `windows` crate: **verified against 0.61.3 source** — only the `ApplicationModel` feature is needed (the plan's speculated `ApplicationModel_StartupTasks` does not exist in 0.61).
- `AppxManifest.xml`: declares `uap5:StartupTask` (TaskId `DropboxSyncStartup`).
- commands `get/set_startup_at_login` (Windows real / non-Windows `Err`). WinRT state is the single source of truth (no `app_config` mirror).
- Frontend: `useStartupAtLogin` + a toggle shown **only when supported** (hidden on macOS / unpackaged dev builds).

## Stack
desktop-tauri

## Jira Ticket
DBSYNC-36 (S4 of 4 — final; S1+S2 #62, S3 #63 merged)

## Test Plan
- [x] `cargo test --lib` 136 pass, `cargo clippy --lib` clean
- [x] `tsc` + `vite build` pass; toggle hidden when unsupported
- [ ] **HITL (deferred)**: rebuild + **reinstall the sparse package**, toggle on → appears in Windows Settings > Startup Apps, toggle off → gone, and a login-launch keeps package identity (CfAPI column + verbs work). ⚠️ The reinstall crosses the known CfAPI re-register data-loss gotcha — use a **disposable** sync folder.

🤖 Generated with Claude Code
https://claude.ai/code/session_016NTD4Qhq5ygTiGwrPoVEqB