### PR TITLE
fix(#DBSYNC-66): cloud-restore data-loss fix — grace window + delete completeness + coalescing + native-only materialization

### DIFF
--- a/apps/desktop/src-tauri/src/cloud_filter.rs
+++ b/apps/desktop/src-tauri/src/cloud_filter.rs
@@ -695,7 +695,7 @@ unsafe extern "system" fn on_notify_delete(
             tracing::debug!(rel = %rel, is_dir, "cfapi notify-delete: self-initiated (our own process) — not tracked, no remote delete will be enqueued");
         } else if in_materialization_grace(&rel) {
             mark_materialization(&rel); // refresh — keeps active churn armed
-            tracing::debug!(rel = %rel, is_dir, "cfapi notify-delete: suppressed — under active materialization grace (restore churn, not a user delete)");
+            tracing::info!(rel = %rel, is_dir, "cfapi notify-delete: suppressed — under active materialization grace (restore churn, not a user delete)");
         } else {
             mark_user_delete_in_flight(&rel, is_dir);
             tracing::debug!(rel = %rel, is_dir, "cfapi notify-delete: user delete observed");
@@ -894,31 +894,192 @@ unsafe fn ack_rename(conn: CF_CONNECTION_KEY, transfer: i64, status: NTSTATUS) -
     CfExecute(&op_info, &mut params)
 }
 
-/// Route a CONFIRMED user delete (from `on_notify_delete_completion`) or a
-/// rename-treated-as-delete (from `on_notify_rename_completion`) into the sync
-/// engine: enqueue the Dropbox `delete` job and untrack the local index row (same
-/// as the scan-inferred path's `process_local_file_deletion` /
-/// `process_known_folder_deletion`), then kick a drain — all OFF the CfAPI callback
-/// thread (never touch the DB/network from inside the `extern "system"` ABI).
-/// Draining goes through the normal `drain_sync_queue`, so the DBSYNC-45/62 guards
-/// (`delete_suppressed_by_dehydration`) still apply at execution time — this is
-/// additive, not a bypass. No-op if `app_state()` is unavailable (e.g.
-/// mid-shutdown); best-effort if another drain already owns `sync_running` — the
-/// job is already persisted and will be picked up by that drain or the next cycle.
-fn enqueue_remote_delete_async(rel: String, is_dir: bool) {
-    std::thread::spawn(move || {
-        let Some(state) = app_state() else {
-            tracing::debug!(rel = %rel, "cfapi event-delete: app state unavailable; skipping (scan backstop covers it)");
-            return;
-        };
+// ── DBSYNC-66 Slice 2: coalesced folder deletes ─────────────────────────────────
+//
+// Deleting a folder tree makes CfAPI fire ONE NOTIFY_DELETE(_COMPLETION) pair per
+// DESCENDANT (every file + every subfolder) — e.g. 32 events for a 32-item tree.
+// Turning each into its own `files/delete_v2` job serializes 32 network round-trips
+// (~30s observed) and, worse, holds the delete queue open for that whole window,
+// during which a concurrent restore can re-materialize part of the tree the user
+// just deleted. Dropbox's `delete_v2` on a FOLDER is already recursive — deleting
+// the top-level folder alone deletes its entire remote subtree — so the fix is to
+// BUFFER the burst of per-descendant events and, once it goes quiet, collapse it to
+// the MINIMAL set of top-level roots and enqueue exactly one recursive `delete_v2`
+// job per root (`minimal_delete_roots` / `flush_pending_deletes`).
+
+/// One buffered CfAPI delete event, captured from a confirmed
+/// `on_notify_delete_completion` (or a rename treated as a delete), awaiting
+/// coalescing by the debounce-flush worker.
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct PendingDelete {
+    rel: String,
+    is_dir: bool,
+}
+
+/// Delete events observed since the last flush. Drained wholesale (and coalesced —
+/// see `minimal_delete_roots`) by `run_delete_flush_worker` once the burst goes
+/// quiet for [`DELETE_DEBOUNCE_WINDOW`].
+static PENDING_EVENT_DELETES: OnceLock<Mutex<Vec<PendingDelete>>> = OnceLock::new();
+/// Instant of the most recent push into `PENDING_EVENT_DELETES`, used by the
+/// debounce worker to decide whether the burst has gone quiet.
+static PENDING_DELETES_LAST_ACTIVITY: OnceLock<Mutex<Option<Instant>>> = OnceLock::new();
+/// Guards against spawning more than one debounce-flush worker at a time. Set by
+/// whichever `enqueue_remote_delete_async` call wins the race to start a worker;
+/// cleared by the worker itself once the buffer has been empty for a couple of
+/// polls (with a re-check to avoid dropping a push that lands in that exact
+/// window — see `run_delete_flush_worker`).
+static DELETE_FLUSH_RUNNING: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
+
+/// How long the buffer must be quiet (no new pushes) before it is flushed.
+/// Comfortably longer than the gap between consecutive descendant
+/// NOTIFY_DELETE_COMPLETION events within a single folder-delete burst, so the
+/// whole burst is captured by one flush.
+const DELETE_DEBOUNCE_WINDOW: Duration = Duration::from_millis(700);
+/// Poll interval for the debounce worker.
+const DELETE_DEBOUNCE_POLL: Duration = Duration::from_millis(400);
+
+/// Buffer one CfAPI delete event and make sure a debounce-flush worker is running.
+/// Runs off the CfAPI callback thread (called from `enqueue_remote_delete_async`,
+/// itself only ever called from a spawned thread) — cheap, no DB/network here.
+fn push_pending_delete(rel: String, is_dir: bool) {
+    if let Ok(mut buf) = PENDING_EVENT_DELETES
+        .get_or_init(|| Mutex::new(Vec::new()))
+        .lock()
+    {
+        buf.push(PendingDelete { rel, is_dir });
+    }
+    if let Ok(mut last) = PENDING_DELETES_LAST_ACTIVITY
+        .get_or_init(|| Mutex::new(None))
+        .lock()
+    {
+        *last = Some(Instant::now());
+    }
+    ensure_delete_flush_worker();
+}
+
+/// Start the debounce-flush worker if one isn't already running (single-thread
+/// gate via `DELETE_FLUSH_RUNNING`). A no-op when a worker is already draining the
+/// buffer — that worker will pick up this push on its next poll.
+fn ensure_delete_flush_worker() {
+    use std::sync::atomic::Ordering;
+    if DELETE_FLUSH_RUNNING
+        .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+        .is_err()
+    {
+        return;
+    }
+    std::thread::spawn(run_delete_flush_worker);
+}
+
+/// The single debounce-flush worker thread: polls every [`DELETE_DEBOUNCE_POLL`],
+/// and once the buffer has been quiet for [`DELETE_DEBOUNCE_WINDOW`] and is
+/// non-empty, takes the whole buffer and flushes it (`flush_pending_deletes`).
+/// Stops once the buffer has been empty for a couple of polls — but re-checks
+/// after clearing `DELETE_FLUSH_RUNNING` so a push landing in the narrow window
+/// between "decided to stop" and "flag cleared" is still picked up (by this same
+/// worker looping again, or ceded to a fresh one if another thread already won the
+/// race), rather than silently stranded in the buffer.
+fn run_delete_flush_worker() {
+    use std::sync::atomic::Ordering;
+    loop {
+        let mut idle_polls = 0u32;
+        loop {
+            std::thread::sleep(DELETE_DEBOUNCE_POLL);
+            let quiet_long_enough = PENDING_DELETES_LAST_ACTIVITY
+                .get()
+                .and_then(|m| m.lock().ok().and_then(|g| *g))
+                .map(|t| t.elapsed() >= DELETE_DEBOUNCE_WINDOW)
+                .unwrap_or(true);
+            let batch = if quiet_long_enough {
+                PENDING_EVENT_DELETES
+                    .get()
+                    .and_then(|m| m.lock().ok().map(|mut b| std::mem::take(&mut *b)))
+            } else {
+                None
+            };
+            match batch {
+                Some(batch) if !batch.is_empty() => {
+                    idle_polls = 0;
+                    match app_state() {
+                        Some(state) => flush_pending_deletes(&state, batch),
+                        None => tracing::debug!(
+                            "cfapi event-delete: app state unavailable; dropping buffered batch (scan backstop covers it)"
+                        ),
+                    }
+                }
+                _ => {
+                    idle_polls += 1;
+                    if idle_polls >= 2 {
+                        break;
+                    }
+                }
+            }
+        }
+        DELETE_FLUSH_RUNNING.store(false, Ordering::Release);
+        let more_pending = PENDING_EVENT_DELETES
+            .get()
+            .and_then(|m| m.lock().ok().map(|b| !b.is_empty()))
+            .unwrap_or(false);
+        if !more_pending {
+            break;
+        }
+        if DELETE_FLUSH_RUNNING
+            .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+            .is_err()
+        {
+            break; // another thread already spawned a fresh worker; let it take over
+        }
+    }
+}
+
+/// Pure core of the coalescing (DBSYNC-66 Slice 2): given the descendant-level
+/// `(rel, is_dir)` events buffered from one delete burst, return only the entries
+/// that have no OTHER entry in `batch` as an ancestor. Dropbox's `delete_v2` on a
+/// folder is already recursive, so a root's own delete job already covers every
+/// entry it is an ancestor of — only the roots need a job. Boundary-safe (mirrors
+/// `materialization_grace_contains`): `"foo/bar"` is NOT an ancestor of
+/// `"foo/barbaz"` — only an exact `/`-separated descendant counts. Pure / no I/O,
+/// no wall-clock — fully unit-testable.
+fn minimal_delete_roots(batch: &[(String, bool)]) -> Vec<(String, bool)> {
+    batch
+        .iter()
+        .filter(|(rel, _)| {
+            !batch
+                .iter()
+                .any(|(other, _)| other != rel && rel.starts_with(&format!("{other}/")))
+        })
+        .cloned()
+        .collect()
+}
+
+/// Flush one debounced batch: coalesce it to its minimal root set
+/// (`minimal_delete_roots`), enqueue ONE recursive `delete_v2` job per root, untrack
+/// EVERY entry in the batch from the local index (so it matches what was deleted —
+/// the remote index rows for the deleted subtree are cleared by the delete drain's
+/// `remove_remote_file` / `prune_empty_deleted_ancestors`), then kick a single
+/// drain. Draining goes through the normal `drain_sync_queue`, so the DBSYNC-45/62
+/// guards (`delete_suppressed_by_dehydration`) still apply per job at execution
+/// time — this is additive, not a bypass. No-op if `sync_running` is already held
+/// by another drain — the jobs are already persisted and will be picked up by that
+/// drain or the next cycle. Called from `run_delete_flush_worker`, off the CfAPI
+/// callback thread.
+fn flush_pending_deletes(state: &crate::state::AppState, batch: Vec<PendingDelete>) {
+    if batch.is_empty() {
+        return;
+    }
+    let entries: Vec<(String, bool)> =
+        batch.iter().map(|p| (p.rel.clone(), p.is_dir)).collect();
+    let roots = minimal_delete_roots(&entries);
+
+    for (rel, is_dir) in &roots {
         // DBSYNC-65 (Slice 1): capture the remote rev at enqueue time (files only —
-        // folders aren't keyed in `remote_file_index`) so a later drain (Slice 2) can
-        // detect whether the remote copy changed since this delete was observed. A
-        // lookup failure here must not abort the delete enqueue; fall back to `None`.
-        let parent_rev = if is_dir {
+        // folders aren't keyed in `remote_file_index`) so a later drain can detect
+        // whether the remote copy changed since this delete was observed. A lookup
+        // failure here must not abort the delete enqueue; fall back to `None`.
+        let parent_rev = if *is_dir {
             None
         } else {
-            match state.db.get_remote_file(&rel) {
+            match state.db.get_remote_file(rel) {
                 Ok(row) => row.map(|r| r.rev),
                 Err(e) => {
                     tracing::warn!(rel = %rel, error = %e, "cfapi event-delete: parent rev lookup failed; enqueuing without it");
@@ -926,45 +1087,66 @@ fn enqueue_remote_delete_async(rel: String, is_dir: bool) {
                 }
             }
         };
-        if let Err(e) = state.db.enqueue_delete_job(&rel, parent_rev.as_deref()) {
+        if let Err(e) = state.db.enqueue_delete_job(rel, parent_rev.as_deref()) {
             tracing::warn!(rel = %rel, error = %e, "cfapi event-delete: enqueue failed");
-            return;
         }
-        let untrack = if is_dir {
-            state.db.remove_known_folder(&rel)
+    }
+
+    for entry in &batch {
+        let untrack = if entry.is_dir {
+            state.db.remove_known_folder(&entry.rel)
         } else {
-            state.db.remove_local_file(&rel)
+            state.db.remove_local_file(&entry.rel)
         };
         if let Err(e) = untrack {
-            tracing::warn!(rel = %rel, is_dir, error = %e, "cfapi event-delete: untrack failed (job still enqueued)");
+            tracing::warn!(rel = %entry.rel, is_dir = entry.is_dir, error = %e, "cfapi event-delete: untrack failed (job still enqueued)");
         }
-        tracing::info!(rel = %rel, is_dir, "cfapi event-delete: remote delete enqueued from NOTIFY_DELETE/NOTIFY_RENAME completion");
+    }
 
-        use std::sync::atomic::Ordering;
-        if state
-            .sync_running
-            .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
-            .is_ok()
-        {
-            // Tray tooltip refresh is UI-only (not correctness-load-bearing here —
-            // the enqueue above already persisted the job). Gated out of `cfg(test)`
-            // for the SAME reason as the notification plugin in `lib.rs`: taking
-            // `Some(on_notify_delete_completion)`'s address for the CfAPI callback
-            // table (above) makes this call chain statically reachable in the
-            // `cargo test --lib` harness binary — which, unlike the real shipped
-            // `.exe`, has no embedded manifest requesting ComCtl32 v6 — and the
-            // `tray-icon`/`muda` Windows backend statically imports
-            // `TaskDialogIndirect` (a ComCtl32 v6-only export), so the test binary
-            // fails to LOAD at all (STATUS_ENTRYPOINT_NOT_FOUND) rather than merely
-            // failing a test. The shipped app is unaffected (real manifest, and this
-            // path already runs on a background thread there regardless).
-            #[cfg(not(test))]
-            crate::auth_session::refresh_tray_tooltip(&state);
-            crate::sync_pipeline::drain_sync_queue(&state);
-            state.sync_running.store(false, Ordering::Release);
-            #[cfg(not(test))]
-            crate::auth_session::refresh_tray_tooltip(&state);
-        }
+    tracing::info!(
+        events = batch.len(),
+        roots = roots.len(),
+        "cfapi event-delete: coalesced burst flushed into recursive delete_v2 job(s)"
+    );
+
+    use std::sync::atomic::Ordering;
+    if state
+        .sync_running
+        .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+        .is_ok()
+    {
+        // Tray tooltip refresh is UI-only (not correctness-load-bearing here —
+        // the enqueues above already persisted the jobs). Gated out of `cfg(test)`
+        // for the SAME reason as the notification plugin in `lib.rs`: taking
+        // `Some(on_notify_delete_completion)`'s address for the CfAPI callback
+        // table (above) makes this call chain statically reachable in the
+        // `cargo test --lib` harness binary — which, unlike the real shipped
+        // `.exe`, has no embedded manifest requesting ComCtl32 v6 — and the
+        // `tray-icon`/`muda` Windows backend statically imports
+        // `TaskDialogIndirect` (a ComCtl32 v6-only export), so the test binary
+        // fails to LOAD at all (STATUS_ENTRYPOINT_NOT_FOUND) rather than merely
+        // failing a test. The shipped app is unaffected (real manifest, and this
+        // path already runs on a background thread there regardless).
+        #[cfg(not(test))]
+        crate::auth_session::refresh_tray_tooltip(state);
+        crate::sync_pipeline::drain_sync_queue(state);
+        state.sync_running.store(false, Ordering::Release);
+        #[cfg(not(test))]
+        crate::auth_session::refresh_tray_tooltip(state);
+    }
+}
+
+/// Route a CONFIRMED user delete (from `on_notify_delete_completion`) or a
+/// rename-treated-as-delete (from `on_notify_rename_completion`) into the sync
+/// engine. DBSYNC-66 Slice 2: rather than enqueueing immediately, this now BUFFERS
+/// the event (`push_pending_delete`) so a burst of per-descendant events from one
+/// user folder-delete coalesces into a handful of recursive `delete_v2` jobs
+/// instead of one job per descendant — see `run_delete_flush_worker` /
+/// `flush_pending_deletes`. Still runs OFF the CfAPI callback thread (never touch
+/// the DB/network from inside the `extern "system"` ABI).
+fn enqueue_remote_delete_async(rel: String, is_dir: bool) {
+    std::thread::spawn(move || {
+        push_pending_delete(rel, is_dir);
     });
 }
 
@@ -1682,5 +1864,76 @@ mod tests {
             now,
             Duration::from_secs(120)
         ));
+    }
+
+    // DBSYNC-66 Slice 2: `minimal_delete_roots` is the pure core of coalescing a
+    // NOTIFY_DELETE burst (one event per descendant) into the minimal set of
+    // top-level roots that actually need a `delete_v2` job (Dropbox's `delete_v2`
+    // on a folder is already recursive, so a root's job covers every descendant
+    // under it that also appears in the same burst).
+
+    fn pd(rel: &str, is_dir: bool) -> (String, bool) {
+        (rel.to_string(), is_dir)
+    }
+
+    #[test]
+    fn minimal_delete_roots_empty_input_is_empty() {
+        let batch: Vec<(String, bool)> = Vec::new();
+        assert_eq!(minimal_delete_roots(&batch), Vec::new());
+    }
+
+    #[test]
+    fn minimal_delete_roots_deep_tree_collapses_to_top_folder() {
+        // Deleting "Photos" (with subfolders and files) fires one event per
+        // descendant + the folder itself — only "Photos" should survive.
+        let batch = vec![
+            pd("Photos", true),
+            pd("Photos/2024", true),
+            pd("Photos/2024/img1.jpg", false),
+            pd("Photos/2024/img2.jpg", false),
+            pd("Photos/2025", true),
+            pd("Photos/2025/img3.jpg", false),
+        ];
+        assert_eq!(minimal_delete_roots(&batch), vec![pd("Photos", true)]);
+    }
+
+    #[test]
+    fn minimal_delete_roots_keeps_both_sibling_folders() {
+        let batch = vec![
+            pd("Photos", true),
+            pd("Photos/img.jpg", false),
+            pd("Docs", true),
+            pd("Docs/report.pdf", false),
+        ];
+        let mut roots = minimal_delete_roots(&batch);
+        roots.sort();
+        let mut expected = vec![pd("Docs", true), pd("Photos", true)];
+        expected.sort();
+        assert_eq!(roots, expected);
+    }
+
+    #[test]
+    fn minimal_delete_roots_boundary_safe_not_treated_as_ancestor() {
+        // "foo/bar" must NOT be treated as an ancestor of "foo/barbaz" — only an
+        // exact `/`-separated descendant counts (same boundary rule as
+        // `materialization_grace_contains`). Both are roots.
+        let batch = vec![pd("foo/bar", false), pd("foo/barbaz", false)];
+        let mut roots = minimal_delete_roots(&batch);
+        roots.sort();
+        let mut expected = batch.clone();
+        expected.sort();
+        assert_eq!(roots, expected);
+    }
+
+    #[test]
+    fn minimal_delete_roots_file_with_parent_folder_in_batch_keeps_only_parent() {
+        let batch = vec![pd("Photos", true), pd("Photos/img.jpg", false)];
+        assert_eq!(minimal_delete_roots(&batch), vec![pd("Photos", true)]);
+    }
+
+    #[test]
+    fn minimal_delete_roots_single_file_no_folder_is_its_own_root() {
+        let batch = vec![pd("top.txt", false)];
+        assert_eq!(minimal_delete_roots(&batch), vec![pd("top.txt", false)]);
     }
 }

--- a/apps/desktop/src-tauri/src/cloud_filter.rs
+++ b/apps/desktop/src-tauri/src/cloud_filter.rs
@@ -1001,7 +1001,23 @@ fn run_delete_flush_worker() {
                 Some(batch) if !batch.is_empty() => {
                     idle_polls = 0;
                     match app_state() {
-                        Some(state) => flush_pending_deletes(&state, batch),
+                        // Panic-firewall the flush: a panic here would kill this
+                        // worker thread with DELETE_FLUSH_RUNNING still set, silently
+                        // disabling event-delete coalescing for the rest of the
+                        // session. Catch it so the loop reaches its normal exit,
+                        // which resets the flag. (The scan backstop still propagates
+                        // deletes regardless.)
+                        Some(state) => {
+                            if std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                                flush_pending_deletes(&state, batch)
+                            }))
+                            .is_err()
+                            {
+                                tracing::error!(
+                                    "cfapi event-delete: coalesced flush panicked (caught); worker continues"
+                                );
+                            }
+                        }
                         None => tracing::debug!(
                             "cfapi event-delete: app state unavailable; dropping buffered batch (scan backstop covers it)"
                         ),

--- a/apps/desktop/src-tauri/src/cloud_filter.rs
+++ b/apps/desktop/src-tauri/src/cloud_filter.rs
@@ -116,6 +116,68 @@ pub(crate) fn in_post_registration_grace() -> bool {
         .unwrap_or(false)
 }
 
+/// `prefix (armed subtree) → last-armed-at`. Armed by the placeholder-materialization
+/// drivers (`cloudsc_ops.rs`, DBSYNC-66 Slice 1) whenever they are about to create a
+/// placeholder / real directory for restored content. While a prefix is armed, CfAPI
+/// churn under it (Explorer/the shell deleting-then-recreating placeholders as part of
+/// materializing a large restored subtree) must NOT be read as a user delete — see
+/// `in_materialization_grace` and its use in `on_notify_delete` /
+/// `delete_suppressed_by_dehydration`.
+static MATERIALIZATION_IN_FLIGHT: OnceLock<Mutex<HashMap<String, Instant>>> = OnceLock::new();
+
+/// Grace window during which an armed subtree's delete notifications are suppressed.
+/// Comfortably longer than the observed ~26s restore-churn lag (see the Slice 1 issue).
+const MATERIALIZATION_GRACE_WINDOW: Duration = Duration::from_secs(120);
+
+/// Arm `prefix` (a `/`-relative path — a folder's own rel, or a file's parent rel) for
+/// [`MATERIALIZATION_GRACE_WINDOW`], starting/refreshing its grace window. Also prunes
+/// any already-expired entries so the map doesn't grow unbounded across a long-running
+/// session (no separate GC needed).
+pub(crate) fn mark_materialization(prefix: &str) {
+    if let Ok(mut m) = MATERIALIZATION_IN_FLIGHT.get_or_init(|| Mutex::new(HashMap::new())).lock() {
+        let now = Instant::now();
+        m.retain(|_, at| {
+            now.checked_duration_since(*at)
+                .map(|d| d < MATERIALIZATION_GRACE_WINDOW)
+                .unwrap_or(true)
+        });
+        m.insert(prefix.to_string(), now);
+    }
+}
+
+/// Pure decision (unit-testable, `now`/`window` injected — no wall-clock): is `rel`
+/// under an armed, still-within-window prefix? `rel == prefix` also matches (a folder
+/// arms its own rel; a delete notification can fire for the folder itself, not just a
+/// child). Boundary-safe: `"foo/bar"` does NOT match `rel = "foo/barbaz"` — only an
+/// exact match or a `/`-separated descendant counts.
+fn materialization_grace_contains(
+    entries: &HashMap<String, Instant>,
+    rel: &str,
+    now: Instant,
+    window: Duration,
+) -> bool {
+    entries.iter().any(|(prefix, at)| {
+        let in_window = now.checked_duration_since(*at).map(|d| d < window).unwrap_or(true);
+        in_window && (rel == prefix || rel.starts_with(&format!("{prefix}/")))
+    })
+}
+
+/// True when `rel` falls under a subtree currently armed by [`mark_materialization`]
+/// (within its grace window) — i.e. a delete notification for it is very likely
+/// materialization churn (a restore re-creating placeholders), not a genuine user
+/// delete. Checked both at CfAPI event time (`on_notify_delete`) and at drain time
+/// (`delete_suppressed_by_dehydration`), matching the `in_post_registration_grace`
+/// two-checkpoint pattern.
+pub(crate) fn in_materialization_grace(rel: &str) -> bool {
+    let Some(lock) = MATERIALIZATION_IN_FLIGHT.get() else {
+        return false;
+    };
+    let Ok(m) = lock.lock() else {
+        return false;
+    };
+    materialization_grace_contains(&m, rel, Instant::now(), MATERIALIZATION_GRACE_WINDOW)
+}
+
 fn to_wide(s: &str) -> Vec<u16> {
     s.encode_utf16().chain(std::iter::once(0)).collect()
 }
@@ -631,6 +693,9 @@ unsafe extern "system" fn on_notify_delete(
         let rel = full_local_path(info).and_then(|abs| rel_under_connected_root(&abs))?;
         if is_own_process(info) {
             tracing::debug!(rel = %rel, is_dir, "cfapi notify-delete: self-initiated (our own process) — not tracked, no remote delete will be enqueued");
+        } else if in_materialization_grace(&rel) {
+            mark_materialization(&rel); // refresh — keeps active churn armed
+            tracing::debug!(rel = %rel, is_dir, "cfapi notify-delete: suppressed — under active materialization grace (restore churn, not a user delete)");
         } else {
             mark_user_delete_in_flight(&rel, is_dir);
             tracing::debug!(rel = %rel, is_dir, "cfapi notify-delete: user delete observed");
@@ -1543,5 +1608,79 @@ mod tests {
         let norm = to_wide("");
         let joined = unsafe { full_path_from(PCWSTR(vol.as_ptr()), PCWSTR(norm.as_ptr())) };
         assert_eq!(joined, None);
+    }
+
+    // DBSYNC-66 Slice 1: `materialization_grace_contains` is the pure core of the
+    // subtree-scoped materialization grace window — `now`/`window` are injected so
+    // these tests don't touch the wall clock (like `is_mass_deletion`).
+
+    #[test]
+    fn materialization_grace_contains_true_within_window_under_armed_prefix() {
+        let base = Instant::now();
+        let mut entries = HashMap::new();
+        entries.insert("Photos".to_string(), base);
+        let now = base.checked_add(Duration::from_secs(10)).unwrap();
+        assert!(materialization_grace_contains(
+            &entries,
+            "Photos/img.jpg",
+            now,
+            Duration::from_secs(120)
+        ));
+    }
+
+    #[test]
+    fn materialization_grace_contains_false_when_expired() {
+        let base = Instant::now();
+        let mut entries = HashMap::new();
+        entries.insert("Photos".to_string(), base);
+        let now = base.checked_add(Duration::from_secs(130)).unwrap();
+        assert!(!materialization_grace_contains(
+            &entries,
+            "Photos/img.jpg",
+            now,
+            Duration::from_secs(120)
+        ));
+    }
+
+    #[test]
+    fn materialization_grace_contains_false_for_unrelated_subtree() {
+        let base = Instant::now();
+        let mut entries = HashMap::new();
+        entries.insert("Photos".to_string(), base);
+        let now = base.checked_add(Duration::from_secs(10)).unwrap();
+        assert!(!materialization_grace_contains(
+            &entries,
+            "Docs/report.pdf",
+            now,
+            Duration::from_secs(120)
+        ));
+    }
+
+    #[test]
+    fn materialization_grace_contains_boundary_safe() {
+        let base = Instant::now();
+        let mut entries = HashMap::new();
+        entries.insert("foo/bar".to_string(), base);
+        let now = base.checked_add(Duration::from_secs(10)).unwrap();
+        assert!(!materialization_grace_contains(
+            &entries,
+            "foo/barbaz",
+            now,
+            Duration::from_secs(120)
+        ));
+    }
+
+    #[test]
+    fn materialization_grace_contains_exact_rel_match() {
+        let base = Instant::now();
+        let mut entries = HashMap::new();
+        entries.insert("top.txt".to_string(), base);
+        let now = base.checked_add(Duration::from_secs(10)).unwrap();
+        assert!(materialization_grace_contains(
+            &entries,
+            "top.txt",
+            now,
+            Duration::from_secs(120)
+        ));
     }
 }

--- a/apps/desktop/src-tauri/src/cloudsc_ops.rs
+++ b/apps/desktop/src-tauri/src/cloudsc_ops.rs
@@ -176,6 +176,12 @@ pub(crate) fn index_remote_folder_children_as_cloudsc_placeholders_internal(
                 } else if tag == "folder" {
                     // A cloud-only folder is a real directory (its children surface as
                     // placeholders next sweep), never a `<name>.cloudsc`.
+                    // DBSYNC-66 Slice 1: arm this folder's own rel BEFORE creating it —
+                    // the shell may churn (delete-then-recreate) placeholders while
+                    // materializing a restored subtree, and that churn must not be
+                    // read as a user delete.
+                    #[cfg(windows)]
+                    crate::cloud_filter::mark_materialization(&relative);
                     match fs::create_dir_all(&target_path) {
                         Ok(()) => {
                             let _ = state.db.upsert_known_folder(&relative);
@@ -274,6 +280,14 @@ fn create_remote_only_placeholder(
     size: i64,
     modified_ts: i64,
 ) -> bool {
+    // DBSYNC-66 Slice 1: arm the PARENT-folder prefix BEFORE creating the placeholder
+    // — covers siblings/descendants under an actively-materializing folder, whose
+    // CfAPI delete-then-recreate churn must not be read as a user delete.
+    #[cfg(windows)]
+    {
+        let arm = rel.rsplit_once('/').map(|(p, _)| p).unwrap_or(rel);
+        crate::cloud_filter::mark_materialization(arm);
+    }
     if !crate::cloud_filter::create_dehydrated_placeholder(
         local_dir,
         child_name,
@@ -338,6 +352,14 @@ pub(crate) fn materialize_remote_only_file_if_absent(
         return; // parent folder not materialized yet — the indexer handles it
     }
     let name = name.to_string_lossy().to_string();
+    // DBSYNC-66 Slice 1: arm rel's parent prefix before materializing (belt-and-
+    // braces alongside the arm inside `create_remote_only_placeholder` itself, since
+    // this is a distinct materialization driver per the Slice 1 plan).
+    #[cfg(windows)]
+    {
+        let arm = rel.rsplit_once('/').map(|(p, _)| p).unwrap_or(rel);
+        crate::cloud_filter::mark_materialization(arm);
+    }
     if create_remote_only_placeholder(
         state,
         parent,

--- a/apps/desktop/src-tauri/src/cloudsc_ops.rs
+++ b/apps/desktop/src-tauri/src/cloudsc_ops.rs
@@ -9,7 +9,7 @@ use crate::auth_session::get_access_token;
 use crate::cloudsc::{
     cloudsc_target_path, read_cloudsc_placeholder_file, write_cloudsc_placeholder_file,
 };
-use crate::dropbox_transfer::download_remote_file_internal;
+use crate::dropbox_transfer::{delete_remote_file_internal, download_remote_file_internal};
 use crate::error::{AppError, AppResult};
 use crate::models::{
     CloudscMeta, CloudscPlaceholderInfo, DropboxListFolderResponse,
@@ -57,6 +57,20 @@ pub(crate) fn index_remote_folder_children_as_cloudsc_placeholders_internal(
         Ok(Some(f)) => crate::cloud_filter::placeholders_active(&f),
         _ => false,
     };
+
+    // DBSYNC-66: on Windows, native CfAPI placeholders are the ONLY correct
+    // representation of cloud-only content — never fall back to `.cloudsc`
+    // sidecars (they show a broken icon and, worse, shadow the native placeholder
+    // so the file never materializes correctly). If CfAPI isn't connected yet — a
+    // brief startup race where this sweep runs before `CfConnectSyncRoot`
+    // completes, or a restore that materializes before the connection is live —
+    // DEFER instead of writing `.cloudsc`: the sweep re-runs on the next tick and
+    // materializes natively once connected.
+    #[cfg(windows)]
+    if !cfapi_active {
+        tracing::debug!("materialization sweep deferred: CfAPI not active yet (avoiding .cloudsc fallback on Windows)");
+        return Ok(0);
+    }
 
     // Page through the folder with cursor + has_more; a folder with more than one
     // page of entries (Dropbox returns up to ~2000 per page) would otherwise be
@@ -139,7 +153,22 @@ pub(crate) fn index_remote_folder_children_as_cloudsc_placeholders_internal(
             // file/dir (a hydrated folder is a real dir, so we never shadow it with
             // a `<name>.cloudsc`).
             if placeholder_path.exists() {
-                continue;
+                // DBSYNC-66: on Windows a `.cloudsc` sidecar is always wrong (a
+                // leftover from an older build or from a moment CfAPI was inactive)
+                // and it shadows the native placeholder — remove it and materialize
+                // natively below. On non-Windows the `.cloudsc` IS the placeholder,
+                // so keep it.
+                #[cfg(windows)]
+                {
+                    if let Err(e) = fs::remove_file(&placeholder_path) {
+                        tracing::warn!(name = %child_name, error = %e, "failed to remove stale .cloudsc sidecar; skipping");
+                        continue;
+                    }
+                }
+                #[cfg(not(windows))]
+                {
+                    continue;
+                }
             }
             if target_path.exists() {
                 continue;
@@ -187,6 +216,24 @@ pub(crate) fn index_remote_folder_children_as_cloudsc_placeholders_internal(
                             let _ = state.db.upsert_known_folder(&relative);
                             created += 1;
                             created_names.push(child_name.clone());
+                            // DBSYNC-66: recurse into the just-created folder now so a
+                            // restored/new subtree materializes fully in ONE sweep
+                            // (depth-first, each folder listed once) instead of one
+                            // level per scan tick — the cause of the minutes-long
+                            // trickle after a cloud folder restore.
+                            match normalize_dropbox_path(&relative) {
+                                Ok(child_remote) => {
+                                    match index_remote_folder_children_as_cloudsc_placeholders_internal(
+                                        state,
+                                        &child_remote,
+                                        &target_path,
+                                    ) {
+                                        Ok(n) => created += n,
+                                        Err(e) => tracing::warn!(rel = %relative, error = %e, "recursive materialization of subfolder failed"),
+                                    }
+                                }
+                                Err(e) => tracing::warn!(rel = %relative, error = %e, "recursive materialization: unsafe child path"),
+                            }
                         }
                         Err(e) => {
                             tracing::warn!(name = %child_name, error = %e, "remote-only folder: create dir failed");
@@ -1105,6 +1152,211 @@ fn untrack_folders_subtree(state: &AppState, folder_rel: &str) -> AppResult<()> 
     Ok(())
 }
 
+// ---------------------------------------------------------------------------
+// DBSYNC-66: folder-delete completeness
+// ---------------------------------------------------------------------------
+//
+// CfAPI/Explorer fires NOTIFY_DELETE for the deleted files and the LEAF folder
+// of a deleted tree, but never for empty INTERMEDIATE ancestor folders — those
+// are left behind both locally and on Dropbox, along with a stale
+// `known_folders` row. `prune_empty_deleted_ancestors` walks up from a just-
+// deleted path and prunes any ancestor the delete genuinely emptied out.
+
+/// Max ancestor-chain depth walked by `prune_empty_deleted_ancestors`. A purely
+/// defensive backstop — real sync-root trees never come close to this — against
+/// an unbounded loop from a malformed/corrupt rel.
+const PRUNE_ANCESTOR_DEPTH_CAP: usize = 64;
+
+/// Returns the chain of ancestor folder rels for `deleted_rel`, nearest-first
+/// (parent, grandparent, …), stopping before the sync root (`""`). Pure and
+/// IO-free so it is unit-tested directly; `deleted_rel` is assumed already
+/// `/`-canonical, as every rel path in this codebase is (see `relpath_under`).
+///
+/// Example: `ancestor_rels("UNET/Ascensos/Asociado/artículos/file.txt")` ==
+/// `["UNET/Ascensos/Asociado/artículos", "UNET/Ascensos/Asociado", "UNET/Ascensos", "UNET"]`.
+pub(crate) fn ancestor_rels(deleted_rel: &str) -> Vec<String> {
+    let mut out = Vec::new();
+    let mut current = deleted_rel;
+    while let Some((parent, _)) = current.rsplit_once('/') {
+        if parent.is_empty() {
+            break;
+        }
+        out.push(parent.to_string());
+        current = parent;
+    }
+    out
+}
+
+/// Classification of a `files/list_folder` probe against a candidate ancestor,
+/// used by `prune_empty_deleted_ancestors` to decide whether it is safe to
+/// prune. Kept as a small enum so the call site is a single 3-way match instead
+/// of inlining the status/body parsing there.
+enum RemoteFolderProbe {
+    /// At least one entry remains on Dropbox — never prune (may still
+    /// materialize locally later).
+    HasContent,
+    /// The folder no longer exists on Dropbox at all — safe to prune locally
+    /// and drop the index rows; nothing to delete remotely.
+    AlreadyGone,
+    /// The folder exists on Dropbox and is empty — safe to `delete_v2` it, then
+    /// prune locally and drop the index rows.
+    Empty,
+}
+
+/// Non-recursive `files/list_folder` probe for `rel`, classified per
+/// `RemoteFolderProbe`. Mirrors the existing `list_folder` call in
+/// `index_remote_folder_children_as_cloudsc_placeholders_internal`. Manual-QA-
+/// only for the network path — no HTTP mock in this repo (existing convention).
+fn probe_remote_folder_empty(state: &AppState, rel: &str) -> AppResult<RemoteFolderProbe> {
+    let token = get_access_token(state)?;
+    let dropbox_path = normalize_dropbox_path(rel)?;
+    let response = state
+        .http_client
+        .post("https://api.dropboxapi.com/2/files/list_folder")
+        .bearer_auth(token.as_str())
+        .json(&serde_json::json!({
+            "path": dropbox_path,
+            "recursive": false,
+            "include_deleted": false
+        }))
+        .send()
+        .map_err(|e| {
+            AppError::Network(format!("list_folder (prune probe) request failed: {e}"))
+        })?;
+
+    if !response.status().is_success() {
+        let status = response.status();
+        let body = response
+            .text()
+            .unwrap_or_else(|_| "<unreadable body>".to_string());
+        if body.contains("path/not_found") {
+            return Ok(RemoteFolderProbe::AlreadyGone);
+        }
+        return Err(AppError::Dropbox {
+            status: status.as_u16(),
+            message: format!("list_folder (prune probe) for {dropbox_path}: {body}"),
+        });
+    }
+
+    let parsed: DropboxListFolderResponse = response
+        .json()
+        .map_err(|e| AppError::Other(format!("list_folder (prune probe) parse failed: {e}")))?;
+
+    // Conservative on the (practically impossible) empty-page-but-more-follows
+    // shape: treat it as content present rather than prune.
+    if parsed.entries.is_empty() && !parsed.has_more {
+        Ok(RemoteFolderProbe::Empty)
+    } else {
+        Ok(RemoteFolderProbe::HasContent)
+    }
+}
+
+/// DBSYNC-66 folder-delete completeness: after a delete job for `deleted_rel`
+/// genuinely succeeds, walk up its ancestor chain pruning any folder that the
+/// delete just emptied out — locally, on Dropbox, and from `known_folders` —
+/// so deleting a folder tree doesn't leave empty ancestor shells behind on
+/// either side (CfAPI only fires NOTIFY_DELETE for files and leaf folders,
+/// never intermediate ones).
+///
+/// SAFETY: a candidate ancestor is pruned only when BOTH (a) its local
+/// directory is missing or empty — any remaining local sibling stops the walk
+/// there — AND (b) Dropbox itself reports it empty or already gone. Never
+/// decided from the local remote-index alone, since it can lag un-materialized
+/// cloud-only content. Never walks past the sync root (`rel == ""`).
+///
+/// Intended to be called from the sequential delete drain (one job at a time),
+/// so there is no TOCTOU race on the emptiness check between ancestors — each
+/// ancestor only becomes locally empty once its last child's delete job has
+/// actually drained. Every remote call here goes straight through
+/// `delete_remote_file_internal` (never the async enqueue path), so a prune
+/// cannot itself re-trigger the burst/mass-delete circuit breaker.
+///
+/// Returns the number of ancestors pruned. A failure partway through the walk
+/// stops the walk (never partially prunes past an error) but is still returned
+/// as an `Err` — callers that must not fail the delete job the prune was
+/// triggered by should treat that `Err` as best-effort/log-and-swallow.
+pub(crate) fn prune_empty_deleted_ancestors(
+    state: &AppState,
+    deleted_rel: &str,
+) -> AppResult<usize> {
+    let Some(folder) = state.db.get_sync_folder()? else {
+        return Ok(0);
+    };
+    let root = Path::new(&folder);
+    let mut pruned = 0usize;
+
+    for rel in ancestor_rels(deleted_rel)
+        .into_iter()
+        .take(PRUNE_ANCESTOR_DEPTH_CAP)
+    {
+        if rel.is_empty() {
+            break; // never touch the sync root
+        }
+
+        let abs = match safe_join(root, &rel) {
+            Ok(p) => p,
+            Err(e) => {
+                tracing::warn!(rel = %rel, error = %e, "folder-delete completeness: unsafe ancestor rel, stopping walk");
+                break;
+            }
+        };
+
+        let locally_present = abs.exists();
+        if locally_present {
+            let non_empty = match fs::read_dir(&abs) {
+                Ok(mut it) => it.next().is_some(),
+                // Unreadable dir: treat conservatively as "has content" so we
+                // never prune on an inconclusive local read.
+                Err(_) => true,
+            };
+            if non_empty {
+                break; // a sibling remains — legitimately populated, stop the walk
+            }
+        }
+
+        // Locally empty (or already gone) — confirm on Dropbox before touching
+        // anything remote; the local index can lag un-materialized cloud content.
+        match probe_remote_folder_empty(state, &rel) {
+            Ok(RemoteFolderProbe::HasContent) => {
+                tracing::debug!(rel = %rel, "folder-delete completeness: ancestor empty locally but has remote content, not pruning");
+                break; // may still materialize locally later — leave it alone
+            }
+            Ok(RemoteFolderProbe::AlreadyGone) => {
+                // Nothing to delete remotely — fall through to local/index cleanup.
+            }
+            Ok(RemoteFolderProbe::Empty) => {
+                if let Err(e) = delete_remote_file_internal(state, &rel, None) {
+                    tracing::warn!(rel = %rel, error = %e, "folder-delete completeness: remote delete of empty ancestor failed, stopping walk");
+                    break;
+                }
+            }
+            Err(e) => {
+                tracing::warn!(rel = %rel, error = %e, "folder-delete completeness: remote emptiness probe failed, stopping walk");
+                break;
+            }
+        }
+
+        // Cleanup: the dir must be empty by now (or already gone) — `remove_dir`
+        // (never `remove_dir_all`) refuses to remove anything unexpectedly
+        // repopulated between the checks above, which stops the walk safely
+        // instead of deleting new content.
+        if locally_present {
+            if let Err(e) = fs::remove_dir(&abs) {
+                if e.kind() != std::io::ErrorKind::NotFound {
+                    tracing::warn!(rel = %rel, error = %e, "folder-delete completeness: local empty-dir removal failed, stopping walk");
+                    break;
+                }
+            }
+        }
+        let _ = state.db.remove_known_folder(&rel);
+        let _ = state.db.remove_remote_file(&rel);
+        pruned += 1;
+        tracing::info!(rel = %rel, "folder-delete completeness: pruned empty ancestor");
+    }
+
+    Ok(pruned)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1127,6 +1379,57 @@ mod tests {
         let rel = relpath_under(&root, &dir).expect("relpath");
         // `normalize_dropbox_path` itself converts OS separators to '/'.
         assert_eq!(normalize_dropbox_path(&rel).unwrap(), "/Cocina/Pizza");
+    }
+
+    // ---------------------------------------------------------------------------
+    // DBSYNC-66: folder-delete completeness — `ancestor_rels` (pure helper)
+    // ---------------------------------------------------------------------------
+
+    #[test]
+    fn ancestor_rels_deep_file_lists_every_ancestor_nearest_first() {
+        assert_eq!(
+            ancestor_rels("UNET/Ascensos/Asociado/artículos/file.txt"),
+            vec![
+                "UNET/Ascensos/Asociado/artículos".to_string(),
+                "UNET/Ascensos/Asociado".to_string(),
+                "UNET/Ascensos".to_string(),
+                "UNET".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn ancestor_rels_deleted_folder_itself_excludes_itself() {
+        // Deleting a leaf folder directly: its own rel is never in the chain,
+        // only its ancestors.
+        assert_eq!(
+            ancestor_rels("UNET/Ascensos/Asociado"),
+            vec!["UNET/Ascensos".to_string(), "UNET".to_string()]
+        );
+    }
+
+    #[test]
+    fn ancestor_rels_top_level_file_has_no_ancestors() {
+        assert_eq!(ancestor_rels("top.txt"), Vec::<String>::new());
+    }
+
+    #[test]
+    fn ancestor_rels_top_level_folder_has_no_ancestors() {
+        assert_eq!(ancestor_rels("UNET"), Vec::<String>::new());
+    }
+
+    #[test]
+    fn ancestor_rels_empty_input_has_no_ancestors() {
+        assert_eq!(ancestor_rels(""), Vec::<String>::new());
+    }
+
+    #[test]
+    fn ancestor_rels_never_yields_the_sync_root() {
+        // No ancestor chain should ever surface "" — callers rely on this to
+        // avoid an explicit root check per iteration.
+        for rel in ancestor_rels("a/b/c/d.txt") {
+            assert!(!rel.is_empty(), "ancestor_rels must never yield \"\"");
+        }
     }
 
     // ---------------------------------------------------------------------------

--- a/apps/desktop/src-tauri/src/dropbox_transfer.rs
+++ b/apps/desktop/src-tauri/src/dropbox_transfer.rs
@@ -1000,6 +1000,15 @@ pub(crate) fn delete_remote_file_internal(
         });
     }
 
+    // DBSYNC-66: the delete genuinely succeeded on Dropbox (a 200 — NOT the
+    // skipped/rev-conflict no-op above, which returns early and leaves the row
+    // intact because the file is back on the server). Clear the remote-index row
+    // for this path AND its whole subtree now so the materialization sweep does
+    // not re-create placeholders for the just-deleted content before longpoll
+    // catches up — the race that forced users to delete a folder twice. The
+    // subtree clear matters for a coalesced folder delete: `delete_v2` on a
+    // folder is recursive, so its descendants' remote rows must go too.
+    state.db.remove_remote_subtree(relative)?;
     Ok(())
 }
 

--- a/apps/desktop/src-tauri/src/storage/db.rs
+++ b/apps/desktop/src-tauri/src/storage/db.rs
@@ -419,6 +419,32 @@ impl Db {
         Ok(())
     }
 
+    /// DBSYNC-66: clear the remote-index row for `prefix` AND every descendant
+    /// under it (`prefix/...`). A folder delete on Dropbox is recursive, so its
+    /// whole subtree of remote rows must go too — otherwise the materialization
+    /// sweep re-creates placeholders for the (now-deleted) descendants, forcing
+    /// the "delete a folder twice" behavior. Boundary-safe via `LIKE ... ESCAPE`
+    /// so a sibling like `prefix-other` is never matched and `%`/`_`/accents in
+    /// the path are treated literally. For a plain file `prefix` this is
+    /// equivalent to `remove_remote_file` (no `prefix/...` descendants exist).
+    pub fn remove_remote_subtree(&self, prefix: &str) -> AppResult<()> {
+        let prefix = prefix.replace('\\', "/");
+        let escaped = prefix
+            .replace('!', "!!")
+            .replace('%', "!%")
+            .replace('_', "!_");
+        let child_pattern = format!("{escaped}/%");
+        let conn = self
+            .write
+            .lock()
+            .map_err(|_| AppError::Storage("db write lock poisoned".into()))?;
+        conn.execute(
+            "DELETE FROM remote_file_index WHERE relative_path = ?1 OR relative_path LIKE ?2 ESCAPE '!'",
+            params![prefix, child_pattern],
+        )?;
+        Ok(())
+    }
+
     pub fn enqueue_job(
         &self,
         job_type: &str,
@@ -1557,6 +1583,32 @@ mod tests {
         db.remove_known_folder("Cocina/Otra").expect("remove");
         let folders = db.list_known_folders().expect("list after remove");
         assert_eq!(folders, vec!["Cocina/Test".to_string()]);
+    }
+
+    #[test]
+    fn remove_remote_subtree_clears_prefix_and_descendants_boundary_safe() {
+        let db = Db::new_at(&unique_db_path()).expect("db init");
+        // The folder itself, a descendant (with an accent + a space), and two
+        // rows that must NOT be touched: a boundary-collision sibling and an
+        // unrelated tree.
+        db.upsert_remote_file("UNET", "h", "r", 0).expect("u1");
+        db.upsert_remote_file("UNET/Ascensos/artículos/a b.pdf", "h", "r", 0)
+            .expect("u2");
+        db.upsert_remote_file("UNET-other/keep.txt", "h", "r", 0)
+            .expect("u3");
+        db.upsert_remote_file("Otra/keep.txt", "h", "r", 0)
+            .expect("u4");
+
+        db.remove_remote_subtree("UNET").expect("prune subtree");
+
+        assert!(db.get_remote_file("UNET").expect("g1").is_none());
+        assert!(db
+            .get_remote_file("UNET/Ascensos/artículos/a b.pdf")
+            .expect("g2")
+            .is_none());
+        // Boundary-collision sibling and unrelated tree survive.
+        assert!(db.get_remote_file("UNET-other/keep.txt").expect("g3").is_some());
+        assert!(db.get_remote_file("Otra/keep.txt").expect("g4").is_some());
     }
 
     #[test]

--- a/apps/desktop/src-tauri/src/sync_pipeline.rs
+++ b/apps/desktop/src-tauri/src/sync_pipeline.rs
@@ -808,10 +808,18 @@ pub(crate) fn process_sync_queue_internal(state: &AppState) -> AppResult<bool> {
                 // placeholder, drop this job instead of deleting the remote file.
                 if delete_suppressed_by_dehydration(state, rel) {
                     tracing::info!(rel, "remote delete suppressed: path is a cloud-only placeholder (dehydration, not a deletion)");
-                    Ok(())
-                } else {
-                    delete_remote_file_internal(state, rel, job.delete_parent_rev.as_deref())
+                    return Ok(());
                 }
+                delete_remote_file_internal(state, rel, job.delete_parent_rev.as_deref())?;
+                // DBSYNC-66 folder-delete completeness: the delete genuinely
+                // succeeded — walk up rel's ancestor chain pruning any empty
+                // ancestor folder it just emptied out (locally + Dropbox +
+                // known_folders). Best-effort: a prune failure must never fail
+                // the delete job that already succeeded.
+                if let Err(e) = crate::cloudsc_ops::prune_empty_deleted_ancestors(state, rel) {
+                    tracing::warn!(rel, error = %e, "folder-delete completeness: ancestor prune failed (delete itself still succeeded)");
+                }
+                Ok(())
             }),
         "local_delete" => job
             .target_path

--- a/apps/desktop/src-tauri/src/sync_pipeline.rs
+++ b/apps/desktop/src-tauri/src/sync_pipeline.rs
@@ -87,6 +87,13 @@ fn delete_suppressed_by_dehydration(state: &AppState, rel: &str) -> bool {
     if crate::cloud_filter::in_post_registration_grace() {
         return true;
     }
+    // DBSYNC-66 Slice 1: drain-time backstop mirroring the `on_notify_delete` event-
+    // time check — a delete under an actively-materializing subtree (restore churn)
+    // must not run even if it slipped past the event-time suppression.
+    #[cfg(windows)]
+    if crate::cloud_filter::in_materialization_grace(rel) {
+        return true;
+    }
     let Ok(Some(folder)) = state.db.get_sync_folder() else {
         return false;
     };


### PR DESCRIPTION
## Summary
Complete fix for DBSYNC-66 (closes #74) — the cloud folder **restore → app re-deletes the restored files** data-loss bug, validated live on the test account (final state clean: no re-deletion, empty Dropbox trash, no empty-folder skeleton, native placeholders only, zero `.cloudsc`).

The branch grew past the original "Slice 1 grace window" as live testing surfaced the full root-cause set. All in one PR now:

### 1. Subtree-scoped materialization grace window (root cause)
`cloud_filter.rs`: prefix-keyed, time-windowed `MATERIALIZATION_IN_FLIGHT` (mirrors `in_post_registration_grace`). A restore's placeholder churn fires `NOTIFY_DELETE`; while the restored subtree is in its grace window those are recognized as churn (not user deletes) and suppressed at `on_notify_delete` + `delete_suppressed_by_dehydration`. Armed at the materialization drivers (parent-prefix), refreshed on each suppressed churn-delete, short window (120s) so genuine deletes elsewhere still propagate.

### 2. remote_index subtree cleanup on delete (kills "delete twice")
`dropbox_transfer.rs` + `db.rs`: on a genuine `delete_v2` success, clear the remote_index row for the path **and its whole subtree** (`remove_remote_subtree`, boundary-safe `LIKE ... ESCAPE`) so the sweep can't re-materialize just-deleted content. Matters for coalesced folder deletes.

### 3. Folder-delete completeness
`cloudsc_ops.rs` + `sync_pipeline.rs`: after a delete empties an ancestor, prune it locally + on Dropbox + from `known_folders` — confirming emptiness **against Dropbox** (never the stale local index), never `remove_dir_all`. No empty skeleton left on either side.

### 4. Coalesced folder deletes
`cloud_filter.rs`: debounce the burst of per-descendant `NOTIFY_DELETE` events and issue one recursive `delete_v2` per minimal root (`minimal_delete_roots`) instead of one delete per descendant. (Reduction is bounded by which folder events CfAPI actually fires — see follow-up ticket for the residual latency.)

### 5. Recursive materialization + no `.cloudsc` on Windows
`cloudsc_ops.rs`: recurse into a newly-created folder so a restored subtree materializes fully in one sweep; and on Windows **never** fall back to `.cloudsc` — defer the sweep until CfAPI is connected, and remove stale `.cloudsc` sidecars that would shadow the native placeholder.

## Stack
desktop-tauri (Rust backend only)

## Jira Ticket
DBSYNC-66

## Test Plan
- [x] `cargo test --lib` → 184 passed, 0 failed (new pure-helper tests: `materialization_grace_contains_*`, `minimal_delete_roots_*`, `ancestor_rels_*`, `remove_remote_subtree_*`, `classify_delete_response_*`)
- [x] `cargo clippy -- -D warnings` clean
- [x] **Live Windows validation**: delete a folder → restore from Dropbox trash → ends clean (files back, trash empty, no re-deletion, no skeleton, native placeholders, zero `.cloudsc`)

## Known follow-ups (tracked separately, NOT data-loss)
- DBSYNC-67: materialized folders stay in "syncing" overlay (cosmetic).
- Perf/UX ticket: delete latency (coalescing limited by CfAPI folder-event delivery + prune probes) and Sync Now not running a full sync (no remote materialization) / no feedback.

🤖 Generated with Claude Code