### PR TITLE
fix(#DBSYNC-68): Sync Now runs the full sync cycle + honest feedback

### DIFF
--- a/apps/desktop/src-tauri/src/commands.rs
+++ b/apps/desktop/src-tauri/src/commands.rs
@@ -262,17 +262,9 @@ pub fn start_background_scheduler(
             // Show "Syncing" for the duration of this tick (DBSYNC-48); the
             // tooltip is refreshed back to Idle/Error after the store below.
             update_tray_tooltip(&app, &current_tray_status_label(&app_state));
-            // Run the sync tick first so a local folder deletion is detected,
-            // its `delete` job enqueued, and drained within this same tick
-            // (deleting the folder remotely) before discovery runs. Otherwise
-            // discovery would still see the (now-orphaned) remote folder and
-            // re-create its `.cloudsc` placeholder.
-            let _ = run_sync_tick_internal(&app_state);
-            match index_materialized_folders_as_cloudsc_placeholders_internal(&app_state) {
-                Ok(n) if n > 0 => tracing::info!(count = n, "indexed new remote placeholder(s)"),
-                Ok(_) => {}
-                Err(e) => tracing::error!(error = %e, "remote placeholder indexing failed"),
-            }
+            // Ordering (tick before discovery) is load-bearing — see the doc
+            // comment on `full_sync_cycle` (DBSYNC-66).
+            crate::sync_pipeline::full_sync_cycle(&app_state);
             app_state.sync_running.store(false, Ordering::Release);
             update_tray_tooltip(&app, &current_tray_status_label(&app_state));
         }
@@ -503,24 +495,25 @@ pub fn trigger_sync_tick(state: tauri::State<AppState>) -> Result<TriggerSyncRes
         .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
         .is_err()
     {
-        return Ok(TriggerSyncResponse { accepted: false });
+        return Ok(TriggerSyncResponse {
+            accepted: false,
+            reason: TriggerSyncReason::AlreadyRunning,
+        });
     }
 
     // Reflect the sync start in the tray tooltip immediately (DBSYNC-48).
     crate::auth_session::refresh_tray_tooltip(state.inner());
     let app_state = state.inner().clone();
     std::thread::spawn(move || {
-        let result = run_sync_tick_internal(&app_state);
-        if let Err(err) = result {
-            if let Ok(mut engine) = app_state.sync_engine.lock() {
-                engine.set_last_error(format!("sync tick failed: {err}"));
-            }
-        }
+        crate::sync_pipeline::full_sync_cycle(&app_state);
         app_state.sync_running.store(false, Ordering::Release);
         crate::auth_session::refresh_tray_tooltip(&app_state);
     });
 
-    Ok(TriggerSyncResponse { accepted: true })
+    Ok(TriggerSyncResponse {
+        accepted: true,
+        reason: TriggerSyncReason::Started,
+    })
 }
 
 #[tauri::command]

--- a/apps/desktop/src-tauri/src/models.rs
+++ b/apps/desktop/src-tauri/src/models.rs
@@ -35,6 +35,14 @@ pub(crate) struct SyncTickResult {
 #[serde(rename_all = "camelCase")]
 pub(crate) struct TriggerSyncResponse {
     pub accepted: bool,
+    pub reason: TriggerSyncReason,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum TriggerSyncReason {
+    Started,
+    AlreadyRunning,
 }
 
 #[derive(Deserialize)]

--- a/apps/desktop/src-tauri/src/sync_pipeline.rs
+++ b/apps/desktop/src-tauri/src/sync_pipeline.rs
@@ -1152,6 +1152,22 @@ pub(crate) fn run_sync_tick_internal(state: &AppState) -> AppResult<SyncTickResu
     })
 }
 
+/// Run the full sync cycle: local scan + queue drain, THEN the remote
+/// materialization sweep. Ordering is load-bearing — the tick must run
+/// first so a local folder deletion's `delete` job drains (deleting the
+/// folder remotely) BEFORE discovery runs; otherwise discovery would see
+/// the still-orphaned remote folder and re-create its `.cloudsc`
+/// placeholder (DBSYNC-66). Callers own the `sync_running` gate; this
+/// helper does not touch it.
+pub(crate) fn full_sync_cycle(state: &AppState) {
+    let _ = run_sync_tick_internal(state);
+    match crate::cloudsc_ops::index_materialized_folders_as_cloudsc_placeholders_internal(state) {
+        Ok(n) if n > 0 => tracing::info!(count = n, "indexed new remote placeholder(s)"),
+        Ok(_) => {}
+        Err(e) => tracing::error!(error = %e, "remote placeholder indexing failed"),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::sync::atomic::AtomicBool;

--- a/apps/desktop/src/components/FlyoutApp.tsx
+++ b/apps/desktop/src/components/FlyoutApp.tsx
@@ -366,24 +366,26 @@ function FlyoutApp() {
       const result = await invoke<TriggerSyncResponse>("trigger_sync_tick");
       if (result.reason === "already_running") {
         pushLog("Sync already running.");
-      } else {
-        pushLog("Sync requested.");
-        setOptimisticSyncing(true);
-        void refreshDashboardNow();
+        return;
+      }
+      pushLog("Sync requested.");
+      // Optimistic feedback: disable the button/indicator immediately, then
+      // hand off to the real dashboard status. The flag only bridges the
+      // click -> first-fetch gap; clearing it in `finally` (once the refreshed
+      // status has been read from the backend) guarantees it can never get
+      // stuck — even for a fast/no-op cycle that finishes before any poll ever
+      // observes syncRunning=true. A genuinely running sync keeps the UI busy
+      // via the real `status.syncRunning` flag after the flag clears.
+      setOptimisticSyncing(true);
+      try {
+        await refreshDashboardNow();
+      } finally {
+        setOptimisticSyncing(false);
       }
     } catch (e) {
       pushLog(`Failed to trigger sync: ${String(e)}`);
     }
   };
-
-  // Defensive clear: once the real dashboard status observes syncRunning, the
-  // real flag drives the UI, so drop the optimistic one to avoid it ever
-  // getting stuck (e.g. if a completion event is missed).
-  useEffect(() => {
-    if (status.syncRunning) {
-      setOptimisticSyncing(false);
-    }
-  }, [status.syncRunning]);
 
   // DBSYNC-64: mass-delete circuit breaker paused sync. Nothing was deleted yet;
   // require an explicit confirm before letting the blocked batch proceed.

--- a/apps/desktop/src/components/FlyoutApp.tsx
+++ b/apps/desktop/src/components/FlyoutApp.tsx
@@ -6,7 +6,7 @@ import { useSyncDashboard } from "../hooks/useSyncDashboard";
 import { useTransferProgress } from "../hooks/useTransferProgress";
 import { usePlaceholderEvents } from "../hooks/usePlaceholderEvents";
 import { formatBytes, formatSpeed } from "../format";
-import type { ActiveTransfer, ActivityEntry, SyncConflict, SyncJob } from "../types";
+import type { ActiveTransfer, ActivityEntry, SyncConflict, SyncJob, TriggerSyncResponse } from "../types";
 import "./FlyoutApp.css";
 
 type Section = "home" | "folders" | "activity";
@@ -284,9 +284,21 @@ function buildActivityFeed(jobs: SyncJob[], activity: ActivityEntry[]): Activity
 function FlyoutApp() {
   const { activity, pushLog } = useActivityLog();
   const { startupLoading, authOk, syncFolderOk, syncFolder } = useStartupRequirements(pushLog);
-  const { status, jobs, conflicts, massDeletePaused, retryFailedJobs, resolveConflict, confirmPendingDeletions } =
-    useSyncDashboard(pushLog);
+  const {
+    status,
+    jobs,
+    conflicts,
+    massDeletePaused,
+    refreshDashboardNow,
+    retryFailedJobs,
+    resolveConflict,
+    confirmPendingDeletions,
+  } = useSyncDashboard(pushLog);
   const [confirmingDeletions, setConfirmingDeletions] = useState(false);
+  // DBSYNC-68: optimistic "Sync Now" flag — flips the disabled/Syncing state
+  // instantly on click, before the 400ms dashboard poll observes the real
+  // `status.syncRunning`. Cleared as soon as the real flag catches up.
+  const [optimisticSyncing, setOptimisticSyncing] = useState(false);
   const { activeTransfer } = useTransferProgress();
   usePlaceholderEvents(pushLog);
 
@@ -345,16 +357,33 @@ function FlyoutApp() {
     }
   };
 
-  // DBSYNC-32: "Sync Now" — kick off an immediate sync tick (non-blocking; the
+  // DBSYNC-32/68: "Sync Now" — kick off an immediate sync tick (non-blocking; the
   // backend CAS-guards against overlapping runs and refreshes the tray state).
+  // Distinguishes "started" from "already_running" and flips the optimistic
+  // syncing flag right away so the button/indicator react before the next poll.
   const syncNow = async () => {
     try {
-      const accepted = await invoke<{ accepted: boolean }>("trigger_sync_tick");
-      pushLog(accepted?.accepted ? "Sync requested." : "Sync already running.");
+      const result = await invoke<TriggerSyncResponse>("trigger_sync_tick");
+      if (result.reason === "already_running") {
+        pushLog("Sync already running.");
+      } else {
+        pushLog("Sync requested.");
+        setOptimisticSyncing(true);
+        void refreshDashboardNow();
+      }
     } catch (e) {
       pushLog(`Failed to trigger sync: ${String(e)}`);
     }
   };
+
+  // Defensive clear: once the real dashboard status observes syncRunning, the
+  // real flag drives the UI, so drop the optimistic one to avoid it ever
+  // getting stuck (e.g. if a completion event is missed).
+  useEffect(() => {
+    if (status.syncRunning) {
+      setOptimisticSyncing(false);
+    }
+  }, [status.syncRunning]);
 
   // DBSYNC-64: mass-delete circuit breaker paused sync. Nothing was deleted yet;
   // require an explicit confirm before letting the blocked batch proceed.
@@ -378,17 +407,19 @@ function FlyoutApp() {
     }
   };
 
+  const isSyncing = status.syncRunning || optimisticSyncing;
+
   const footerLabel = startupLoading
     ? "Starting..."
     : !authOk || !syncFolderOk
       ? "Setup required"
       : status.lastError
         ? "Error"
-        : status.syncRunning
+        : isSyncing
           ? "Syncing..."
           : "Vos fichiers sont à jour";
 
-  const footerClass = !authOk || !syncFolderOk || status.lastError ? "warn" : status.syncRunning ? "busy" : "ok";
+  const footerClass = !authOk || !syncFolderOk || status.lastError ? "warn" : isSyncing ? "busy" : "ok";
 
   const recentJobs: SyncJob[] = jobs.slice(0, 8);
   const hasFailedJobs = jobs.some((job) => job.status === "failed");
@@ -427,7 +458,7 @@ function FlyoutApp() {
           type="button"
           className="flyout-settings"
           onClick={() => void syncNow()}
-          disabled={status.syncRunning}
+          disabled={isSyncing}
           title="Synchroniser maintenant"
         >
           <span className="glyph">{"🔄"}</span>

--- a/apps/desktop/src/hooks/useSyncDashboard.ts
+++ b/apps/desktop/src/hooks/useSyncDashboard.ts
@@ -160,8 +160,9 @@ export function useSyncDashboard(pushLog: (line: string) => void) {
     massDeletePaused,
     refreshDashboard,
     // One-shot immediate dashboard fetch (same fetch logic as refreshDashboard),
-    // exposed under this name for callers that want to kick the 400ms poll loop
-    // into gear right after triggering a background action (e.g. Sync Now).
+    // exposed under this name for callers that want to read the freshest status
+    // right after triggering a background action (e.g. Sync Now) instead of
+    // waiting for the next mount/focus refresh.
     refreshDashboardNow: refreshDashboard,
     retryFailedJobs,
     resolveConflict,

--- a/apps/desktop/src/hooks/useSyncDashboard.ts
+++ b/apps/desktop/src/hooks/useSyncDashboard.ts
@@ -159,6 +159,10 @@ export function useSyncDashboard(pushLog: (line: string) => void) {
     conflicts,
     massDeletePaused,
     refreshDashboard,
+    // One-shot immediate dashboard fetch (same fetch logic as refreshDashboard),
+    // exposed under this name for callers that want to kick the 400ms poll loop
+    // into gear right after triggering a background action (e.g. Sync Now).
+    refreshDashboardNow: refreshDashboard,
     retryFailedJobs,
     resolveConflict,
     confirmPendingDeletions,

--- a/apps/desktop/src/types.ts
+++ b/apps/desktop/src/types.ts
@@ -75,8 +75,19 @@ export type IgnoreGlobs = {
   csv: string;
 };
 
+/** Mirror of Rust `models::TriggerActionResponse`, returned by
+ *  `trigger_hydrate_cloudsc_placeholder`, `trigger_download_remote_file`, and
+ *  `trigger_hydrate_remote_folder`. */
 export type TriggerActionResponse = {
   accepted: boolean;
+};
+
+export type TriggerSyncReason = "started" | "already_running";
+
+/** Mirror of Rust `models::TriggerSyncResponse`, returned by `trigger_sync_tick` only. */
+export type TriggerSyncResponse = {
+  accepted: boolean;
+  reason: TriggerSyncReason;
 };
 
 export type CloudscPlaceholderInfo = {


### PR DESCRIPTION
## Summary
- **Sync Now now runs a FULL sync cycle.** Extracted `full_sync_cycle` (local tick + queue drain, THEN the remote materialization sweep) and routed both the 5-min scheduler loop and `trigger_sync_tick` through it. Previously "Sync Now" only ran the local half, so it never pulled down / materialized pending remote content (only the longpoll did).
- **Tick-before-discovery ordering preserved** (load-bearing, DBSYNC-66) and the **outer** `index_materialized_folders_as_cloudsc_placeholders_internal` is called so the per-folder Windows CfAPI guard still fires. The `sync_running` CAS gate scope is unchanged — each caller keeps owning it; the helper never touches it.
- **Honest feedback.** Widened `TriggerSyncResponse` with a `reason` enum (`started` / `already_running`). The frontend uses a dedicated `TriggerSyncResponse` TS type, branches its activity-log message on `reason`, and flips the "Syncing" indicator **optimistically** on click (instant button disable + immediate dashboard refresh to close the 400 ms poll gap), cleared defensively once the real status catches up.
- Contract hygiene: reverted the shared `TriggerActionResponse` TS type back to `{ accepted }` (its correct shape for the other 3 `trigger_*` commands) and added a separate `TriggerSyncResponse` for `trigger_sync_tick`.

## Constraints honored
- NO `sleep`/artificial delay inside the `sync_running` gate (would starve the longpoll).
- NO toast/notification infra added (none exists) — uses the existing `pushLog` activity log.
- Folder-delete latency was **split out** to a follow-up ticket (DBSYNC-70) — this PR is Sync Now only.

## Stack
desktop-tauri (Rust backend + React/TS frontend)

## Jira Ticket
DBSYNC-68

## Test Plan
- [x] `cargo clippy --all-targets` clean (no warnings)
- [x] `cargo test` — 184 passed, 0 failed
- [x] `npm --workspace apps/desktop run build` (tsc + vite) clean
- [ ] Manual live QA (Windows, requires running the app):
  - [ ] With pending remote content, click **Sync Now** → the remote folder/files materialize locally (proves the sweep now runs on the button, not just the longpoll)
  - [ ] Double-click Sync Now → second click logs "Sync already running." (not silent)
  - [ ] Button disables **instantly** on click (optimistic flip, no ~400 ms poll lag)
  - [ ] Delete a local folder then let a full cycle run → folder does NOT resurrect as a placeholder (DBSYNC-66 ordering regression check)

### Stack-specific validation
- desktop-tauri: affected IPC command (`trigger_sync_tick`) exercised; no terminal errors; frontend uses `@tauri-apps/api` `invoke` only.

🤖 Generated with Claude Code
https://claude.ai/code/session_01MQMywd4gJCi52EsngmpU9h