### PR TITLE
fix(#DBSYNC-67): convert folders to in-sync placeholders while empty (fixes stuck 'syncing' overlay)

### DIFF
--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -65,4 +65,5 @@ windows = { version = "0.61", features = [
     "Win32_System_CorrelationVector",
     "Win32_System_IO",
     "Win32_System_Threading",
+    "Win32_UI_Shell",
 ] }

--- a/apps/desktop/src-tauri/src/cloud_filter.rs
+++ b/apps/desktop/src-tauri/src/cloud_filter.rs
@@ -65,6 +65,7 @@ use windows::Win32::Storage::FileSystem::{
 };
 use windows::Win32::System::Com::{CoInitializeEx, COINIT_MULTITHREADED};
 use windows::Win32::System::Threading::{GetCurrentProcess, GetCurrentProcessId, OpenProcessToken};
+use windows::Win32::UI::Shell::{SHChangeNotify, SHCNE_UPDATEITEM, SHCNF_PATHW};
 
 use crate::error::{AppError, AppResult};
 
@@ -269,7 +270,7 @@ pub(crate) fn sync_folder_states(sync_folder: Option<&str>, folder_rels: &[Strin
 /// Convert a directory to an in-sync placeholder (no pin) so the shell renders its
 /// aggregate status. Under PopulationPolicy=AlwaysFull this never hides children.
 /// Fails soft.
-fn apply_folder_state(abs: &Path) -> bool {
+pub(crate) fn apply_folder_state(abs: &Path) -> bool {
     let path = to_wide(&abs.to_string_lossy());
     unsafe {
         let handle = match CreateFileW(
@@ -292,8 +293,61 @@ fn apply_folder_state(abs: &Path) -> bool {
         let conv = CfConvertToPlaceholder(handle, None, 0, CF_CONVERT_FLAG_MARK_IN_SYNC, None, None);
         let sync = CfSetInSyncState(handle, CF_IN_SYNC_STATE_IN_SYNC, CF_SET_IN_SYNC_FLAG_NONE, None);
         let _ = CloseHandle(handle);
-        tracing::debug!(dir = %abs.display(), convert = ?conv, set_in_sync = ?sync, "cfapi apply_folder_state");
+        // DBSYNC-67: CfConvertToPlaceholder only succeeds on an EMPTY directory —
+        // once the folder holds placeholder children it returns 0x8007017C
+        // ("cloud operation not valid"). We therefore call this at folder-CREATE
+        // time (empty), before materializing children (see cloudsc_ops). A convert
+        // failure on an already-populated folder is expected and benign (logged at
+        // debug); a real problem shows via SetInSyncState.
+        if conv.is_err() {
+            tracing::debug!(dir = %abs.display(), convert = ?conv, set_in_sync = ?sync, "cfapi apply_folder_state: convert skipped (folder not empty / not convertible)");
+        }
+        // Return true so the once-per-session cache (APPLIED_FOLDERS in
+        // sync_folder_states) does NOT retry a folder every sweep — a convert
+        // failure on a populated folder is permanent, retrying it is a wasteful
+        // storm. The real conversion happens at folder-create time (empty) in the
+        // materialization sweep, where this caller ignores the return value.
         true
+    }
+}
+
+/// DBSYNC-67: nudge Explorer to re-render the cloud overlay of the given folders.
+///
+/// Under `PopulationPolicy=AlwaysFull` a folder's cloud glyph is the AGGREGATE of
+/// its children — once every child is an in-sync placeholder the folder is
+/// "cloud", not "syncing". But Explorer caches that overlay and only re-queries it
+/// on a shell change notification or a restart, so a folder freshly filled by the
+/// materialization sweep stays stuck on the "syncing" glyph until the app is
+/// reopened (converting the folder itself to a placeholder is NOT the fix — and in
+/// fact fails with `0x8007017C` once it already holds placeholder children).
+/// `SHChangeNotify(SHCNE_UPDATEITEM)` forces the re-query now. `folder_rels` are
+/// `/`-relative under the sync root; missing dirs are skipped. Best-effort, no-op
+/// if the shell call is unavailable.
+pub(crate) fn notify_shell_folders_changed(sync_folder: Option<&str>, folder_rels: &[String]) {
+    let Some(folder) = sync_folder else {
+        return;
+    };
+    let root = Path::new(folder);
+    tracing::debug!(count = folder_rels.len(), "SHChangeNotify(SHCNE_UPDATEITEM) refreshing folder overlays");
+    for rel in folder_rels {
+        if rel.is_empty() {
+            continue;
+        }
+        let abs = root.join(rel);
+        if !abs.is_dir() {
+            continue;
+        }
+        let wide = to_wide(&abs.to_string_lossy());
+        // SAFETY: `wide` is a NUL-terminated UTF-16 path that outlives the call;
+        // SHChangeNotify with SHCNF_PATHW reads it as a PCWSTR and does not retain it.
+        unsafe {
+            SHChangeNotify(
+                SHCNE_UPDATEITEM,
+                SHCNF_PATHW,
+                Some(wide.as_ptr() as *const core::ffi::c_void),
+                None,
+            );
+        }
     }
 }
 

--- a/apps/desktop/src-tauri/src/cloudsc_ops.rs
+++ b/apps/desktop/src-tauri/src/cloudsc_ops.rs
@@ -216,6 +216,15 @@ pub(crate) fn index_remote_folder_children_as_cloudsc_placeholders_internal(
                             let _ = state.db.upsert_known_folder(&relative);
                             created += 1;
                             created_names.push(child_name.clone());
+                            // DBSYNC-67: convert this folder to an in-sync placeholder
+                            // NOW, while it is still empty — CfConvertToPlaceholder
+                            // only works on an empty directory (it returns 0x8007017C
+                            // once the folder holds placeholder children). Doing it
+                            // here, BEFORE the recursion below materializes children,
+                            // is what makes Explorer render the cloud/aggregate icon
+                            // instead of a stuck "syncing" glyph.
+                            #[cfg(windows)]
+                            crate::cloud_filter::apply_folder_state(&target_path);
                             // DBSYNC-66: recurse into the just-created folder now so a
                             // restored/new subtree materializes fully in ONE sweep
                             // (depth-first, each folder listed once) instead of one
@@ -514,6 +523,20 @@ pub(crate) fn index_materialized_folders_as_cloudsc_placeholders_internal(
             // One unreadable folder must not abort the whole sweep.
             Err(e) => tracing::error!(remote_path = %remote_path, error = %e, "index remote folder failed"),
         }
+    }
+
+    // DBSYNC-67: if this sweep materialized new placeholders, the aggregate cloud
+    // state of the folders holding them has changed — but Explorer caches the
+    // folder overlay and won't re-query it until a restart. Nudge the shell to
+    // re-render every known folder now so they drop the stale "syncing" glyph and
+    // show the cloud/aggregate icon promptly (windows-gated; near-free no-op for
+    // folders whose overlay is already correct).
+    #[cfg(windows)]
+    if created > 0 {
+        crate::cloud_filter::notify_shell_folders_changed(
+            Some(&sync_folder_str),
+            &state.db.list_known_folders().unwrap_or_default(),
+        );
     }
 
     Ok(created)


### PR DESCRIPTION
## Summary
Fixes DBSYNC-67 — materialized folders stayed on the Explorer **"syncing"** glyph even though every child was a correct cloud-only placeholder.

### Root cause (confirmed live via HRESULT logging)
`CfConvertToPlaceholder` only succeeds on an **EMPTY** directory. Once a folder holds placeholder children it returns `0x8007017C` ("cloud operation not valid"). The old approach created folders as plain dirs (`create_dir_all`) and tried to convert them **later** — by which point they were already populated — so the convert always failed, the folder was never a placeholder, and `CfSetInSyncState` was a no-op on it. Under `PopulationPolicy=AlwaysFull` that renders the folder as "syncing".

### Fix
Convert each folder to an in-sync placeholder **at create time**, in the materialization sweep, right after `create_dir_all` while it is still empty and **before** the recursion materializes its children.

- **cloud_filter.rs**: `apply_folder_state` is now `pub(crate)`; returns `true` so the once-per-session `APPLIED_FOLDERS` cache never retries a permanently-failing convert on an already-populated folder (avoids a per-sweep storm); convert failures log at debug. New `notify_shell_folders_changed` (`SHChangeNotify` / `SHCNE_UPDATEITEM`) nudges Explorer to re-render folder overlays after a sweep materialized new placeholders (Explorer caches the overlay otherwise).
- **cloudsc_ops.rs**: call `apply_folder_state` on the just-created empty folder before recursing; `SHChangeNotify` known folders at the end of the sweep when `created > 0`.
- **Cargo.toml**: add windows `Win32_UI_Shell` feature.

## Stack
desktop-tauri (Rust backend only; Windows CfAPI path)

## Jira Ticket
DBSYNC-67

## Test Plan
- [x] `cargo test --lib` → 184 passed, 0 failed
- [x] `cargo clippy -- -D warnings` clean
- [x] **Live Windows**: delete + restore a folder → freshly materialized folders (UNET/Tutor etc.) become `Directory, ReparsePoint` (placeholders) and Explorer shows the **cloud icon**, not "syncing". (Pre-existing already-populated folders are only fixed on their next re-materialization — convert-while-empty applies to newly created folders.)

## Notes
- Cosmetic overlay fix; no data-loss / sync-correctness change.
- Follow-ups still open: DBSYNC-68 (Sync Now completeness + delete latency), DBSYNC-69 (longpoll / restore-materialization latency).

🤖 Generated with Claude Code