### PR TITLE
fix(sync): mass-delete circuit breaker on the remote-sweep local-delete direction (#DBSYNC-64)

### DIFF
--- a/apps/desktop/src-tauri/src/remote_index.rs
+++ b/apps/desktop/src-tauri/src/remote_index.rs
@@ -253,50 +253,14 @@ pub(crate) fn refresh_remote_index_and_enqueue_downloads_internal(
     }
 
     let (remote_by_path, _cursor) = fetch_all_remote_file_metadata(state)?;
-
     let pending_targets = pending_job_targets(state)?;
 
-    let mut enqueued = 0usize;
-
-    // PRESENT files: reconcile immediately, same as before — never gated by the
-    // breaker (it only guards inferred deletions).
-    for local in &local_files {
-        let rel = &local.relative_path;
-        if rel.ends_with(".cloudsc") || pending_targets.contains(rel) {
-            continue;
-        }
-        if let Some(remote_meta) = remote_by_path.get(&normalize_dropbox_path(rel)?.to_lowercase())
-        {
-            enqueued += reconcile_remote_present(state, rel, remote_meta)?;
-        }
-    }
-
-    // ABSENT files + mass-deletion circuit breaker, remote→local direction
-    // (DBSYNC-64 extension). A full sweep INFERS "deleted remotely" from a path's
-    // absence in this snapshot; unlike the cursor-delta's explicit `.tag=="deleted"`
-    // entries (apply_remote_delta, always authoritative and never gated here), a
-    // wrong/incomplete snapshot would misclassify still-present files as absent and
-    // mass-delete local copies. So: compute how many of the absent files would
-    // actually enqueue a `local_delete` (an unmodified local copy — a diverged one
-    // becomes a conflict, never a delete, so it doesn't count), and block the whole
-    // absent batch this pass if that looks like a catastrophe rather than an
-    // intentional bulk delete. PRESENT files above are unaffected either way.
-    let (absent, delete_candidates) =
-        remote_sweep_delete_candidates(state, &local_files, &remote_by_path, &pending_targets)?;
-    let tracked = local_files.len();
-
-    let overridden =
-        delete_candidates > 0 && crate::sync_pipeline::consume_mass_delete_override(state)?;
-
-    if crate::sync_pipeline::is_mass_deletion(delete_candidates, tracked) && !overridden {
-        crate::sync_pipeline::block_mass_deletion(state, delete_candidates, tracked);
-    } else {
-        // Not a mass deletion this pass (or the user overrode it) → sync isn't paused.
-        crate::sync_pipeline::clear_mass_delete_blocked(state);
-        for rel in &absent {
-            enqueued += reconcile_remote_absent(state, rel)?;
-        }
-    }
+    let enqueued = reconcile_remote_snapshot_with_breaker(
+        state,
+        &local_files,
+        &remote_by_path,
+        &pending_targets,
+    )?;
 
     // Summarise a remote-index refresh that enqueued work (DBSYNC-47); a no-op
     // refresh stays silent so the periodic sweep doesn't spam the log.
@@ -309,12 +273,80 @@ pub(crate) fn refresh_remote_index_and_enqueue_downloads_internal(
     Ok(enqueued)
 }
 
-/// Pure decision helper for the full-sweep half of the DBSYNC-64 mass-deletion
-/// circuit breaker (remote→local direction): given the local index and a fetched
-/// remote snapshot, returns the relative paths ABSENT from the remote (candidates
-/// for `reconcile_remote_absent`) alongside how many of them would actually
-/// enqueue a `local_delete` — i.e. the local copy still matches the last-synced
-/// remote content (`get_remote_file(rel).content_hash == local.hash`), exactly the
+/// Reconciles a fetched remote snapshot against the local index, gating inferred
+/// deletions behind the DBSYNC-64 mass-deletion circuit breaker (remote→local
+/// direction). PRESENT files are reconciled immediately and are NEVER gated (the
+/// breaker only guards inferred deletions). For ABSENT files: a full snapshot
+/// INFERS "deleted remotely" from a path's absence, unlike the cursor-delta's
+/// explicit `.tag=="deleted"` entries (`apply_remote_delta`, always authoritative
+/// and never gated) — so a wrong/incomplete snapshot could misclassify
+/// still-present files as absent and mass-delete local copies. This computes how
+/// many absent files would actually enqueue a `local_delete` (an unmodified local
+/// copy — a diverged one becomes a conflict, never a delete, so it doesn't count)
+/// and blocks the WHOLE absent batch this pass if that looks like a catastrophe
+/// rather than an intentional bulk delete.
+///
+/// Shared by BOTH remote-snapshot callers that reconcile against the full local
+/// index — the periodic full sweep
+/// (`refresh_remote_index_and_enqueue_downloads_internal`) and
+/// `seed_remote_delta_cursor` — so the cursor-reset re-snapshot path (which runs
+/// with the full local index still intact) gets the exact same guard as the
+/// periodic sweep (DBSYNC-64 CTO fix). Returns jobs enqueued.
+fn reconcile_remote_snapshot_with_breaker(
+    state: &AppState,
+    local_files: &[FileIndexRow],
+    remote_by_path: &HashMap<String, RemoteFileMeta>,
+    pending_targets: &HashSet<String>,
+) -> AppResult<usize> {
+    let mut enqueued = 0usize;
+
+    // PRESENT files: reconcile immediately, never gated by the breaker.
+    for local in local_files {
+        let rel = &local.relative_path;
+        if rel.ends_with(".cloudsc") || pending_targets.contains(rel) {
+            continue;
+        }
+        if let Some(remote_meta) = remote_by_path.get(&normalize_dropbox_path(rel)?.to_lowercase())
+        {
+            enqueued += reconcile_remote_present(state, rel, remote_meta)?;
+        }
+    }
+
+    // ABSENT files + mass-deletion circuit breaker.
+    let (absent, delete_candidates) =
+        remote_sweep_delete_candidates(state, local_files, remote_by_path, pending_targets)?;
+    let tracked = local_files.len();
+
+    let overridden =
+        delete_candidates > 0 && crate::sync_pipeline::consume_mass_delete_override(state)?;
+
+    if crate::sync_pipeline::is_mass_deletion(delete_candidates, tracked) && !overridden {
+        crate::sync_pipeline::block_mass_deletion(
+            state,
+            delete_candidates,
+            tracked,
+            crate::sync_pipeline::MassDeleteSource::RemoteSweep,
+        );
+    } else {
+        // Not a mass deletion this pass (or the user overrode it) → sync isn't paused.
+        crate::sync_pipeline::clear_mass_delete_blocked(
+            state,
+            crate::sync_pipeline::MassDeleteSource::RemoteSweep,
+        );
+        for rel in &absent {
+            enqueued += reconcile_remote_absent(state, rel)?;
+        }
+    }
+
+    Ok(enqueued)
+}
+
+/// Pure decision helper for the DBSYNC-64 mass-deletion circuit breaker
+/// (remote→local direction): given the local index and a fetched remote snapshot,
+/// returns the relative paths ABSENT from the remote (candidates for
+/// `reconcile_remote_absent`) alongside how many of them would actually enqueue a
+/// `local_delete` — i.e. the local copy still matches the last-synced remote
+/// content (`get_remote_file(rel).content_hash == local.hash`), exactly the
 /// condition `reconcile_remote_absent` itself uses. A diverged local file becomes a
 /// conflict instead of a delete, so it is intentionally NOT counted as a
 /// mass-delete candidate. No network I/O — takes the already-fetched snapshot, so
@@ -337,11 +369,12 @@ fn remote_sweep_delete_candidates(
             continue; // present — handled by the caller's other loop.
         }
 
+        // `local` is already the `FileIndexRow` for `rel` from `list_local_files`,
+        // so its `.hash` is the current local content — no need to re-fetch it via
+        // `get_local_file` (DBSYNC-64 review nit).
         if let Some(prev) = state.db.get_remote_file(rel)? {
-            if let Some(local_row) = state.db.get_local_file(rel)? {
-                if local_row.hash == prev.content_hash {
-                    delete_candidates += 1;
-                }
+            if local.hash == prev.content_hash {
+                delete_candidates += 1;
             }
         }
         absent.push(rel.clone());
@@ -434,26 +467,28 @@ pub(crate) fn reconcile_remote_absent(state: &AppState, rel: &str) -> AppResult<
 /// and persist the resulting cursor as the seed for cursor-delta longpoll. The
 /// cursor MUST come from this same sweep so it points at exactly the state the
 /// index now reflects (not a later `get_latest_cursor`). Returns the cursor.
+///
+/// DBSYNC-64 (CTO fix): this reconciles against the SAME kind of absence-inferred
+/// snapshot as the periodic full sweep, and it is reachable with a FULL local
+/// index intact — not just on first login/after `reset_sync_state` (which wipes
+/// `local_file_index` first, so an empty index makes the breaker a no-op there),
+/// but also via the Dropbox cursor-RESET path: `apply_remote_delta` catches a
+/// `reset` error, clears only the cursor, and calls this function while
+/// `local_file_index` is untouched. A wrong/short snapshot on that path would
+/// otherwise mass-delete local files ungated — so this goes through the exact
+/// same `reconcile_remote_snapshot_with_breaker` gate as the periodic sweep.
 pub(crate) fn seed_remote_delta_cursor(state: &AppState) -> AppResult<String> {
     let (remote_by_path, cursor) = fetch_all_remote_file_metadata(state)?;
 
     let local_files = state.db.list_local_files()?;
     if !local_files.is_empty() {
         let pending_targets = pending_job_targets(state)?;
-        for local in local_files {
-            let rel = local.relative_path;
-            if rel.ends_with(".cloudsc") || pending_targets.contains(&rel) {
-                continue;
-            }
-            match remote_by_path.get(&normalize_dropbox_path(&rel)?.to_lowercase()) {
-                Some(meta) => {
-                    reconcile_remote_present(state, &rel, meta)?;
-                }
-                None => {
-                    reconcile_remote_absent(state, &rel)?;
-                }
-            }
-        }
+        reconcile_remote_snapshot_with_breaker(
+            state,
+            &local_files,
+            &remote_by_path,
+            &pending_targets,
+        )?;
     }
 
     state
@@ -878,6 +913,89 @@ mod tests {
             "neither absent file matches the diverged/never-indexed exclusion rules"
         );
         assert!(!is_mass_deletion(delete_candidates, local_files.len()));
+    }
+
+    #[test]
+    fn reconcile_remote_snapshot_with_breaker_blocks_then_proceeds_on_override() {
+        // Regression coverage for the CTO fix: `seed_remote_delta_cursor` (reached
+        // via the cursor-reset path with a FULL local index intact, per
+        // `apply_remote_delta`'s "reset" branch) and the periodic full sweep both
+        // funnel through this exact function — so this test exercises the shared
+        // gate both callers now get, without needing to mock the network calls
+        // inside either caller.
+        let state = build_state();
+        for i in 0..30 {
+            let rel = format!("g{i}.txt");
+            state.db.upsert_remote_file(&rel, "H", "rev", 0).unwrap();
+            state.db.upsert_local_file(&rel, "H", 3, 0).unwrap();
+        }
+        let local_files = state.db.list_local_files().unwrap();
+        assert_eq!(local_files.len(), 30);
+
+        let remote_by_path: HashMap<String, RemoteFileMeta> = HashMap::new();
+        let pending_targets: HashSet<String> = HashSet::new();
+
+        // First pass: 30/30 absent+matching → BLOCKED. Nothing enqueued/deleted,
+        // and the REMOTE-direction pause flag (not the scan one) is set.
+        let enqueued = reconcile_remote_snapshot_with_breaker(
+            &state,
+            &local_files,
+            &remote_by_path,
+            &pending_targets,
+        )
+        .unwrap();
+        assert_eq!(enqueued, 0, "a blocked mass deletion enqueues nothing");
+        assert!(
+            job_targets(&state, "local_delete").is_empty(),
+            "a mass deletion must be blocked — no local_delete jobs enqueued"
+        );
+        assert_eq!(
+            state.db.list_local_files().unwrap().len(),
+            30,
+            "blocked deletion must NOT drop the index rows"
+        );
+        assert!(
+            state
+                .db
+                .get_app_config("mass_delete_blocked_remote")
+                .unwrap()
+                .is_some_and(|s| !s.is_empty()),
+            "a blocked remote-sweep mass deletion must persist the REMOTE durable pause flag"
+        );
+        assert!(
+            state
+                .db
+                .get_app_config("mass_delete_blocked_scan")
+                .unwrap()
+                .unwrap_or_default()
+                .is_empty(),
+            "the remote sweep must never touch the local-scan pause flag"
+        );
+
+        // User confirms → the override lets this batch of 30 through, and clears
+        // the remote pause flag.
+        state
+            .db
+            .set_app_config("mass_delete_override_once", "1")
+            .unwrap();
+        let enqueued = reconcile_remote_snapshot_with_breaker(
+            &state,
+            &local_files,
+            &remote_by_path,
+            &pending_targets,
+        )
+        .unwrap();
+        assert_eq!(enqueued, 30, "an explicit override lets the reviewed batch through");
+        assert_eq!(job_targets(&state, "local_delete").len(), 30);
+        assert!(
+            state
+                .db
+                .get_app_config("mass_delete_blocked_remote")
+                .unwrap()
+                .unwrap_or_default()
+                .is_empty(),
+            "overriding the batch must clear the remote pause flag"
+        );
     }
 
     #[test]

--- a/apps/desktop/src-tauri/src/remote_index.rs
+++ b/apps/desktop/src-tauri/src/remote_index.rs
@@ -7,6 +7,7 @@ use crate::error::{AppError, AppResult};
 use crate::models::{DropboxEntry, DropboxListFolderResponse};
 use crate::path_util::normalize_dropbox_path;
 use crate::state::AppState;
+use crate::storage::db::FileIndexRow;
 
 #[derive(Clone, Debug, PartialEq)]
 pub(crate) struct RemoteFileMeta {
@@ -203,6 +204,12 @@ pub(crate) fn fetch_all_remote_file_metadata(
             .map_err(|e| AppError::Other(format!("list_folder parse failed: {e}")))?
     };
 
+    // Pagination completeness (mass-delete safety, see doc comment above): this loop
+    // only exits via `break` after a page with `has_more == false`. Every
+    // `list_folder/continue` call above is guarded by `?` on both the HTTP request and
+    // the JSON parse, so a failure on any page propagates as `Err` and unwinds out of
+    // this function — the caller never receives a map that silently stops short of the
+    // full snapshot.
     loop {
         for entry in &entries_resp.entries {
             if let Some((path_key, meta)) = remote_meta_from_entry(entry) {
@@ -250,15 +257,44 @@ pub(crate) fn refresh_remote_index_and_enqueue_downloads_internal(
     let pending_targets = pending_job_targets(state)?;
 
     let mut enqueued = 0usize;
-    for local in local_files {
-        let rel = local.relative_path;
-        if rel.ends_with(".cloudsc") || pending_targets.contains(&rel) {
+
+    // PRESENT files: reconcile immediately, same as before — never gated by the
+    // breaker (it only guards inferred deletions).
+    for local in &local_files {
+        let rel = &local.relative_path;
+        if rel.ends_with(".cloudsc") || pending_targets.contains(rel) {
             continue;
         }
+        if let Some(remote_meta) = remote_by_path.get(&normalize_dropbox_path(rel)?.to_lowercase())
+        {
+            enqueued += reconcile_remote_present(state, rel, remote_meta)?;
+        }
+    }
 
-        match remote_by_path.get(&normalize_dropbox_path(&rel)?.to_lowercase()) {
-            Some(remote_meta) => enqueued += reconcile_remote_present(state, &rel, remote_meta)?,
-            None => enqueued += reconcile_remote_absent(state, &rel)?,
+    // ABSENT files + mass-deletion circuit breaker, remote→local direction
+    // (DBSYNC-64 extension). A full sweep INFERS "deleted remotely" from a path's
+    // absence in this snapshot; unlike the cursor-delta's explicit `.tag=="deleted"`
+    // entries (apply_remote_delta, always authoritative and never gated here), a
+    // wrong/incomplete snapshot would misclassify still-present files as absent and
+    // mass-delete local copies. So: compute how many of the absent files would
+    // actually enqueue a `local_delete` (an unmodified local copy — a diverged one
+    // becomes a conflict, never a delete, so it doesn't count), and block the whole
+    // absent batch this pass if that looks like a catastrophe rather than an
+    // intentional bulk delete. PRESENT files above are unaffected either way.
+    let (absent, delete_candidates) =
+        remote_sweep_delete_candidates(state, &local_files, &remote_by_path, &pending_targets)?;
+    let tracked = local_files.len();
+
+    let overridden =
+        delete_candidates > 0 && crate::sync_pipeline::consume_mass_delete_override(state)?;
+
+    if crate::sync_pipeline::is_mass_deletion(delete_candidates, tracked) && !overridden {
+        crate::sync_pipeline::block_mass_deletion(state, delete_candidates, tracked);
+    } else {
+        // Not a mass deletion this pass (or the user overrode it) → sync isn't paused.
+        crate::sync_pipeline::clear_mass_delete_blocked(state);
+        for rel in &absent {
+            enqueued += reconcile_remote_absent(state, rel)?;
         }
     }
 
@@ -271,6 +307,47 @@ pub(crate) fn refresh_remote_index_and_enqueue_downloads_internal(
         );
     }
     Ok(enqueued)
+}
+
+/// Pure decision helper for the full-sweep half of the DBSYNC-64 mass-deletion
+/// circuit breaker (remote→local direction): given the local index and a fetched
+/// remote snapshot, returns the relative paths ABSENT from the remote (candidates
+/// for `reconcile_remote_absent`) alongside how many of them would actually
+/// enqueue a `local_delete` — i.e. the local copy still matches the last-synced
+/// remote content (`get_remote_file(rel).content_hash == local.hash`), exactly the
+/// condition `reconcile_remote_absent` itself uses. A diverged local file becomes a
+/// conflict instead of a delete, so it is intentionally NOT counted as a
+/// mass-delete candidate. No network I/O — takes the already-fetched snapshot, so
+/// it's unit-testable independent of `fetch_all_remote_file_metadata`.
+fn remote_sweep_delete_candidates(
+    state: &AppState,
+    local_files: &[FileIndexRow],
+    remote_by_path: &HashMap<String, RemoteFileMeta>,
+    pending_targets: &HashSet<String>,
+) -> AppResult<(Vec<String>, usize)> {
+    let mut absent = Vec::new();
+    let mut delete_candidates = 0usize;
+
+    for local in local_files {
+        let rel = &local.relative_path;
+        if rel.ends_with(".cloudsc") || pending_targets.contains(rel) {
+            continue;
+        }
+        if remote_by_path.contains_key(&normalize_dropbox_path(rel)?.to_lowercase()) {
+            continue; // present — handled by the caller's other loop.
+        }
+
+        if let Some(prev) = state.db.get_remote_file(rel)? {
+            if let Some(local_row) = state.db.get_local_file(rel)? {
+                if local_row.hash == prev.content_hash {
+                    delete_candidates += 1;
+                }
+            }
+        }
+        absent.push(rel.clone());
+    }
+
+    Ok((absent, delete_candidates))
 }
 
 /// The set of relative paths with an in-flight job, so we don't enqueue a
@@ -491,6 +568,7 @@ pub(crate) fn apply_remote_delta(state: &AppState) -> AppResult<usize> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::sync_pipeline::{consume_mass_delete_override, is_mass_deletion};
 
     fn file_entry(
         path_display: Option<&str>,
@@ -704,6 +782,102 @@ mod tests {
         let n = reconcile_remote_present(&state, "f.txt", &meta).unwrap();
         assert_eq!(n, 0);
         assert!(job_targets(&state, "download").is_empty());
+    }
+
+    // ── DBSYNC-64: mass-deletion circuit breaker, remote→local (sweep) ─────────
+
+    #[test]
+    fn remote_sweep_delete_candidates_flags_matching_absent_files_as_mass_delete() {
+        let state = build_state();
+        // 30 tracked files, each with a local copy matching the last-synced remote
+        // hash, and NONE present in this sweep's remote snapshot → all 30 are
+        // `local_delete` candidates.
+        for i in 0..30 {
+            let rel = format!("f{i}.txt");
+            state.db.upsert_remote_file(&rel, "H", "rev", 0).unwrap();
+            state.db.upsert_local_file(&rel, "H", 3, 0).unwrap();
+        }
+        let local_files = state.db.list_local_files().unwrap();
+        assert_eq!(local_files.len(), 30);
+
+        let remote_by_path: HashMap<String, RemoteFileMeta> = HashMap::new();
+        let pending_targets: HashSet<String> = HashSet::new();
+
+        let (absent, delete_candidates) =
+            remote_sweep_delete_candidates(&state, &local_files, &remote_by_path, &pending_targets)
+                .unwrap();
+
+        assert_eq!(absent.len(), 30, "every tracked file is absent from the snapshot");
+        assert_eq!(delete_candidates, 30, "every absent file matches its last-synced hash");
+        assert!(
+            is_mass_deletion(delete_candidates, local_files.len()),
+            "30/30 candidates must trip the breaker"
+        );
+
+        // Not overridden yet.
+        assert!(!consume_mass_delete_override(&state).unwrap());
+
+        // User confirms → the one-shot override lets the batch proceed, then is
+        // consumed (a second check reads false again).
+        state
+            .db
+            .set_app_config("mass_delete_override_once", "1")
+            .unwrap();
+        assert!(consume_mass_delete_override(&state).unwrap());
+        assert!(!consume_mass_delete_override(&state).unwrap());
+    }
+
+    #[test]
+    fn remote_sweep_delete_candidates_excludes_diverged_files_and_present_files() {
+        let state = build_state();
+
+        // Diverged local copy: absent from remote, but local hash no longer matches
+        // the last-synced remote hash → NOT a delete candidate (becomes a conflict
+        // via reconcile_remote_absent, never counted toward the breaker).
+        state.db.upsert_remote_file("diverged.txt", "H", "rev", 0).unwrap();
+        state.db.upsert_local_file("diverged.txt", "DIFFERENT", 3, 0).unwrap();
+
+        // Never indexed remotely: absent from the snapshot, but there's no prior
+        // remote row, so it can't be a remote-wins delete either.
+        state.db.upsert_local_file("never_indexed.txt", "H", 3, 0).unwrap();
+
+        // Present in this sweep's snapshot: excluded from `absent` entirely.
+        state.db.upsert_remote_file("present.txt", "H", "rev", 0).unwrap();
+        state.db.upsert_local_file("present.txt", "H", 3, 0).unwrap();
+
+        // Pending job: skipped like `.cloudsc` files, even though it would
+        // otherwise be a clean delete candidate.
+        state.db.upsert_remote_file("pending.txt", "H", "rev", 0).unwrap();
+        state.db.upsert_local_file("pending.txt", "H", 3, 0).unwrap();
+
+        let local_files = state.db.list_local_files().unwrap();
+        let mut remote_by_path: HashMap<String, RemoteFileMeta> = HashMap::new();
+        remote_by_path.insert(
+            "/present.txt".to_string(),
+            RemoteFileMeta {
+                content_hash: "H".to_string(),
+                rev: "rev".to_string(),
+                modified_ts: 0,
+            },
+        );
+        let mut pending_targets: HashSet<String> = HashSet::new();
+        pending_targets.insert("pending.txt".to_string());
+
+        let (absent, delete_candidates) =
+            remote_sweep_delete_candidates(&state, &local_files, &remote_by_path, &pending_targets)
+                .unwrap();
+
+        let mut absent_sorted = absent.clone();
+        absent_sorted.sort();
+        assert_eq!(
+            absent_sorted,
+            vec!["diverged.txt".to_string(), "never_indexed.txt".to_string()]
+        );
+        assert_eq!(
+            delete_candidates, 0,
+            "neither absent file matches the diverged/never-indexed exclusion rules"
+        );
+        assert!(!is_mass_deletion(delete_candidates, local_files.len()));
     }
 
     #[test]

--- a/apps/desktop/src-tauri/src/sync_pipeline.rs
+++ b/apps/desktop/src-tauri/src/sync_pipeline.rs
@@ -418,7 +418,11 @@ pub(crate) fn is_mass_deletion(candidates: usize, tracked: usize) -> bool {
 
 /// Returns true (and CONSUMES the one-shot flag) if the user has explicitly
 /// authorized the next mass deletion to proceed.
-fn consume_mass_delete_override(state: &AppState) -> AppResult<bool> {
+///
+/// `pub(crate)`: shared with the remote sweep (`remote_index.rs`, DBSYNC-64
+/// remote→local extension) so both directions consume the same one-shot flag
+/// instead of each keeping their own.
+pub(crate) fn consume_mass_delete_override(state: &AppState) -> AppResult<bool> {
     if state.db.get_app_config(MASS_DELETE_OVERRIDE_KEY)?.as_deref() == Some("1") {
         state.db.set_app_config(MASS_DELETE_OVERRIDE_KEY, "0")?;
         tracing::warn!("mass-deletion override consumed: allowing this deletion batch");
@@ -430,7 +434,11 @@ fn consume_mass_delete_override(state: &AppState) -> AppResult<bool> {
 /// Block a suspicious mass deletion: propagate NONE of it, log loudly, notify, and
 /// persist a DURABLE "sync paused" flag so the UI keeps showing it every tick until
 /// the block clears (DBSYNC-64).
-fn block_mass_deletion(state: &AppState, candidates: usize, tracked: usize) {
+///
+/// `pub(crate)`: shared with the remote sweep (`remote_index.rs`) — the durable
+/// pause flag applies regardless of which direction (local scan or remote sweep)
+/// tripped the breaker.
+pub(crate) fn block_mass_deletion(state: &AppState, candidates: usize, tracked: usize) {
     let msg = format!(
         "Sync paused: {candidates} deletions in one pass ({tracked} tracked) look like a bug \
          or missing files, not an intentional delete — nothing was deleted. Review, then \
@@ -453,7 +461,9 @@ fn block_mass_deletion(state: &AppState, candidates: usize, tracked: usize) {
 
 /// Clear the durable mass-deletion pause flag — the situation resolved (no mass
 /// deletion this pass, or the user overrode it), so sync is no longer paused.
-fn clear_mass_delete_blocked(state: &AppState) {
+///
+/// `pub(crate)`: shared with the remote sweep (`remote_index.rs`).
+pub(crate) fn clear_mass_delete_blocked(state: &AppState) {
     if state
         .db
         .get_app_config(MASS_DELETE_BLOCKED_KEY)

--- a/apps/desktop/src-tauri/src/sync_pipeline.rs
+++ b/apps/desktop/src-tauri/src/sync_pipeline.rs
@@ -34,10 +34,21 @@ pub(crate) fn refresh_queue_depth_internal(state: &AppState) -> AppResult<()> {
     // job — so surface it here (with precedence over a transient job error) instead
     // of a bare `engine.set_last_error`, which this very function would then clear on
     // the next tick (the block enqueues no failed rows).
-    let paused = state
+    //
+    // Per-direction keys (CTO fix): the local scan and the remote sweep each have
+    // their OWN durable pause flag so a benign pass in one direction can't clobber
+    // the other's still-active pause message within the same tick (the remote sweep
+    // runs right after the local scan in `scan_local_changes_internal`). Surface
+    // whichever is set; the scan's message takes precedence if somehow both are.
+    let scan_paused = state
         .db
-        .get_app_config(MASS_DELETE_BLOCKED_KEY)?
+        .get_app_config(MASS_DELETE_BLOCKED_SCAN_KEY)?
         .filter(|s| !s.is_empty());
+    let remote_paused = state
+        .db
+        .get_app_config(MASS_DELETE_BLOCKED_REMOTE_KEY)?
+        .filter(|s| !s.is_empty());
+    let paused = scan_paused.or(remote_paused);
 
     let mut engine = state
         .sync_engine
@@ -398,13 +409,55 @@ const MASS_DELETE_FRACTION_FLOOR: usize = 25;
 const MASS_DELETE_FRACTION_PERCENT: usize = 10;
 
 /// One-shot app_config flag the user sets (via `confirm_pending_deletions`) to let
-/// the next mass deletion through.
+/// the next mass deletion through. Intentionally SHARED across both directions
+/// (known trade-off: confirming one also authorizes the other's next pass) rather
+/// than split per-direction — the local scan and remote sweep run back-to-back in
+/// the same tick, and splitting this one would just mean confirming twice.
 const MASS_DELETE_OVERRIDE_KEY: &str = "mass_delete_override_once";
 
-/// Durable app_config flag holding the "sync paused: mass deletion blocked" message.
+/// Durable app_config flag holding the "sync paused: mass deletion blocked" message
+/// for a LOCAL-SCAN-tripped breaker (DBSYNC-64: `scan_local_changes_internal`).
 /// Persisted (not a transient engine field) so `refresh_queue_depth_internal` keeps
 /// surfacing it every tick until the block clears. Empty string = not paused.
-const MASS_DELETE_BLOCKED_KEY: &str = "mass_delete_blocked";
+///
+/// Split from the remote-sweep key (CTO fix) because the local scan and the remote
+/// sweep both run within one `scan_local_changes_internal` call — a single shared
+/// key meant a benign remote sweep's `clear_mass_delete_blocked` would silently
+/// erase the local scan's still-active pause message from moments earlier.
+const MASS_DELETE_BLOCKED_SCAN_KEY: &str = "mass_delete_blocked_scan";
+
+/// Same as `MASS_DELETE_BLOCKED_SCAN_KEY`, but for the REMOTE-SWEEP direction:
+/// `remote_index.rs`'s full sweep (`refresh_remote_index_and_enqueue_downloads_internal`)
+/// and `seed_remote_delta_cursor` (reached via the cursor-reset path with a full
+/// local index still intact).
+const MASS_DELETE_BLOCKED_REMOTE_KEY: &str = "mass_delete_blocked_remote";
+
+/// Which direction tripped the mass-deletion circuit breaker (DBSYNC-64), so
+/// `block_mass_deletion`/`clear_mass_delete_blocked` write/clear the right durable
+/// flag instead of a single shared one both directions could clobber.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum MassDeleteSource {
+    /// `scan_local_changes_internal`'s local→remote deletion detection.
+    LocalScan,
+    /// `remote_index.rs`'s remote→local sweep (full snapshot + cursor reseed).
+    RemoteSweep,
+}
+
+impl MassDeleteSource {
+    fn blocked_key(self) -> &'static str {
+        match self {
+            MassDeleteSource::LocalScan => MASS_DELETE_BLOCKED_SCAN_KEY,
+            MassDeleteSource::RemoteSweep => MASS_DELETE_BLOCKED_REMOTE_KEY,
+        }
+    }
+
+    fn label(self) -> &'static str {
+        match self {
+            MassDeleteSource::LocalScan => "local scan",
+            MassDeleteSource::RemoteSweep => "remote sweep",
+        }
+    }
+}
 
 /// True if this many deletion candidates out of `tracked` tracked entries looks like
 /// a catastrophe rather than an intentional bulk delete.
@@ -435,22 +488,29 @@ pub(crate) fn consume_mass_delete_override(state: &AppState) -> AppResult<bool> 
 /// persist a DURABLE "sync paused" flag so the UI keeps showing it every tick until
 /// the block clears (DBSYNC-64).
 ///
-/// `pub(crate)`: shared with the remote sweep (`remote_index.rs`) — the durable
-/// pause flag applies regardless of which direction (local scan or remote sweep)
-/// tripped the breaker.
-pub(crate) fn block_mass_deletion(state: &AppState, candidates: usize, tracked: usize) {
+/// `pub(crate)`: shared with the remote sweep (`remote_index.rs`) — `source`
+/// selects which direction's durable pause flag gets written so the two
+/// directions can't clobber each other's message.
+pub(crate) fn block_mass_deletion(
+    state: &AppState,
+    candidates: usize,
+    tracked: usize,
+    source: MassDeleteSource,
+) {
     let msg = format!(
-        "Sync paused: {candidates} deletions in one pass ({tracked} tracked) look like a bug \
-         or missing files, not an intentional delete — nothing was deleted. Review, then \
-         confirm to proceed."
+        "Sync paused: {candidates} deletions in one pass ({tracked} tracked, {}) look like a \
+         bug or missing files, not an intentional delete — nothing was deleted. Review, then \
+         confirm to proceed.",
+        source.label()
     );
     tracing::error!(
         candidates,
         tracked,
+        source = source.label(),
         "MASS-DELETION BLOCKED by circuit breaker; no deletions propagated (DBSYNC-64)"
     );
     // Durable so `refresh_queue_depth_internal` re-surfaces it instead of clearing it.
-    if let Err(e) = state.db.set_app_config(MASS_DELETE_BLOCKED_KEY, &msg) {
+    if let Err(e) = state.db.set_app_config(source.blocked_key(), &msg) {
         tracing::error!(error = %e, "failed to persist mass-deletion pause flag");
     }
     if let Ok(mut engine) = state.sync_engine.lock() {
@@ -459,19 +519,22 @@ pub(crate) fn block_mass_deletion(state: &AppState, candidates: usize, tracked: 
     crate::sharing::notify("DropboxSync - sync paused", &msg);
 }
 
-/// Clear the durable mass-deletion pause flag — the situation resolved (no mass
-/// deletion this pass, or the user overrode it), so sync is no longer paused.
+/// Clear the durable mass-deletion pause flag for `source` — that direction's
+/// situation resolved (no mass deletion this pass, or the user overrode it), so
+/// sync is no longer paused ON THAT ACCOUNT. The other direction's flag (if set)
+/// is left untouched — it's the other direction's job to clear its own.
 ///
 /// `pub(crate)`: shared with the remote sweep (`remote_index.rs`).
-pub(crate) fn clear_mass_delete_blocked(state: &AppState) {
+pub(crate) fn clear_mass_delete_blocked(state: &AppState, source: MassDeleteSource) {
+    let key = source.blocked_key();
     if state
         .db
-        .get_app_config(MASS_DELETE_BLOCKED_KEY)
+        .get_app_config(key)
         .ok()
         .flatten()
         .is_some_and(|s| !s.is_empty())
     {
-        let _ = state.db.set_app_config(MASS_DELETE_BLOCKED_KEY, "");
+        let _ = state.db.set_app_config(key, "");
     }
 }
 
@@ -623,10 +686,15 @@ pub(crate) fn scan_local_changes_internal(state: &AppState) -> AppResult<usize> 
         let overridden = candidate_count > 0 && consume_mass_delete_override(state)?;
 
         if is_mass_deletion(candidate_count, tracked_count) && !overridden {
-            block_mass_deletion(state, candidate_count, tracked_count);
+            block_mass_deletion(
+                state,
+                candidate_count,
+                tracked_count,
+                MassDeleteSource::LocalScan,
+            );
         } else {
             // Not a mass deletion (or the user confirmed) → sync is not paused.
-            clear_mass_delete_blocked(state);
+            clear_mass_delete_blocked(state, MassDeleteSource::LocalScan);
             for rel in &file_deletions {
                 enqueued_jobs += process_local_file_deletion(state, &tracked_root, rel)?;
             }
@@ -1056,9 +1124,10 @@ mod tests {
     use tempfile::tempdir;
 
     use super::{
-        cleanup_stale_upload_state, is_mass_deletion, process_changed_paths,
-        resolve_conflict_internal, run_sync_tick_internal, scan_local_changes_internal,
-        ConflictAction, SYNC_BATCH_CAP,
+        block_mass_deletion, cleanup_stale_upload_state, clear_mass_delete_blocked,
+        is_mass_deletion, process_changed_paths, resolve_conflict_internal,
+        run_sync_tick_internal, scan_local_changes_internal, ConflictAction, MassDeleteSource,
+        SYNC_BATCH_CAP,
     };
     use crate::state::AppState;
     use crate::storage::db::Db;
@@ -1658,7 +1727,7 @@ mod tests {
         assert!(
             state
                 .db
-                .get_app_config("mass_delete_blocked")
+                .get_app_config("mass_delete_blocked_scan")
                 .unwrap()
                 .is_some_and(|s| !s.is_empty()),
             "a blocked mass deletion must persist a durable pause flag"
@@ -1679,11 +1748,78 @@ mod tests {
         assert!(
             state
                 .db
-                .get_app_config("mass_delete_blocked")
+                .get_app_config("mass_delete_blocked_scan")
                 .unwrap()
                 .unwrap_or_default()
                 .is_empty(),
             "overriding the batch must clear the pause flag"
+        );
+    }
+
+    #[test]
+    fn per_direction_pause_flags_do_not_clobber_each_other() {
+        // CTO fix: the local scan and the remote sweep must each own a SEPARATE
+        // durable pause flag — clearing one direction's flag must never erase the
+        // other direction's still-active pause message from earlier in the tick.
+        let tmp = tempdir().expect("tempdir");
+        let state = build_state(tmp.path());
+
+        block_mass_deletion(&state, 40, 100, MassDeleteSource::LocalScan);
+        assert!(
+            state
+                .db
+                .get_app_config("mass_delete_blocked_scan")
+                .unwrap()
+                .is_some_and(|s| !s.is_empty()),
+            "local scan block must set the scan key"
+        );
+        assert!(
+            state
+                .db
+                .get_app_config("mass_delete_blocked_remote")
+                .unwrap()
+                .unwrap_or_default()
+                .is_empty(),
+            "local scan block must NOT touch the remote key"
+        );
+
+        // A benign remote sweep pass clears ONLY its own key.
+        clear_mass_delete_blocked(&state, MassDeleteSource::RemoteSweep);
+        assert!(
+            state
+                .db
+                .get_app_config("mass_delete_blocked_scan")
+                .unwrap()
+                .is_some_and(|s| !s.is_empty()),
+            "a remote-sweep clear must NOT erase the local scan's pause message"
+        );
+
+        // Now the remote sweep also blocks — both flags are set independently.
+        block_mass_deletion(&state, 50, 100, MassDeleteSource::RemoteSweep);
+        assert!(state
+            .db
+            .get_app_config("mass_delete_blocked_remote")
+            .unwrap()
+            .is_some_and(|s| !s.is_empty()));
+
+        // Clearing the scan side leaves the remote pause intact, and vice versa.
+        clear_mass_delete_blocked(&state, MassDeleteSource::LocalScan);
+        assert!(
+            state
+                .db
+                .get_app_config("mass_delete_blocked_scan")
+                .unwrap()
+                .unwrap_or_default()
+                .is_empty(),
+            "scan clear removes the scan flag"
+        );
+        assert!(
+            state
+                .db
+                .get_app_config("mass_delete_blocked_remote")
+                .unwrap()
+                .is_some_and(|s| !s.is_empty()),
+            "scan clear must leave the remote pause flag untouched"
         );
     }
 }


### PR DESCRIPTION
## Summary
Completes **part 1** of the DBSYNC-64 breaker — the **remote→local** direction (the 334 `local_delete`s in the incident).

The remote sweep (`refresh_remote_index_and_enqueue_downloads_internal`) enqueues `local_delete` for tracked local files absent from the remote snapshot; an incomplete/wrong snapshot mass-deletes local files. Now gated by the same breaker as the local scan.

- The 3 breaker primitives (`block_mass_deletion`, `consume_mass_delete_override`, `clear_mass_delete_blocked`) are made `pub(crate)` and **reused** (no duplication; same durable pause flag + one-shot override).
- New pure, unit-testable helper `remote_sweep_delete_candidates` → absent rels + the count that would actually `local_delete` (remote `content_hash == local hash`; a diverged file is a conflict, not a delete). If it trips `is_mass_deletion` and there's no override → the whole absent batch is skipped this sweep (nothing deleted) + pause/notify; present files still download.
- **Delta/longpoll path is deliberately NOT gated** — `.tag=="deleted"` entries are authoritative real deletes, not absence-inference.
- Confirmed `fetch_all_remote_file_metadata` fully paginates and errors on any page failure (never a silent partial snapshot).

## Stack
desktop-tauri

## Jira Ticket
DBSYNC-64 (part 1 completion — both scan directions now covered). Follow-up: `seed_remote_delta_cursor` does the same absence-inference and should get the same guard.

## Test Plan
- [x] `cargo test --lib` 144 pass (new: candidates-flagged-as-mass + diverged/present/pending excluded), `cargo clippy --lib` clean

🤖 Generated with Claude Code
https://claude.ai/code/session_016NTD4Qhq5ygTiGwrPoVEqB