### PR TITLE
feat(#DBSYNC-65): plumb captured delete-rev end-to-end (slice 1/2)

### DIFF
--- a/apps/desktop/src-tauri/src/cloud_filter.rs
+++ b/apps/desktop/src-tauri/src/cloud_filter.rs
@@ -846,7 +846,22 @@ fn enqueue_remote_delete_async(rel: String, is_dir: bool) {
             tracing::debug!(rel = %rel, "cfapi event-delete: app state unavailable; skipping (scan backstop covers it)");
             return;
         };
-        if let Err(e) = state.db.enqueue_job("delete", Some(&rel), Some(&rel)) {
+        // DBSYNC-65 (Slice 1): capture the remote rev at enqueue time (files only —
+        // folders aren't keyed in `remote_file_index`) so a later drain (Slice 2) can
+        // detect whether the remote copy changed since this delete was observed. A
+        // lookup failure here must not abort the delete enqueue; fall back to `None`.
+        let parent_rev = if is_dir {
+            None
+        } else {
+            match state.db.get_remote_file(&rel) {
+                Ok(row) => row.map(|r| r.rev),
+                Err(e) => {
+                    tracing::warn!(rel = %rel, error = %e, "cfapi event-delete: parent rev lookup failed; enqueuing without it");
+                    None
+                }
+            }
+        };
+        if let Err(e) = state.db.enqueue_delete_job(&rel, parent_rev.as_deref()) {
             tracing::warn!(rel = %rel, error = %e, "cfapi event-delete: enqueue failed");
             return;
         }

--- a/apps/desktop/src-tauri/src/storage/db.rs
+++ b/apps/desktop/src-tauri/src/storage/db.rs
@@ -35,6 +35,7 @@ pub struct SyncJobRow {
     pub next_retry_at: Option<String>,
     pub updated_at: String,
     pub last_error: Option<String>,
+    pub delete_parent_rev: Option<String>,
 }
 
 #[derive(Clone, Serialize)]
@@ -450,6 +451,30 @@ impl Db {
         Ok(())
     }
 
+    /// DBSYNC-65 (Slice 1): dedicated `delete` job enqueue that also captures the
+    /// Dropbox `rev` of the file being deleted at enqueue time, so a later drain
+    /// can detect (Slice 2) whether the remote copy changed since the local
+    /// delete was observed. Mirrors `enqueue_job`'s ON CONFLICT collapse, but the
+    /// `DO UPDATE SET` additionally refreshes `delete_parent_rev` — re-enqueuing a
+    /// delete for an already-queued path must NOT keep a stale captured rev.
+    pub fn enqueue_delete_job(&self, target_path: &str, parent_rev: Option<&str>) -> AppResult<()> {
+        let now = Utc::now().to_rfc3339();
+        let conn = self
+            .write
+            .lock()
+            .map_err(|_| AppError::Storage("db write lock poisoned".into()))?;
+        conn.execute(
+            "
+            INSERT INTO sync_jobs(job_type, source_path, target_path, delete_parent_rev, status, attempt_count, next_retry_at, created_at, updated_at)
+            VALUES('delete', ?1, ?1, ?2, 'queued', 0, NULL, ?3, ?3)
+            ON CONFLICT(job_type, target_path) WHERE status IN ('queued','retry_wait','running')
+            DO UPDATE SET source_path=excluded.source_path, delete_parent_rev=excluded.delete_parent_rev, updated_at=excluded.updated_at
+            ",
+            params![target_path, parent_rev, now],
+        )?;
+        Ok(())
+    }
+
     pub fn count_active_jobs(&self) -> AppResult<usize> {
         let conn = self
             .read
@@ -498,7 +523,7 @@ impl Db {
         let mut stmt = conn
             .prepare(
                 "
-                SELECT id, job_type, source_path, target_path, status, attempt_count, next_retry_at, updated_at, last_error
+                SELECT id, job_type, source_path, target_path, status, attempt_count, next_retry_at, updated_at, last_error, delete_parent_rev
                 FROM sync_jobs
                 ORDER BY id DESC
                 LIMIT ?1
@@ -517,6 +542,7 @@ impl Db {
                 next_retry_at: row.get(6)?,
                 updated_at: row.get(7)?,
                 last_error: row.get(8)?,
+                delete_parent_rev: row.get(9)?,
             })
         })?;
 
@@ -533,7 +559,7 @@ impl Db {
             let mut stmt = conn
                 .prepare(
                     "
-                SELECT id, job_type, source_path, target_path, status, attempt_count, next_retry_at, updated_at, last_error
+                SELECT id, job_type, source_path, target_path, status, attempt_count, next_retry_at, updated_at, last_error, delete_parent_rev
                 FROM sync_jobs
                 WHERE status = 'queued' OR (status = 'retry_wait' AND (next_retry_at IS NULL OR next_retry_at <= ?1))
                 ORDER BY id ASC
@@ -554,6 +580,7 @@ impl Db {
                     next_retry_at: row.get(6)?,
                     updated_at: row.get(7)?,
                     last_error: row.get(8)?,
+                    delete_parent_rev: row.get(9)?,
                 })
             } else {
                 None
@@ -971,6 +998,7 @@ fn migrate(conn: &Connection) -> AppResult<()> {
     add_column_if_missing(conn, "sync_jobs", "upload_session_offset", "INTEGER")?;
     add_column_if_missing(conn, "sync_jobs", "upload_session_file_len", "INTEGER")?;
     add_column_if_missing(conn, "sync_jobs", "upload_session_file_mtime", "INTEGER")?;
+    add_column_if_missing(conn, "sync_jobs", "delete_parent_rev", "TEXT")?;
 
     // DBSYNC-35: structured fields for conflict resolution — the sibling copy holding
     // the preserved local content, and a flag for the remote-deleted scenario. Both
@@ -1042,12 +1070,13 @@ fn migrate(conn: &Connection) -> AppResult<()> {
                 upload_session_id TEXT,
                 upload_session_offset INTEGER,
                 upload_session_file_len INTEGER,
-                upload_session_file_mtime INTEGER
+                upload_session_file_mtime INTEGER,
+                delete_parent_rev TEXT
             );
             INSERT INTO sync_jobs_new
                 SELECT id, job_type, source_path, target_path, status, attempt_count, next_retry_at,
                        created_at, updated_at, last_error, upload_session_id, upload_session_offset,
-                       upload_session_file_len, upload_session_file_mtime
+                       upload_session_file_len, upload_session_file_mtime, delete_parent_rev
                 FROM sync_jobs
                 WHERE status IN ('queued','running','retry_wait','done','failed')
                   AND job_type IN ('upload','download','delete','local_delete','hydrate_cloudsc');
@@ -1362,6 +1391,37 @@ mod tests {
             .filter(|j| j.job_type == "upload")
             .count();
         assert_eq!(uploads, 2, "a new active upload coexists with the completed one");
+    }
+
+    #[test]
+    fn enqueue_delete_job_persists_parent_rev() {
+        let db = Db::new_at(&unique_db_path()).expect("db init");
+        db.enqueue_delete_job("a.txt", Some("rev123")).expect("enqueue");
+
+        let jobs = db.list_recent_jobs(10).expect("jobs");
+        assert_eq!(jobs.len(), 1);
+        assert_eq!(jobs[0].job_type, "delete");
+        assert_eq!(jobs[0].target_path.as_deref(), Some("a.txt"));
+        assert_eq!(jobs[0].delete_parent_rev.as_deref(), Some("rev123"));
+    }
+
+    #[test]
+    fn enqueue_delete_job_on_conflict_updates_rev_not_just_source_path() {
+        let db = Db::new_at(&unique_db_path()).expect("db init");
+        // DBSYNC-65 (Slice 1) crux regression: re-enqueuing an already-active delete
+        // for the same target must refresh `delete_parent_rev`, not keep the stale
+        // value captured by the first enqueue.
+        db.enqueue_delete_job("a.txt", Some("old_rev")).expect("first enqueue");
+        db.enqueue_delete_job("a.txt", Some("new_rev")).expect("second enqueue");
+
+        assert_eq!(
+            db.count_active_jobs().unwrap(),
+            1,
+            "re-enqueuing the same delete target must collapse into one active job"
+        );
+        let jobs = db.list_recent_jobs(10).expect("jobs");
+        assert_eq!(jobs.len(), 1);
+        assert_eq!(jobs[0].delete_parent_rev.as_deref(), Some("new_rev"));
     }
 
     #[test]

--- a/apps/desktop/src-tauri/src/sync_pipeline.rs
+++ b/apps/desktop/src-tauri/src/sync_pipeline.rs
@@ -187,7 +187,11 @@ fn process_local_file_deletion(
         state.db.remove_local_file(prev_rel)?;
         return Ok(0);
     }
-    state.db.enqueue_job("delete", Some(prev_rel), Some(prev_rel))?;
+    // DBSYNC-65 (Slice 1): capture the remote rev at enqueue time so a later drain
+    // (Slice 2) can detect whether the remote copy changed since this delete was
+    // observed. Not yet read/enforced — plumbing only.
+    let parent_rev = state.db.get_remote_file(prev_rel)?.map(|r| r.rev);
+    state.db.enqueue_delete_job(prev_rel, parent_rev.as_deref())?;
     state.db.remove_local_file(prev_rel)?;
     Ok(1)
 }
@@ -210,7 +214,8 @@ fn process_known_folder_deletion(
         state.db.remove_known_folder(rel)?;
         return Ok(0);
     }
-    state.db.enqueue_job("delete", Some(rel), Some(rel))?;
+    // Folders are never keyed in `remote_file_index`, so there is no rev to capture.
+    state.db.enqueue_delete_job(rel, None)?;
     state.db.remove_known_folder(rel)?;
     Ok(1)
 }
@@ -1413,6 +1418,106 @@ mod tests {
             !super::delete_suppressed_by_dehydration(&state, "gone.txt"),
             "a genuinely deleted file (no placeholder) must still be deleted on remote"
         );
+    }
+
+    // ---- DBSYNC-65 (Slice 1): capture delete-time parent rev (plumbing only) ----
+
+    #[test]
+    fn file_deletion_captures_remote_rev_on_enqueue() {
+        let tmp = tempdir().expect("tempdir");
+        let state = build_state(tmp.path());
+        let root = sync_root(&state);
+        // No `.cloudsc`/native placeholder at this path, so the enqueue path in
+        // `process_local_file_deletion` is actually exercised (not short-circuited).
+        state
+            .db
+            .upsert_remote_file("foo.txt", "hash", "rev123", 0)
+            .expect("seed remote row");
+
+        let n = super::process_local_file_deletion(&state, &root, "foo.txt").expect("process");
+        assert_eq!(n, 1);
+
+        let job = state
+            .db
+            .pick_next_due_job()
+            .expect("pick job")
+            .expect("job present");
+        assert_eq!(job.job_type, "delete");
+        assert_eq!(job.delete_parent_rev, Some("rev123".to_string()));
+    }
+
+    #[test]
+    fn file_deletion_with_no_remote_index_row_enqueues_none_rev() {
+        let tmp = tempdir().expect("tempdir");
+        let state = build_state(tmp.path());
+        let root = sync_root(&state);
+        // No `remote_file_index` row seeded for this path.
+
+        let n = super::process_local_file_deletion(&state, &root, "gone.txt").expect("process");
+        assert_eq!(n, 1);
+
+        let job = state
+            .db
+            .pick_next_due_job()
+            .expect("pick job")
+            .expect("job present");
+        assert_eq!(job.delete_parent_rev, None);
+    }
+
+    #[test]
+    fn folder_deletion_always_enqueues_none_rev() {
+        let tmp = tempdir().expect("tempdir");
+        let state = build_state(tmp.path());
+        let root = sync_root(&state);
+        // Seeded defensively at the folder's path — `process_known_folder_deletion`
+        // must never consult `remote_file_index` (folders aren't keyed there).
+        state
+            .db
+            .upsert_remote_file("dir", "hash", "rev999", 0)
+            .expect("seed remote row");
+
+        let n = super::process_known_folder_deletion(&state, &root, "dir").expect("process");
+        assert_eq!(n, 1);
+
+        let job = state
+            .db
+            .pick_next_due_job()
+            .expect("pick job")
+            .expect("job present");
+        assert_eq!(job.job_type, "delete");
+        assert_eq!(job.delete_parent_rev, None);
+    }
+
+    #[test]
+    fn re_enqueuing_delete_refreshes_stale_parent_rev() {
+        let tmp = tempdir().expect("tempdir");
+        let state = build_state(tmp.path());
+
+        state
+            .db
+            .enqueue_delete_job("foo.txt", Some("old_rev"))
+            .expect("enqueue old");
+        state
+            .db
+            .enqueue_delete_job("foo.txt", Some("new_rev"))
+            .expect("enqueue new");
+
+        let active: Vec<_> = state
+            .db
+            .list_recent_jobs(50)
+            .expect("list jobs")
+            .into_iter()
+            .filter(|j| {
+                j.job_type == "delete"
+                    && matches!(j.status.as_str(), "queued" | "retry_wait" | "running")
+            })
+            .collect();
+        assert_eq!(
+            active.len(),
+            1,
+            "re-enqueuing the same delete target must collapse into one active job, not duplicate"
+        );
+        assert_eq!(active[0].delete_parent_rev, Some("new_rev".to_string()));
     }
 
     // ---- DBSYNC-55: editor-temp / vanished-source handling ----


### PR DESCRIPTION
## Summary
Slice 1 of DBSYNC-65 (closes #70). **Pure plumbing — zero behavior change.** Captures the Dropbox `rev` at delete-enqueue time and persists it on a new `sync_jobs.delete_parent_rev` column, threaded end-to-end to the drain. The rev is stored but **not yet enforced** (Slice 2 / #71 activates the `parent_rev` guard), so remote-delete behavior is byte-for-byte unchanged.

### Key changes
- **storage/db.rs**: additive migration `delete_parent_rev TEXT` (+ old-DB CHECK-rebuild literal for correctness); `SyncJobRow.delete_parent_rev`; both projections (`pick_next_due_job`, `list_recent_jobs`); new dedicated `enqueue_delete_job(target, parent_rev)` whose `ON CONFLICT ... DO UPDATE SET` includes `delete_parent_rev=excluded.delete_parent_rev` — the crux: a delete re-enqueued for an already-queued path (restore-then-redelete) refreshes the rev instead of keeping a stale one. Generic `enqueue_job` (28 call sites) left untouched.
- **sync_pipeline.rs**: `process_local_file_deletion` captures the remote rev before untrack; `process_known_folder_deletion` passes `None` (folders aren't keyed in `remote_file_index`). Drain arm untouched.
- **cloud_filter.rs**: `enqueue_remote_delete_async` captures the rev gated on `!is_dir` (falls back to `None` on lookup error, never aborts the enqueue).

## Stack
desktop-tauri (Rust backend only; frontend untouched)

## Jira Ticket
DBSYNC-65

## Test Plan
- [x] Automated tests pass (`cargo test --lib` → 161 passed, 0 failed; 6 new)
- [x] `cargo clippy -- -D warnings` clean
- [x] desktop-tauri: no behavior change this slice (parent_rev not sent); enqueue/drain plumbing exercised by unit tests

### New tests
- `file_deletion_captures_remote_rev_on_enqueue`
- `file_deletion_with_no_remote_index_row_enqueues_none_rev`
- `folder_deletion_always_enqueues_none_rev`
- `re_enqueuing_delete_refreshes_stale_parent_rev` (crux regression)
- `enqueue_delete_job_persists_parent_rev`
- `enqueue_delete_job_on_conflict_updates_rev_not_just_source_path`

## Notes
- No project-wide `cargo fmt` (repo has no `rustfmt.toml` and isn't fmt-clean; new lines follow each file's existing convention).
- Blocks #71 (Slice 2): must land first so `delete_parent_rev` exists before the guard reads it.

🤖 Generated with Claude Code