### PR TITLE
fix(#DBSYNC-69): longpoll drives the materialization sweep so cloud restores materialize promptly

### DIFF
--- a/apps/desktop/src-tauri/src/remote_longpoll.rs
+++ b/apps/desktop/src-tauri/src/remote_longpoll.rs
@@ -174,6 +174,19 @@ fn apply_and_drain(state: &AppState) -> bool {
         Err(e) => tracing::error!(error = %e, "apply_remote_delta failed"),
     }
     crate::sync_pipeline::drain_sync_queue(state);
+    // DBSYNC-69: drive the materialization sweep on the longpoll path too, so a
+    // cloud restore materializes within seconds instead of waiting for the 5-min
+    // periodic sweep. apply_remote_delta only records rows / materializes files
+    // whose parent is already a real dir; restored FOLDERS (delta Ignore) and
+    // files under a not-yet-materialized parent need the tree sweep. Runs inside
+    // this same sync_running gate, AFTER the drain (so delta-driven deletes drain
+    // before discovery). The DBSYNC-66 grace window is armed inside the sweep, so
+    // restore churn still can't be read as a user delete.
+    match crate::cloudsc_ops::index_materialized_folders_as_cloudsc_placeholders_internal(state) {
+        Ok(n) if n > 0 => tracing::info!(count = n, "indexed new remote placeholder(s) (longpoll)"),
+        Ok(_) => {}
+        Err(e) => tracing::error!(error = %e, "remote placeholder indexing failed (longpoll)"),
+    }
     state.sync_running.store(false, Ordering::Release);
     crate::auth_session::refresh_tray_tooltip(state);
     true


### PR DESCRIPTION
## Summary
- **Cloud restores now materialize within seconds instead of >2 min.** The longpoll (`remote_longpoll::apply_and_drain`) fired promptly and applied the remote delta + drained the queue, but never ran the folder-tree materialization sweep. `apply_remote_delta` only records rows / materializes files whose parent is already a real local dir; a restored **folder** delta is classified `Ignore`, and files under a not-yet-materialized parent bail — so a restore waited for the 5-min periodic sweep.
- **Fix:** call `index_materialized_folders_as_cloudsc_placeholders_internal(state)` in `apply_and_drain`, **after the drain** and **inside the already-held `sync_running` gate** (same sweep the 5-min `full_sync_cycle` uses). One added `match` block, log-and-continue on `Err`.
- **Untouched:** the longpoll backoff (already bounded 5→60 s + reset-on-success — it was NOT the cause), the CAS gate, and cursor handling.

## Data-safety / concurrency
- The DBSYNC-66 materialization grace window is armed **inside** the sweep functions, so driving the same sweep from the longpoll preserves the invariant that materialization never propagates as a Dropbox delete — no new guard code.
- drain-before-sweep ordering preserved (delta-driven deletes drain before discovery runs).
- No new races: the call is inside the existing `sync_running` critical section; the 5-min loop and Sync Now CAS the same single-flight flag.

## Stack
desktop-tauri (Rust backend; no frontend surface)

## Jira Ticket
DBSYNC-69

## Test Plan
- [x] `cargo clippy --all-targets` clean (no warnings)
- [x] `cargo test` — 184 passed, 0 failed
- [ ] Manual live QA (Windows, requires running the app):
  - [ ] Restore a folder subtree from Dropbox trash → placeholders appear within **seconds** (longpoll-driven), NOT at the next 5-min tick (`indexed new remote placeholder(s) (longpoll)` in the log)
  - [ ] No spurious re-delete (grace window holds); no folder resurrection (DBSYNC-66 regression check)

### Stack-specific validation
- desktop-tauri: affected path is the background longpoll loop; no IPC/UI surface. No terminal errors.

🤖 Generated with Claude Code
https://claude.ai/code/session_01MQMywd4gJCi52EsngmpU9h