### PR TITLE
fix(#DBSYNC-72): Finder Sync reads overlay_state from Application Support

### DIFF
--- a/apps/desktop/README.md
+++ b/apps/desktop/README.md
@@ -132,7 +132,7 @@ APPLE_TEAM_ID=XXXXXXXXXX npm run build:finder-sync
 
 The Rust backend writes:
 
-- macOS: `~/Library/Applications/DropboxSyncDesktop/overlay_state.json`
+- macOS: `~/Library/Application Support/DropboxSyncDesktop/overlay_state.json`
 - Windows: `%LOCALAPPDATA%\\DropboxSyncDesktop\\overlay_state.json`
 
 Schema summary:

--- a/apps/desktop/native/macos/FinderSyncExtension/README.md
+++ b/apps/desktop/native/macos/FinderSyncExtension/README.md
@@ -2,7 +2,7 @@
 
 The Tauri app writes **`overlay_state.json`** next to the SQLite database:
 
-- Path: `~/Library/Applications/DropboxSyncDesktop/overlay_state.json`
+- Path: `~/Library/Application Support/DropboxSyncDesktop/overlay_state.json`
 - Schema: see `src-tauri/src/overlay_state.rs` (`version`, `updated_at`, `sync_folder`, `paths` map with tiers `synced`, `out_of_sync`, `syncing`).
 
 This folder contains a **Finder Sync** implementation (`SyncExtension.swift`) that registers three badge images and assigns them per file using `requestBadgeIdentifier(for:)`.

--- a/apps/desktop/native/macos/FinderSyncExtension/SyncExtension.swift
+++ b/apps/desktop/native/macos/FinderSyncExtension/SyncExtension.swift
@@ -28,10 +28,18 @@ final class DropboxSyncFinderSync: FIFinderSync {
         }
     }
 
+    /// Resolves the same path the Rust side writes in `db::app_data_dir()`:
+    /// `~/Library/Application Support/DropboxSyncDesktop/overlay_state.json`.
+    /// The extension is not sandboxed, so `.userDomainMask` yields the plain
+    /// per-user Application Support directory rather than a container path.
     private func overlayStateURL() -> URL {
-        let home = FileManager.default.homeDirectoryForCurrentUser
-        return home
-            .appendingPathComponent("Library/Applications/DropboxSyncDesktop/overlay_state.json")
+        let appSupport = FileManager.default
+            .urls(for: .applicationSupportDirectory, in: .userDomainMask)
+            .first
+            ?? FileManager.default.homeDirectoryForCurrentUser
+                .appendingPathComponent("Library/Application Support")
+        return appSupport
+            .appendingPathComponent("DropboxSyncDesktop/overlay_state.json")
     }
 
     private func monitoredDirectoryURLs() -> Set<URL> {

--- a/apps/desktop/src-tauri/src/run_events.rs
+++ b/apps/desktop/src-tauri/src/run_events.rs
@@ -1,4 +1,6 @@
 use std::path::Path;
+#[cfg(any(target_os = "macos", target_os = "ios"))]
+use std::path::PathBuf;
 use std::time::Duration;
 
 use tauri::AppHandle;


### PR DESCRIPTION
## Summary

Fixes the overlay-state path mismatch that made Finder Sync badges impossible on macOS (DBSYNC-72 Slice 1, closes the code half of #81), plus a rider commit that restores the macOS Rust build.

**Commit 1 — the slice.** `SyncExtension.swift` read `~/Library/Applications/DropboxSyncDesktop/overlay_state.json`; the Rust side writes `~/Library/Application Support/DropboxSyncDesktop/`. `Library/Applications` is not a real macOS directory, so `reloadState()` read nothing on every tick and no badge could ever render — silently, because a failed read only sets `state = nil`. Now resolved through `FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask)` with a **non-crashing fallback**: a Finder Sync extension must never trap, it would take the whole Finder process down. Two READMEs documented the same wrong path and are corrected.

**Commit 2 — rider, unrelated to the path bug.** `run_events.rs` used `PathBuf` inside a `#[cfg(macos/ios)]` arm while importing only `Path`, so the Rust backend **had not compiled on macOS since 9ea4fbc (2026-07-13)**. One line, `cfg`-gated to match its only use. It ships here because it blocks `cargo test` and the `npm run dev:mac` that Slice 3 (#83) depends on.

## Stack

`desktop-tauri` — Swift (Finder Sync appex) + Rust backend. No frontend change.

## Jira Ticket

DBSYNC-72 — https://manuelbsan.atlassian.net/browse/DBSYNC-72

## Test Plan

- [x] `cargo test --manifest-path apps/desktop/src-tauri/Cargo.toml` — **163 passed**, 0 failed
- [x] `cargo clippy --manifest-path apps/desktop/src-tauri/Cargo.toml` — no new warnings (the remaining ones are pre-existing: `unused import: std::io`, two dead functions, one `sort_by_key`)
- [x] `npm --workspace apps/desktop run build` — `tsc` + `vite` clean
- [x] `npm --workspace apps/desktop run build:finder-sync` — **BUILD SUCCEEDED**, no errors, no warnings, x86_64 + arm64
- [x] Regression guard: `grep -rn "Library/Applications" apps/` returns **0 matches** (was exactly 3)

### desktop-tauri validation

Path equivalence was proven at runtime rather than by inspection. Running the exact resolution logic under `xcrun swift`:

```
/Users/<user>/Library/Application Support/DropboxSyncDesktop/overlay_state.json
```

which is byte-for-byte the location `db::app_data_dir()` documents (`storage/db.rs:1220`) and writes (`:1241`). This also confirms `.userDomainMask` returns the plain per-user directory rather than a container path — consistent with the no-sandbox ADR on the ticket, since no `.entitlements` file exists anywhere under `apps/desktop`.

## What this PR does NOT prove

- **That badges actually render.** Compiling is not rendering. That is Slice 3 (#83): enabling the extension under System Settings → Privacy & Security → Extensions → Finder on real hardware and looking at the three badge tiers.
- **Nothing was verified by CI.** The `ci` workflow is `disabled_manually` and last ran on 2026-07-12 (last 8 runs red). Every check above was run locally. See DBSYNC-74.

## Reviewer notes

- The AC on #81 cited `FileManager.url(for:in:)`; that is not a valid non-throwing overload. The plural `urls(for:in:)` is used instead, and the ticket AC has been corrected.
- Decoding `overlay_state.json` still uses `keyDecodingStrategy = .convertFromSnakeCase`, which on Foundation prior to the swift-foundation rewrite also rewrote **dictionary** keys — i.e. the `paths` map keyed by relative file path. It does not reproduce on macOS 26 (verified), but the app targets macOS 12+ and `JSONDecoder` comes from the user's OS. Deliberately left alone here to keep this diff minimal; tracked as **DBSYNC-73**.
- The local Rust toolchain had to be updated (1.74 → 1.97.1) before anything compiled: `Cargo.lock` is `version = 4`, which needs Cargo ≥ 1.78.

Refs: DBSYNC-72, #81 · Related: DBSYNC-73, DBSYNC-74
