### PR TITLE
fix(sync): mass-deletion circuit breaker (safety net) (#DBSYNC-64)

### DIFF
--- a/apps/desktop/src-tauri/src/commands.rs
+++ b/apps/desktop/src-tauri/src/commands.rs
@@ -464,6 +464,18 @@ pub fn resolve_conflict(
     Ok(())
 }
 
+/// User override for the mass-deletion circuit breaker (DBSYNC-64): authorize the
+/// NEXT scan to propagate the deletions it blocked. One-shot — the flag is consumed
+/// by the next scan pass. Only call this after the user has reviewed the blocked
+/// deletion and confirmed it is an intentional bulk delete.
+#[tauri::command]
+pub fn confirm_pending_deletions(state: tauri::State<AppState>) -> Result<(), String> {
+    state
+        .db
+        .set_app_config("mass_delete_override_once", "1")?;
+    Ok(())
+}
+
 #[tauri::command]
 pub fn scan_local_changes(state: tauri::State<AppState>) -> Result<usize, String> {
     scan_local_changes_internal(state.inner()).map_err(String::from)

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -394,6 +394,7 @@ pub fn run() {
             commands::get_sync_dashboard,
             commands::retry_failed_jobs,
             commands::resolve_conflict,
+            commands::confirm_pending_deletions,
             commands::scan_local_changes,
             commands::process_sync_queue,
             commands::sync_tick,

--- a/apps/desktop/src-tauri/src/sync_pipeline.rs
+++ b/apps/desktop/src-tauri/src/sync_pipeline.rs
@@ -30,13 +30,21 @@ pub(crate) fn refresh_queue_depth_internal(state: &AppState) -> AppResult<()> {
     let queue_depth = state.db.count_active_jobs()?;
 
     let failed_error = state.db.latest_failed_error()?;
+    // DBSYNC-64: the mass-deletion pause is a DURABLE app_config flag, not a failed
+    // job — so surface it here (with precedence over a transient job error) instead
+    // of a bare `engine.set_last_error`, which this very function would then clear on
+    // the next tick (the block enqueues no failed rows).
+    let paused = state
+        .db
+        .get_app_config(MASS_DELETE_BLOCKED_KEY)?
+        .filter(|s| !s.is_empty());
 
     let mut engine = state
         .sync_engine
         .lock()
         .map_err(|_| AppError::Sync("sync engine lock poisoned".to_string()))?;
     engine.set_queue_depth(queue_depth);
-    match failed_error {
+    match paused.or(failed_error) {
         Some(msg) => engine.set_last_error(msg),
         None => engine.clear_last_error(),
     }
@@ -393,6 +401,11 @@ const MASS_DELETE_FRACTION_PERCENT: usize = 10;
 /// the next mass deletion through.
 const MASS_DELETE_OVERRIDE_KEY: &str = "mass_delete_override_once";
 
+/// Durable app_config flag holding the "sync paused: mass deletion blocked" message.
+/// Persisted (not a transient engine field) so `refresh_queue_depth_internal` keeps
+/// surfacing it every tick until the block clears. Empty string = not paused.
+const MASS_DELETE_BLOCKED_KEY: &str = "mass_delete_blocked";
+
 /// True if this many deletion candidates out of `tracked` tracked entries looks like
 /// a catastrophe rather than an intentional bulk delete.
 pub(crate) fn is_mass_deletion(candidates: usize, tracked: usize) -> bool {
@@ -415,7 +428,8 @@ fn consume_mass_delete_override(state: &AppState) -> AppResult<bool> {
 }
 
 /// Block a suspicious mass deletion: propagate NONE of it, log loudly, notify, and
-/// surface a sticky error so the UI shows sync is paused (DBSYNC-64).
+/// persist a DURABLE "sync paused" flag so the UI keeps showing it every tick until
+/// the block clears (DBSYNC-64).
 fn block_mass_deletion(state: &AppState, candidates: usize, tracked: usize) {
     let msg = format!(
         "Sync paused: {candidates} deletions in one pass ({tracked} tracked) look like a bug \
@@ -427,10 +441,28 @@ fn block_mass_deletion(state: &AppState, candidates: usize, tracked: usize) {
         tracked,
         "MASS-DELETION BLOCKED by circuit breaker; no deletions propagated (DBSYNC-64)"
     );
+    // Durable so `refresh_queue_depth_internal` re-surfaces it instead of clearing it.
+    if let Err(e) = state.db.set_app_config(MASS_DELETE_BLOCKED_KEY, &msg) {
+        tracing::error!(error = %e, "failed to persist mass-deletion pause flag");
+    }
     if let Ok(mut engine) = state.sync_engine.lock() {
         engine.set_last_error(msg.clone());
     }
     crate::sharing::notify("DropboxSync - sync paused", &msg);
+}
+
+/// Clear the durable mass-deletion pause flag — the situation resolved (no mass
+/// deletion this pass, or the user overrode it), so sync is no longer paused.
+fn clear_mass_delete_blocked(state: &AppState) {
+    if state
+        .db
+        .get_app_config(MASS_DELETE_BLOCKED_KEY)
+        .ok()
+        .flatten()
+        .is_some_and(|s| !s.is_empty())
+    {
+        let _ = state.db.set_app_config(MASS_DELETE_BLOCKED_KEY, "");
+    }
 }
 
 pub(crate) fn scan_local_changes_internal(state: &AppState) -> AppResult<usize> {
@@ -575,11 +607,16 @@ pub(crate) fn scan_local_changes_internal(state: &AppState) -> AppResult<usize> 
         let candidate_count = file_deletions.len() + folder_deletions.len();
         let tracked_count = known.len() + seen_dirs.len();
 
-        if is_mass_deletion(candidate_count, tracked_count)
-            && !consume_mass_delete_override(state)?
-        {
+        // Consume the one-shot override whenever THIS pass actually has deletions, so
+        // a stale confirmation can't linger and silently authorize an unrelated future
+        // mass deletion (only read it when there's something to authorize).
+        let overridden = candidate_count > 0 && consume_mass_delete_override(state)?;
+
+        if is_mass_deletion(candidate_count, tracked_count) && !overridden {
             block_mass_deletion(state, candidate_count, tracked_count);
         } else {
+            // Not a mass deletion (or the user confirmed) → sync is not paused.
+            clear_mass_delete_blocked(state);
             for rel in &file_deletions {
                 enqueued_jobs += process_local_file_deletion(state, &tracked_root, rel)?;
             }
@@ -1592,10 +1629,12 @@ mod tests {
         }
 
         // First scan: the batch is a mass deletion → BLOCKED. Nothing propagated,
-        // index rows kept, a sticky error surfaced. (The scan's later remote-refresh
-        // step errors here with no token, but the deletion decision runs BEFORE it,
-        // so its side effects are already committed — ignore the Result and assert
-        // those.)
+        // index rows kept, and a DURABLE pause flag persisted. (The scan's later
+        // remote-refresh step errors here with no token, but the deletion decision +
+        // the pause-flag write run BEFORE it, so those side effects are committed —
+        // ignore the Result and assert them. Asserting the DURABLE app_config flag,
+        // not the transient engine error, is what proves the pause survives a full
+        // scan in production — `refresh_queue_depth_internal` reads this flag.)
         let _ = scan_local_changes_internal(&state);
         assert!(
             job_targets(&state, "delete").is_empty(),
@@ -1608,16 +1647,15 @@ mod tests {
         );
         assert!(
             state
-                .sync_engine
-                .lock()
+                .db
+                .get_app_config("mass_delete_blocked")
                 .unwrap()
-                .current_status(false)
-                .last_error
-                .is_some(),
-            "a blocked mass deletion must surface a sticky error"
+                .is_some_and(|s| !s.is_empty()),
+            "a blocked mass deletion must persist a durable pause flag"
         );
 
-        // User reviews and confirms → the next scan propagates the deletions.
+        // User reviews and confirms → the next scan propagates the deletions AND
+        // clears the pause flag.
         state
             .db
             .set_app_config("mass_delete_override_once", "1")
@@ -1627,6 +1665,15 @@ mod tests {
             job_targets(&state, "delete").len(),
             30,
             "an explicit override lets the reviewed batch through"
+        );
+        assert!(
+            state
+                .db
+                .get_app_config("mass_delete_blocked")
+                .unwrap()
+                .unwrap_or_default()
+                .is_empty(),
+            "overriding the batch must clear the pause flag"
         );
     }
 }

--- a/apps/desktop/src-tauri/src/sync_pipeline.rs
+++ b/apps/desktop/src-tauri/src/sync_pipeline.rs
@@ -378,6 +378,61 @@ fn enqueue_targeted_deletions(
     Ok(enqueued)
 }
 
+/// Mass-deletion circuit breaker thresholds (DBSYNC-64). A single scan pass that
+/// would propagate at least `MASS_DELETE_ABSOLUTE` deletions, OR at least
+/// `MASS_DELETE_FRACTION_PERCENT`% of the tracked set (guarded by a small floor so a
+/// tiny repo isn't over-eager), is treated as a likely bug / CfAPI eviction / drive
+/// hiccup rather than an intentional bulk delete — and is BLOCKED pending an explicit
+/// user override. No sync client should ever nuke hundreds of files (local OR remote)
+/// from a single reconcile without a sanity check.
+const MASS_DELETE_ABSOLUTE: usize = 200;
+const MASS_DELETE_FRACTION_FLOOR: usize = 25;
+const MASS_DELETE_FRACTION_PERCENT: usize = 10;
+
+/// One-shot app_config flag the user sets (via `confirm_pending_deletions`) to let
+/// the next mass deletion through.
+const MASS_DELETE_OVERRIDE_KEY: &str = "mass_delete_override_once";
+
+/// True if this many deletion candidates out of `tracked` tracked entries looks like
+/// a catastrophe rather than an intentional bulk delete.
+pub(crate) fn is_mass_deletion(candidates: usize, tracked: usize) -> bool {
+    if candidates >= MASS_DELETE_ABSOLUTE {
+        return true;
+    }
+    candidates >= MASS_DELETE_FRACTION_FLOOR
+        && candidates.saturating_mul(100) >= tracked.saturating_mul(MASS_DELETE_FRACTION_PERCENT)
+}
+
+/// Returns true (and CONSUMES the one-shot flag) if the user has explicitly
+/// authorized the next mass deletion to proceed.
+fn consume_mass_delete_override(state: &AppState) -> AppResult<bool> {
+    if state.db.get_app_config(MASS_DELETE_OVERRIDE_KEY)?.as_deref() == Some("1") {
+        state.db.set_app_config(MASS_DELETE_OVERRIDE_KEY, "0")?;
+        tracing::warn!("mass-deletion override consumed: allowing this deletion batch");
+        return Ok(true);
+    }
+    Ok(false)
+}
+
+/// Block a suspicious mass deletion: propagate NONE of it, log loudly, notify, and
+/// surface a sticky error so the UI shows sync is paused (DBSYNC-64).
+fn block_mass_deletion(state: &AppState, candidates: usize, tracked: usize) {
+    let msg = format!(
+        "Sync paused: {candidates} deletions in one pass ({tracked} tracked) look like a bug \
+         or missing files, not an intentional delete — nothing was deleted. Review, then \
+         confirm to proceed."
+    );
+    tracing::error!(
+        candidates,
+        tracked,
+        "MASS-DELETION BLOCKED by circuit breaker; no deletions propagated (DBSYNC-64)"
+    );
+    if let Ok(mut engine) = state.sync_engine.lock() {
+        engine.set_last_error(msg.clone());
+    }
+    crate::sharing::notify("DropboxSync - sync paused", &msg);
+}
+
 pub(crate) fn scan_local_changes_internal(state: &AppState) -> AppResult<usize> {
     let folder = state
         .db
@@ -452,22 +507,6 @@ pub(crate) fn scan_local_changes_internal(state: &AppState) -> AppResult<usize> 
         )?;
     }
 
-    // Only propagate FILE deletions when we trust the walk was complete.
-    if !walk_had_error {
-        for prev in known {
-            if prev.relative_path.ends_with(".cloudsc") {
-                continue;
-            }
-            if is_ignored_local_path(&prev.relative_path) {
-                continue;
-            }
-            if !seen_paths.contains(&prev.relative_path) {
-                enqueued_jobs +=
-                    process_local_file_deletion(state, &tracked_root, &prev.relative_path)?;
-            }
-        }
-    }
-
     // Track real (materialized) directories so a folder deletion — which has no
     // file content to diff — can still be detected: any previously-known folder
     // that is no longer present on disk must have been deleted locally, so its
@@ -505,20 +544,47 @@ pub(crate) fn scan_local_changes_internal(state: &AppState) -> AppResult<usize> 
         state.db.upsert_known_folder(&relative)?;
     }
 
-    // Only propagate FOLDER deletions (recursive remote delete) when the dir
-    // walk was fully readable — a partial walk must never be treated as a batch
-    // of deletions.
+    // ── Deletion propagation + mass-deletion circuit breaker (DBSYNC-64) ────────
+    // Only propagate deletions when BOTH walks were fully readable — a partial walk
+    // must never be treated as a batch of deletions. Collect the FILE and FOLDER
+    // deletion candidates FIRST (don't enqueue yet); if a single pass would delete a
+    // suspicious number of them, a bug / CfAPI eviction / drive hiccup likely made
+    // real files look absent — block the whole batch (nothing enqueued), alert, and
+    // require an explicit user override, instead of nuking the user's Dropbox.
+    //
+    // Ignored/temp-named folders are excluded: they're skipped by the walk (never in
+    // `seen_dirs`), and a stale row from an older build would otherwise trigger a
+    // RECURSIVE remote delete of a folder that still exists (DBSYNC-55).
     if !walk_had_error {
-        for rel in state.db.list_known_folders()? {
-            // Never propagate a "deletion" for an ignored/temp-named folder: it is
-            // skipped by the walk above (so never in `seen_dirs`), and a stale row
-            // from an older build would otherwise trigger a RECURSIVE remote delete
-            // of a folder that still exists (DBSYNC-55).
-            if is_ignored_local_path(&rel) {
-                continue;
+        let file_deletions: Vec<String> = known
+            .iter()
+            .map(|f| f.relative_path.clone())
+            .filter(|rel| {
+                !rel.ends_with(".cloudsc")
+                    && !is_ignored_local_path(rel)
+                    && !seen_paths.contains(rel)
+            })
+            .collect();
+        let folder_deletions: Vec<String> = state
+            .db
+            .list_known_folders()?
+            .into_iter()
+            .filter(|rel| !is_ignored_local_path(rel) && !seen_dirs.contains(rel))
+            .collect();
+
+        let candidate_count = file_deletions.len() + folder_deletions.len();
+        let tracked_count = known.len() + seen_dirs.len();
+
+        if is_mass_deletion(candidate_count, tracked_count)
+            && !consume_mass_delete_override(state)?
+        {
+            block_mass_deletion(state, candidate_count, tracked_count);
+        } else {
+            for rel in &file_deletions {
+                enqueued_jobs += process_local_file_deletion(state, &tracked_root, rel)?;
             }
-            if !seen_dirs.contains(&rel) {
-                enqueued_jobs += process_known_folder_deletion(state, &tracked_root, &rel)?;
+            for rel in &folder_deletions {
+                enqueued_jobs += process_known_folder_deletion(state, &tracked_root, rel)?;
             }
         }
     }
@@ -943,8 +1009,9 @@ mod tests {
     use tempfile::tempdir;
 
     use super::{
-        cleanup_stale_upload_state, process_changed_paths, resolve_conflict_internal,
-        run_sync_tick_internal, ConflictAction, SYNC_BATCH_CAP,
+        cleanup_stale_upload_state, is_mass_deletion, process_changed_paths,
+        resolve_conflict_internal, run_sync_tick_internal, scan_local_changes_internal,
+        ConflictAction, SYNC_BATCH_CAP,
     };
     use crate::state::AppState;
     use crate::storage::db::Db;
@@ -1499,5 +1566,67 @@ mod tests {
         resolve_conflict_internal(&state, id, ConflictAction::UseRemote).unwrap();
 
         assert_eq!(unresolved_count(&state), 0);
+    }
+
+    // ── DBSYNC-64: mass-deletion circuit breaker ─────────────────────────────
+
+    #[test]
+    fn is_mass_deletion_thresholds() {
+        assert!(is_mass_deletion(200, 100_000), "absolute limit trips regardless of fraction");
+        assert!(is_mass_deletion(30, 100), ">= floor and >= 10% of tracked");
+        assert!(!is_mass_deletion(24, 100), "below the absolute floor");
+        assert!(!is_mass_deletion(30, 1000), "3% is under the 10% fraction");
+        assert!(!is_mass_deletion(0, 0), "nothing to delete");
+    }
+
+    #[test]
+    fn scan_blocks_mass_deletion_until_overridden() {
+        let tmp = tempdir().expect("tempdir");
+        let state = build_state(tmp.path());
+        // 30 tracked files that no longer exist on disk → 30 deletion candidates.
+        for i in 0..30 {
+            state
+                .db
+                .upsert_local_file(&format!("f{i}.txt"), "h", 1, 1)
+                .unwrap();
+        }
+
+        // First scan: the batch is a mass deletion → BLOCKED. Nothing propagated,
+        // index rows kept, a sticky error surfaced. (The scan's later remote-refresh
+        // step errors here with no token, but the deletion decision runs BEFORE it,
+        // so its side effects are already committed — ignore the Result and assert
+        // those.)
+        let _ = scan_local_changes_internal(&state);
+        assert!(
+            job_targets(&state, "delete").is_empty(),
+            "a mass deletion must be blocked — no remote deletes enqueued"
+        );
+        assert_eq!(
+            state.db.list_local_files().unwrap().len(),
+            30,
+            "blocked deletion must NOT drop the index rows"
+        );
+        assert!(
+            state
+                .sync_engine
+                .lock()
+                .unwrap()
+                .current_status(false)
+                .last_error
+                .is_some(),
+            "a blocked mass deletion must surface a sticky error"
+        );
+
+        // User reviews and confirms → the next scan propagates the deletions.
+        state
+            .db
+            .set_app_config("mass_delete_override_once", "1")
+            .unwrap();
+        let _ = scan_local_changes_internal(&state);
+        assert_eq!(
+            job_targets(&state, "delete").len(),
+            30,
+            "an explicit override lets the reviewed batch through"
+        );
     }
 }


### PR DESCRIPTION
## Summary
**Emergency data-safety net** (part 1 of #DBSYNC-64) after a data-loss incident where the local scan propagated **612 remote deletes + 334 local deletes** of real files that had vanished from disk via a failing CfAPI placeholder op — no existing guard caught the batch.

The full local scan (`scan_local_changes_internal`) now collects FILE and FOLDER deletion candidates **before enqueuing any**, and if a single pass would delete a suspicious number:
- **>= 200 absolute**, OR
- **>= 10% of the tracked set** (above a 25-item floor)

…it **BLOCKS the whole batch**: nothing enqueued, index rows kept, a **sticky error** surfaced, and an **OS notification** fired. No sync client should delete hundreds of files from one reconcile without a sanity check — this would have prevented the incident **regardless of the CfAPI root cause**.

To proceed with a genuine bulk delete, the user explicitly confirms via the new **`confirm_pending_deletions`** command (one-shot override consumed by the next scan).

## Stack
desktop-tauri

## Jira Ticket
DBSYNC-64 (data-loss). This is **part 1** (the safety net). Remaining on the ticket: the remote-reconcile → local-delete direction needs the same breaker, plus the deeper CfAPI root cause (atomic dehydration; extend the delete-suppression guard to native CfAPI placeholders).

## Test Plan
- [x] `cargo test --lib` 138 pass (new: `is_mass_deletion` thresholds + `scan_blocks_mass_deletion_until_overridden` — 30 tracked files gone → blocked, index kept, error set; override → batch let through), `cargo clippy --lib` clean
- [ ] Live (test account, disposable folder): induce a bulk local absence → confirm sync pauses with the alert and nothing is deleted; confirm the override lets a genuine bulk delete through.

## Notes
- Threshold rationale: the incident deleted ~10% of ~9100 tracked files; both the 10% fraction and the 200 absolute rules catch it.
- The block sets a sticky engine error (tray shows Error) + notifies; the frontend confirm button is a follow-up (the `confirm_pending_deletions` command exists now).

🤖 Generated with Claude Code
https://claude.ai/code/session_016NTD4Qhq5ygTiGwrPoVEqB