### PR TITLE
feat(sync): confirm-deletions UI for the mass-delete circuit breaker (#DBSYNC-64)

### DIFF
--- a/apps/desktop/src-tauri/src/commands.rs
+++ b/apps/desktop/src-tauri/src/commands.rs
@@ -23,8 +23,8 @@ use crate::path_util::{parse_ignore_globs_csv, set_user_ignore_globs};
 use crate::state::AppState;
 use crate::sync::engine::SyncStatus;
 use crate::sync_pipeline::{
-    process_sync_queue_internal, refresh_queue_depth_internal, run_sync_tick_internal,
-    scan_local_changes_internal,
+    mass_delete_pause_active, process_sync_queue_internal, refresh_queue_depth_internal,
+    run_sync_tick_internal, scan_local_changes_internal,
 };
 
 #[tauri::command]
@@ -435,10 +435,13 @@ pub fn get_sync_dashboard(state: tauri::State<AppState>) -> Result<SyncDashboard
         .map_err(|_| "sync engine lock poisoned".to_string())?
         .current_status(state.sync_running.load(Ordering::Acquire));
 
+    let mass_delete_paused = mass_delete_pause_active(state.inner())?;
+
     Ok(SyncDashboard {
         status,
         jobs,
         conflicts,
+        mass_delete_paused,
     })
 }
 

--- a/apps/desktop/src-tauri/src/models.rs
+++ b/apps/desktop/src-tauri/src/models.rs
@@ -16,6 +16,11 @@ pub(crate) struct SyncDashboard {
     pub status: SyncStatus,
     pub jobs: Vec<SyncJobRow>,
     pub conflicts: Vec<ConflictRow>,
+    /// DBSYNC-64: true while the mass-deletion circuit breaker has paused sync
+    /// (either direction's durable `mass_delete_blocked_*` flag is set), so the
+    /// frontend can show a "review & confirm deletions" button that calls
+    /// `confirm_pending_deletions`. See `sync_pipeline::mass_delete_pause_active`.
+    pub mass_delete_paused: bool,
 }
 
 #[derive(Serialize)]

--- a/apps/desktop/src-tauri/src/sync_pipeline.rs
+++ b/apps/desktop/src-tauri/src/sync_pipeline.rs
@@ -538,6 +538,23 @@ pub(crate) fn clear_mass_delete_blocked(state: &AppState, source: MassDeleteSour
     }
 }
 
+/// True while EITHER direction's durable mass-deletion pause flag is set
+/// (DBSYNC-64), i.e. sync is currently paused pending `confirm_pending_deletions`.
+/// Shared by `refresh_queue_depth_internal`'s message surfacing and by
+/// `get_sync_dashboard`'s `massDeletePaused` flag, so the frontend can show a
+/// "review & confirm deletions" button without re-deriving the two key names.
+pub(crate) fn mass_delete_pause_active(state: &AppState) -> AppResult<bool> {
+    let scan_paused = state
+        .db
+        .get_app_config(MASS_DELETE_BLOCKED_SCAN_KEY)?
+        .is_some_and(|s| !s.is_empty());
+    let remote_paused = state
+        .db
+        .get_app_config(MASS_DELETE_BLOCKED_REMOTE_KEY)?
+        .is_some_and(|s| !s.is_empty());
+    Ok(scan_paused || remote_paused)
+}
+
 pub(crate) fn scan_local_changes_internal(state: &AppState) -> AppResult<usize> {
     let folder = state
         .db
@@ -1125,9 +1142,9 @@ mod tests {
 
     use super::{
         block_mass_deletion, cleanup_stale_upload_state, clear_mass_delete_blocked,
-        is_mass_deletion, process_changed_paths, resolve_conflict_internal,
-        run_sync_tick_internal, scan_local_changes_internal, ConflictAction, MassDeleteSource,
-        SYNC_BATCH_CAP,
+        is_mass_deletion, mass_delete_pause_active, process_changed_paths,
+        resolve_conflict_internal, run_sync_tick_internal, scan_local_changes_internal,
+        ConflictAction, MassDeleteSource, SYNC_BATCH_CAP,
     };
     use crate::state::AppState;
     use crate::storage::db::Db;
@@ -1820,6 +1837,35 @@ mod tests {
                 .unwrap()
                 .is_some_and(|s| !s.is_empty()),
             "scan clear must leave the remote pause flag untouched"
+        );
+    }
+
+    #[test]
+    fn mass_delete_pause_active_reflects_either_direction_flag() {
+        let tmp = tempdir().expect("tempdir");
+        let state = build_state(tmp.path());
+
+        assert!(
+            !mass_delete_pause_active(&state).unwrap(),
+            "neither key set → not paused"
+        );
+
+        block_mass_deletion(&state, 40, 100, MassDeleteSource::LocalScan);
+        assert!(
+            mass_delete_pause_active(&state).unwrap(),
+            "scan key set (non-empty) → paused"
+        );
+
+        clear_mass_delete_blocked(&state, MassDeleteSource::LocalScan);
+        assert!(
+            !mass_delete_pause_active(&state).unwrap(),
+            "scan key cleared back to empty string → not paused"
+        );
+
+        block_mass_deletion(&state, 50, 100, MassDeleteSource::RemoteSweep);
+        assert!(
+            mass_delete_pause_active(&state).unwrap(),
+            "remote key set (non-empty) → paused"
         );
     }
 }

--- a/apps/desktop/src/components/FlyoutApp.css
+++ b/apps/desktop/src/components/FlyoutApp.css
@@ -162,6 +162,57 @@ html, body, #root {
   font-size: 12px;
 }
 
+/* DBSYNC-64: mass-delete circuit breaker — impossible-to-miss warning banner.
+   Distinct from .flyout-banner (info) via the error palette + a left accent bar. */
+.mass-delete-banner {
+  align-items: flex-start;
+  background: var(--flyout-error-soft);
+  border: 1px solid var(--flyout-error);
+  border-left-width: 4px;
+}
+
+.mass-delete-banner-icon .event-icon {
+  background: transparent;
+  color: var(--flyout-error);
+  width: 20px;
+  height: 20px;
+}
+
+.mass-delete-banner-body {
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+.mass-delete-banner-body h3 {
+  margin: 0 0 4px;
+  font-size: 12.5px;
+  font-weight: 700;
+  color: var(--flyout-error);
+}
+
+.mass-delete-banner-body p {
+  margin: 0 0 6px;
+  font-size: 11.5px;
+  color: var(--flyout-text);
+  word-break: break-word;
+}
+
+.mass-delete-banner-note {
+  font-weight: 600;
+  font-style: italic;
+}
+
+.mass-delete-banner-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-top: 4px;
+}
+
+.mass-delete-confirm-btn {
+  background: linear-gradient(180deg, #ef4444 0%, #c0392b 100%);
+}
+
 .flyout-section h2 {
   font-size: 11px;
   text-transform: uppercase;

--- a/apps/desktop/src/components/FlyoutApp.tsx
+++ b/apps/desktop/src/components/FlyoutApp.tsx
@@ -284,7 +284,9 @@ function buildActivityFeed(jobs: SyncJob[], activity: ActivityEntry[]): Activity
 function FlyoutApp() {
   const { activity, pushLog } = useActivityLog();
   const { startupLoading, authOk, syncFolderOk, syncFolder } = useStartupRequirements(pushLog);
-  const { status, jobs, conflicts, retryFailedJobs, resolveConflict } = useSyncDashboard(pushLog);
+  const { status, jobs, conflicts, massDeletePaused, retryFailedJobs, resolveConflict, confirmPendingDeletions } =
+    useSyncDashboard(pushLog);
+  const [confirmingDeletions, setConfirmingDeletions] = useState(false);
   const { activeTransfer } = useTransferProgress();
   usePlaceholderEvents(pushLog);
 
@@ -351,6 +353,21 @@ function FlyoutApp() {
       pushLog(accepted?.accepted ? "Sync requested." : "Sync already running.");
     } catch (e) {
       pushLog(`Failed to trigger sync: ${String(e)}`);
+    }
+  };
+
+  // DBSYNC-64: mass-delete circuit breaker paused sync. Nothing was deleted yet;
+  // require an explicit confirm before letting the blocked batch proceed.
+  const onConfirmPendingDeletions = async () => {
+    const ok = window.confirm(
+      "This will delete the blocked items from Dropbox (or locally). Only confirm if you intentionally deleted them. Continue?",
+    );
+    if (!ok) return;
+    setConfirmingDeletions(true);
+    try {
+      await confirmPendingDeletions();
+    } finally {
+      setConfirmingDeletions(false);
     }
   };
 
@@ -421,6 +438,32 @@ function FlyoutApp() {
       </nav>
 
       <div className="flyout-body">
+        {massDeletePaused && (
+          <div className="flyout-banner mass-delete-banner" role="alert">
+            <div className="mass-delete-banner-icon" aria-hidden="true">
+              <EventIcon kind="conflict" />
+            </div>
+            <div className="mass-delete-banner-body">
+              <h3>Sync paused — mass deletion blocked</h3>
+              <p>{status.lastError || "A large batch of deletions looked suspicious, so nothing was deleted. Review, then confirm to proceed."}</p>
+              <p className="mass-delete-banner-note">Nothing has been deleted yet.</p>
+              <div className="mass-delete-banner-actions">
+                <button type="button" className="flyout-btn" onClick={() => void openSyncFolder()}>
+                  Review deletions
+                </button>
+                <button
+                  type="button"
+                  className="flyout-btn mass-delete-confirm-btn"
+                  onClick={() => void onConfirmPendingDeletions()}
+                  disabled={confirmingDeletions}
+                >
+                  {confirmingDeletions ? "Confirming..." : "Confirm & resume"}
+                </button>
+              </div>
+            </div>
+          </div>
+        )}
+
         {!authOk && (
           <div className="flyout-banner">
             <p>Dropbox is not connected.</p>

--- a/apps/desktop/src/hooks/useSyncDashboard.ts
+++ b/apps/desktop/src/hooks/useSyncDashboard.ts
@@ -17,6 +17,7 @@ export function useSyncDashboard(pushLog: (line: string) => void) {
   const [status, setStatus] = useState<SyncStatus>(idleStatus);
   const [jobs, setJobs] = useState<SyncJob[]>([]);
   const [conflicts, setConflicts] = useState<SyncConflict[]>([]);
+  const [massDeletePaused, setMassDeletePaused] = useState(false);
   const prevSyncRunningRef = useRef(false);
 
   const refreshDashboard = useCallback(async () => {
@@ -25,6 +26,7 @@ export function useSyncDashboard(pushLog: (line: string) => void) {
       setStatus(dashboard.status);
       setJobs(dashboard.jobs);
       setConflicts(dashboard.conflicts);
+      setMassDeletePaused(dashboard.massDeletePaused);
     } catch (e) {
       pushLog(`Dashboard refresh failed: ${String(e)}`);
     }
@@ -55,6 +57,18 @@ export function useSyncDashboard(pushLog: (line: string) => void) {
     },
     [pushLog, refreshDashboard],
   );
+
+  // DBSYNC-64: user reviewed the blocked deletion batch and wants to proceed.
+  // Sets a one-shot backend override for the next scan/sweep and clears the pause.
+  const confirmPendingDeletions = useCallback(async () => {
+    try {
+      await invoke("confirm_pending_deletions");
+      pushLog("Confirmed pending deletions; sync will resume and apply them.");
+    } catch (error) {
+      pushLog(`Confirm pending deletions error: ${String(error)}`);
+    }
+    await refreshDashboard();
+  }, [pushLog, refreshDashboard]);
 
   useEffect(() => {
     void refreshDashboard();
@@ -139,5 +153,14 @@ export function useSyncDashboard(pushLog: (line: string) => void) {
     prevSyncRunningRef.current = status.syncRunning;
   }, [status.syncRunning, status.lastError, status.lastScanAt, refreshDashboard, pushLog]);
 
-  return { status, jobs, conflicts, refreshDashboard, retryFailedJobs, resolveConflict };
+  return {
+    status,
+    jobs,
+    conflicts,
+    massDeletePaused,
+    refreshDashboard,
+    retryFailedJobs,
+    resolveConflict,
+    confirmPendingDeletions,
+  };
 }

--- a/apps/desktop/src/types.ts
+++ b/apps/desktop/src/types.ts
@@ -46,6 +46,9 @@ export type SyncDashboard = {
   status: SyncStatus;
   jobs: SyncJob[];
   conflicts: SyncConflict[];
+  /** DBSYNC-64: true while the mass-deletion circuit breaker has paused sync
+   *  (a blocked deletion batch is pending `confirm_pending_deletions`). */
+  massDeletePaused: boolean;
 };
 
 export type RemoteEntry = {


### PR DESCRIPTION
## Summary
Surfaces the DBSYNC-64 mass-delete **pause** in the flyout so the user can review and resume it.

- **Backend**: `SyncDashboard` gains `massDeletePaused` (via a new `mass_delete_pause_active` helper checking the per-direction durable pause flags `mass_delete_blocked_scan`/`_remote`).
- **Frontend**: when paused, a prominent alert banner shows the pause reason (`status.lastError`) + **"Nothing has been deleted yet"**, a **"Review deletions"** button (opens the sync folder to inspect what's missing) and a **"Confirm & resume"** button that — behind a `window.confirm` — calls the existing `confirm_pending_deletions` one-shot override and refreshes.

## Stack
desktop-tauri

## Jira Ticket
DBSYNC-64 (breaker UX). Completes the breaker's user-facing loop.

## Test Plan
- [x] `cargo test --lib` 155 pass (new `mass_delete_pause_active`), clippy clean, `tsc` + vite build pass
- [ ] Live: trigger a block → banner appears with the reason; "Confirm & resume" proceeds + clears the pause.

🤖 Generated with Claude Code
https://claude.ai/code/session_016NTD4Qhq5ygTiGwrPoVEqB