### PR TITLE
fix(#DBSYNC-72): sign the Finder Sync appex with a real Developer ID

### DIFF
--- a/apps/desktop/native/macos/FinderSyncExtension/README.md
+++ b/apps/desktop/native/macos/FinderSyncExtension/README.md
@@ -34,8 +34,11 @@ entitlements, and it reads `overlay_state.json` straight from `~/Library/Applica
 No App Group container is introduced and `db::app_data_dir()` is not changed.
 
 "Carries no entitlements" is a claim about the **shipped artifact**, not merely about the sources, and the two
-can diverge: `xcodebuild` injects `com.apple.security.get-task-allow` unless told not to. Check the product,
-never the project file — `codesign -d --entitlements - build/DropboxSyncFinderSync.appex` must print nothing.
+can diverge: `xcodebuild` injects `com.apple.security.get-task-allow` unless told not to, which is why
+`build-appex.sh` disables that injection on every path, signed or ad-hoc. Check the product, never the project
+file — `codesign -d --entitlements - build/DropboxSyncFinderSync.appex` must print nothing. If it prints
+`get-task-allow`, the appex was built by something other than that script (a plain `xcodebuild`, or Xcode.app)
+and must not be shipped.
 
 **Context.** The app is distributed with **Developer ID** (direct download), not through the Mac App Store.
 App Sandbox is mandatory only for the App Store; Developer ID requires Hardened Runtime plus notarization
@@ -95,11 +98,11 @@ Three things about `build-appex.sh` that are easy to get wrong:
    bundle. The script passes `OTHER_CODE_SIGN_FLAGS=--timestamp`.
 
 Points 2 and 3 are not optional polish, because **this signature is final**: Tauri does not re-sign the appex.
-`copy_custom_files_to_bundle()` places it into `Contents/PlugIns/` without adding it to the bundler's
-`sign_paths`, and the bundler's own `codesign` call carries no `--deep` (verified in `tauri-bundler` 2.8.1,
-the version behind `@tauri-apps/cli` 2.10.1). Whatever is wrong here reaches Apple unchanged — and the bundler
-auto-submits for notarization as soon as credentials are present, so a bad signature is submitted without
-anyone asking for it.
+`copy_custom_files_to_bundle()` (`tauri-bundler` 2.8.1, `bundle/macos/app.rs`) places it into
+`Contents/PlugIns/` without adding it to the bundler's `sign_paths`, and the `codesign` invocation itself —
+which lives in `tauri-macos-sign` 2.3.3, not in the bundler — carries no `--deep`. Whatever is wrong here
+reaches Apple unchanged. Worse, once an identity resolves *and* notarization credentials are present, the
+bundler submits automatically, so a bad signature goes to Apple without anyone asking for it.
 
 With neither variable exported the appex is ad-hoc signed (`Signature=adhoc`, `TeamIdentifier=not set`), which
 is correct for development and for CI, and cannot be notarized.

--- a/apps/desktop/native/macos/FinderSyncExtension/README.md
+++ b/apps/desktop/native/macos/FinderSyncExtension/README.md
@@ -19,7 +19,9 @@ Produces `native/macos/FinderSyncExtension/build/DropboxSyncFinderSync.appex` (a
 
 ## Xcode GUI
 
-Open `DropboxSyncFinderSync.xcodeproj` to edit signing (**Signing & Capabilities** → Team) or Swift. Embed the built **`DropboxSyncFinderSync.appex`** into the main app at **`Contents/PlugIns/`**; host app and extension must use the **same development team** for production. `Info.plist.example` mirrors the committed `Info.plist` for reference.
+Open `DropboxSyncFinderSync.xcodeproj` to edit Swift. Embedding into the main app at **`Contents/PlugIns/`** is automatic via `bundle.macOS.files`, and host app and extension must use the **same Apple team**. `Info.plist.example` mirrors the committed `Info.plist` for reference.
+
+**Do not set the Team under Signing & Capabilities.** The GUI writes `DEVELOPMENT_TEAM` into the committed `project.pbxproj`, which is exactly what the signing section below keeps empty on purpose. Export `APPLE_TEAM_ID` instead.
 
 After install, the user may need to enable the extension under **System Settings → Privacy & Security → Extensions → Finder** (wording varies by macOS version).
 
@@ -27,9 +29,13 @@ After install, the user may need to enable the extension under **System Settings
 
 **Status:** Accepted — 2026-08-19 (DBSYNC-72).
 
-**Decision.** The extension is **not sandboxed**. It ships with Hardened Runtime enabled and no entitlements
-file, and it reads `overlay_state.json` straight from `~/Library/Application Support/DropboxSyncDesktop/`.
+**Decision.** The extension is **not sandboxed**. It ships with Hardened Runtime enabled and carries no
+entitlements, and it reads `overlay_state.json` straight from `~/Library/Application Support/DropboxSyncDesktop/`.
 No App Group container is introduced and `db::app_data_dir()` is not changed.
+
+"Carries no entitlements" is a claim about the **shipped artifact**, not merely about the sources, and the two
+can diverge: `xcodebuild` injects `com.apple.security.get-task-allow` unless told not to. Check the product,
+never the project file — `codesign -d --entitlements - build/DropboxSyncFinderSync.appex` must print nothing.
 
 **Context.** The app is distributed with **Developer ID** (direct download), not through the Mac App Store.
 App Sandbox is mandatory only for the App Store; Developer ID requires Hardened Runtime plus notarization
@@ -54,32 +60,48 @@ or the decoder key-conversion issue (DBSYNC-73).
 
 ## Signing: environment-driven, never committed
 
-`tauri.conf.json` deliberately does **not** set `bundle.macOS.signingIdentity`, and `project.pbxproj` keeps
-`DEVELOPMENT_TEAM = ""`. A value in either place would take precedence over the environment and silently pin
-an identity — which also breaks every unsigned build path, including CI, which holds no certificate.
+Nothing in the repository names a real identity. Two committed values look like they might, and both are
+deliberate fallbacks rather than pins:
 
-Export both variables for a signed build; the same team must be used for the app and the extension:
+- `tauri.conf.json` keeps `bundle.macOS.signingIdentity: "-"` (ad-hoc). **`APPLE_SIGNING_IDENTITY` wins over
+  it** — tauri-cli reads the environment variable first and falls back to the config key only when it is unset
+  (`interface/rust.rs`, verified in 2.10.1). The `"-"` must stay: `tauri-bundler` skips its entire signing
+  block when no identity resolves, so removing it would leave unsigned builds with no signature and no
+  `CodeResources` seal over `Contents/PlugIns/*.appex`.
+- `project.pbxproj` keeps `DEVELOPMENT_TEAM = ""`. `build-appex.sh` passes the team to `xcodebuild` as a
+  command-line override, which takes precedence, so a committed team id would buy nothing.
+
+For a signed build, export both; the same team must be used for the app and the extension:
 
 ```bash
-export APPLE_SIGNING_IDENTITY="Developer ID Application: Your Name (TEAMID)"   # Tauri, host app
-export APPLE_TEAM_ID=TEAMID                                                    # xcodebuild + notarization
-npm run build:finder-sync
+export APPLE_SIGNING_IDENTITY="Developer ID Application: Your Name (TEAMID)"   # host app, read by tauri build
+export APPLE_TEAM_ID=TEAMID                                                    # appex build + notarization
+npm run build:finder-sync    # reads APPLE_TEAM_ID only
+npm run tauri build          # reads both
 ```
 
-Two things about `build-appex.sh` that are easy to get wrong:
+Three things about `build-appex.sh` that are easy to get wrong:
 
-1. **A team alone is not enough.** The project uses `CODE_SIGN_STYLE = Automatic`, and automatic signing
-   resolves a *development* certificate for a build action. With a team set and no **Mac Development**
-   certificate in the keychain — which a Developer ID-only account never has — xcodebuild fails outright with
-   `No signing certificate "Mac Development" found`. The script therefore switches to `CODE_SIGN_STYLE=Manual`
-   and names `CODE_SIGN_IDENTITY` explicitly whenever a team is present. Override the identity with
-   `APPEX_CODE_SIGN_IDENTITY` if you need something other than `Developer ID Application`.
-2. **Xcode signs without a secure timestamp** (`--timestamp=none`). Notarization requires a secure timestamp on
-   every nested bundle, so the `.appex` as produced here is *not* notarizable on its own: it must be re-signed
-   with `--timestamp` before submission. Whether Tauri's bundling pass does that re-signing is still unverified
-   — that is finding F4 of DBSYNC-72, resolved in Slice 4 (#84).
+1. **A team alone is not enough — it breaks the build.** The project uses `CODE_SIGN_STYLE = Automatic`, and
+   automatic signing resolves a *development* certificate for a build action. With a team set and no **Mac
+   Development** certificate in the keychain — which a Developer ID-only account never has — xcodebuild fails
+   with `No signing certificate "Mac Development" found`. The script therefore switches to
+   `CODE_SIGN_STYLE=Manual` and names `CODE_SIGN_IDENTITY` explicitly whenever a team is present. Override it
+   with `APPEX_CODE_SIGN_IDENTITY` if you need something other than `Developer ID Application`.
+2. **`xcodebuild build` injects `com.apple.security.get-task-allow`** by default
+   (`CODE_SIGN_INJECT_BASE_ENTITLEMENTS`). That is a debugging entitlement: notarization refuses it outright,
+   and it defeats part of Hardened Runtime. The script sets it to `NO`.
+3. **Xcode signs with `--timestamp=none`**, while notarization requires a secure TSA timestamp on every nested
+   bundle. The script passes `OTHER_CODE_SIGN_FLAGS=--timestamp`.
 
-With neither variable exported the build is ad-hoc signed (`Signature=adhoc`, `TeamIdentifier=not set`), which
+Points 2 and 3 are not optional polish, because **this signature is final**: Tauri does not re-sign the appex.
+`copy_custom_files_to_bundle()` places it into `Contents/PlugIns/` without adding it to the bundler's
+`sign_paths`, and the bundler's own `codesign` call carries no `--deep` (verified in `tauri-bundler` 2.8.1,
+the version behind `@tauri-apps/cli` 2.10.1). Whatever is wrong here reaches Apple unchanged — and the bundler
+auto-submits for notarization as soon as credentials are present, so a bad signature is submitted without
+anyone asking for it.
+
+With neither variable exported the appex is ad-hoc signed (`Signature=adhoc`, `TeamIdentifier=not set`), which
 is correct for development and for CI, and cannot be notarized.
 
 ## Why not pure Tauri?

--- a/apps/desktop/native/macos/FinderSyncExtension/README.md
+++ b/apps/desktop/native/macos/FinderSyncExtension/README.md
@@ -23,6 +23,65 @@ Open `DropboxSyncFinderSync.xcodeproj` to edit signing (**Signing & Capabilities
 
 After install, the user may need to enable the extension under **System Settings → Privacy & Security → Extensions → Finder** (wording varies by macOS version).
 
+## ADR: no App Sandbox, Hardened Runtime on, no App Group
+
+**Status:** Accepted — 2026-08-19 (DBSYNC-72).
+
+**Decision.** The extension is **not sandboxed**. It ships with Hardened Runtime enabled and no entitlements
+file, and it reads `overlay_state.json` straight from `~/Library/Application Support/DropboxSyncDesktop/`.
+No App Group container is introduced and `db::app_data_dir()` is not changed.
+
+**Context.** The app is distributed with **Developer ID** (direct download), not through the Mac App Store.
+App Sandbox is mandatory only for the App Store; Developer ID requires Hardened Runtime plus notarization
+instead, and both are already in place — `ENABLE_HARDENED_RUNTIME = YES` in both build configurations, and no
+`CODE_SIGN_ENTITLEMENTS` key or `.entitlements` file exists anywhere under `apps/desktop`.
+
+**Why it matters.** Sandboxing is the *only* reason this extension would need an App Group. A sandboxed
+extension cannot read the host app's Application Support directory, which would force the state file into
+`~/Library/Group Containers/<group-id>/`, force a rewrite of `db::app_data_dir()`, force a migration of every
+existing user's state, and require a provisioning profile carrying the App Group entitlement. Staying
+unsandboxed removes all four at no cost.
+
+Verified rather than assumed: running the resolution logic of `overlayStateURL()` outside a container yields
+the plain per-user directory, identical to what the Rust side writes.
+
+**Trade-off accepted.** The app cannot be submitted to the Mac App Store without reopening this decision.
+
+**Contingency — not a planned step.** If the extension cannot read the state file *and* Console.app shows a
+sandbox or TCC denial for the appex, reopen this ADR and cost the App Group migration separately. Badges
+merely being absent is **not** the trigger: likelier causes are a stale `overlay_state.json` (see DBSYNC-75)
+or the decoder key-conversion issue (DBSYNC-73).
+
+## Signing: environment-driven, never committed
+
+`tauri.conf.json` deliberately does **not** set `bundle.macOS.signingIdentity`, and `project.pbxproj` keeps
+`DEVELOPMENT_TEAM = ""`. A value in either place would take precedence over the environment and silently pin
+an identity — which also breaks every unsigned build path, including CI, which holds no certificate.
+
+Export both variables for a signed build; the same team must be used for the app and the extension:
+
+```bash
+export APPLE_SIGNING_IDENTITY="Developer ID Application: Your Name (TEAMID)"   # Tauri, host app
+export APPLE_TEAM_ID=TEAMID                                                    # xcodebuild + notarization
+npm run build:finder-sync
+```
+
+Two things about `build-appex.sh` that are easy to get wrong:
+
+1. **A team alone is not enough.** The project uses `CODE_SIGN_STYLE = Automatic`, and automatic signing
+   resolves a *development* certificate for a build action. With a team set and no **Mac Development**
+   certificate in the keychain — which a Developer ID-only account never has — xcodebuild fails outright with
+   `No signing certificate "Mac Development" found`. The script therefore switches to `CODE_SIGN_STYLE=Manual`
+   and names `CODE_SIGN_IDENTITY` explicitly whenever a team is present. Override the identity with
+   `APPEX_CODE_SIGN_IDENTITY` if you need something other than `Developer ID Application`.
+2. **Xcode signs without a secure timestamp** (`--timestamp=none`). Notarization requires a secure timestamp on
+   every nested bundle, so the `.appex` as produced here is *not* notarizable on its own: it must be re-signed
+   with `--timestamp` before submission. Whether Tauri's bundling pass does that re-signing is still unverified
+   — that is finding F4 of DBSYNC-72, resolved in Slice 4 (#84).
+
+With neither variable exported the build is ad-hoc signed (`Signature=adhoc`, `TeamIdentifier=not set`), which
+is correct for development and for CI, and cannot be notarized.
+
 ## Why not pure Tauri?
 
 Finder badge overlays are implemented only via **App Extension** APIs (`FIFinderSync` / `FIFinderSyncController`). The Rust/Tauri process cannot draw those badges itself.

--- a/apps/desktop/native/macos/FinderSyncExtension/build-appex.sh
+++ b/apps/desktop/native/macos/FinderSyncExtension/build-appex.sh
@@ -32,18 +32,18 @@ echo "Building ${SCHEME}.appex (${CONFIG})…"
 #   error: No signing certificate "Mac Development" found
 # A Developer ID-only account (the distribution model for this app) never has that certificate. So whenever a
 # team is present we switch to manual signing and name the identity explicitly.
-# This signature is FINAL: Tauri does not re-sign it. `copy_custom_files_to_bundle()` places the appex from
-# bundle.macOS.files into Contents/PlugIns/ without adding it to the bundler's sign_paths, and the bundler's
-# codesign invocation carries no --deep (verified in tauri-bundler 2.8.1, the version behind @tauri-apps/cli
-# 2.10.1). Whatever is wrong here reaches notarization unchanged, so the two extra settings below are not
-# optional polish — without them Apple rejects the build:
+# This signature is FINAL: Tauri does not re-sign it. `copy_custom_files_to_bundle()` (tauri-bundler 2.8.1,
+# bundle/macos/app.rs) places the appex from bundle.macOS.files into Contents/PlugIns/ without adding it to
+# the bundler's sign_paths, and the codesign invocation itself — which lives in tauri-macos-sign 2.3.3, not
+# in the bundler — carries no --deep. Whatever is wrong here reaches Apple unchanged.
 #
-#   CODE_SIGN_INJECT_BASE_ENTITLEMENTS=NO   `xcodebuild build` otherwise injects
-#                                           com.apple.security.get-task-allow, a debugging entitlement that
-#                                           notarization refuses and that defeats part of Hardened Runtime.
-#   OTHER_CODE_SIGN_FLAGS=--timestamp       Xcode signs build products with --timestamp=none; notarization
-#                                           requires a secure TSA timestamp on every nested bundle.
-SIGN_ARGS=()
+# CODE_SIGN_INJECT_BASE_ENTITLEMENTS is set unconditionally, NOT only when signing for real: `xcodebuild
+# build` otherwise injects com.apple.security.get-task-allow, a debugger-attach entitlement that notarization
+# refuses and that defeats part of Hardened Runtime. Keeping it out of the ad-hoc path too means the appex
+# never carries it, whichever way it was built — otherwise exporting APPLE_SIGNING_IDENTITY without
+# APPLE_TEAM_ID would produce a Developer ID host wrapping an ad-hoc appex that still has it, and the
+# bundler's notarize_auth() accepts an ASC API key without APPLE_TEAM_ID, so that could be submitted.
+SIGN_ARGS=(CODE_SIGN_INJECT_BASE_ENTITLEMENTS=NO)
 TEAM="${APPLE_TEAM_ID:-${DEVELOPMENT_TEAM:-}}"
 APPEX_IDENTITY="${APPEX_CODE_SIGN_IDENTITY:-Developer ID Application}"
 if [[ -n "$TEAM" ]]; then
@@ -51,11 +51,17 @@ if [[ -n "$TEAM" ]]; then
     DEVELOPMENT_TEAM="$TEAM"
     CODE_SIGN_STYLE=Manual
     CODE_SIGN_IDENTITY="$APPEX_IDENTITY"
-    CODE_SIGN_INJECT_BASE_ENTITLEMENTS=NO
+    # Xcode signs build products with --timestamp=none; notarization requires a secure TSA timestamp on every
+    # nested bundle. Only meaningful with a real identity — an ad-hoc signature cannot be timestamped.
     OTHER_CODE_SIGN_FLAGS="--timestamp"
   )
   echo "Signing appex as '${APPEX_IDENTITY}' for team ${TEAM} (hardened runtime, secure timestamp, no injected entitlements)."
 else
+  if [[ -n "${APPLE_SIGNING_IDENTITY:-}" ]]; then
+    echo "WARNING: APPLE_SIGNING_IDENTITY is set but APPLE_TEAM_ID is not." >&2
+    echo "         The host app will be signed for real while this appex stays ad-hoc, which cannot be" >&2
+    echo "         notarized. Export APPLE_TEAM_ID as well." >&2
+  fi
   echo "No APPLE_TEAM_ID/DEVELOPMENT_TEAM set: ad-hoc signing (fine for development and CI, not notarizable)."
 fi
 

--- a/apps/desktop/native/macos/FinderSyncExtension/build-appex.sh
+++ b/apps/desktop/native/macos/FinderSyncExtension/build-appex.sh
@@ -25,13 +25,28 @@ mkdir -p "$DERIVED"
 echo "Building ${SCHEME}.appex (${CONFIG})…"
 
 # Same team as the main app: set APPLE_TEAM_ID (also used by Tauri notarization) or DEVELOPMENT_TEAM.
-TEAM_ARGS=()
-if [[ -n "${APPLE_TEAM_ID:-}" ]]; then
-  TEAM_ARGS+=(DEVELOPMENT_TEAM="$APPLE_TEAM_ID")
-  echo "Using DEVELOPMENT_TEAM from APPLE_TEAM_ID."
-elif [[ -n "${DEVELOPMENT_TEAM:-}" ]]; then
-  TEAM_ARGS+=(DEVELOPMENT_TEAM="$DEVELOPMENT_TEAM")
-  echo "Using DEVELOPMENT_TEAM from environment."
+#
+# Supplying a team is NOT enough on its own. The project ships CODE_SIGN_STYLE=Automatic, and automatic
+# signing resolves the *development* certificate for a build action: with a team set and no "Mac Development"
+# certificate in the keychain, xcodebuild fails with
+#   error: No signing certificate "Mac Development" found
+# A Developer ID-only account (the distribution model for this app) never has that certificate. So whenever a
+# team is present we switch to manual signing and name the identity explicitly.
+SIGN_ARGS=()
+TEAM="${APPLE_TEAM_ID:-${DEVELOPMENT_TEAM:-}}"
+APPEX_IDENTITY="${APPEX_CODE_SIGN_IDENTITY:-Developer ID Application}"
+if [[ -n "$TEAM" ]]; then
+  SIGN_ARGS+=(
+    DEVELOPMENT_TEAM="$TEAM"
+    CODE_SIGN_STYLE=Manual
+    CODE_SIGN_IDENTITY="$APPEX_IDENTITY"
+  )
+  echo "Signing appex as '${APPEX_IDENTITY}' for team ${TEAM}."
+  # Xcode signs build products with --timestamp=none. A secure timestamp is mandatory for notarization, so
+  # the appex must be re-signed with --timestamp before submission (see DBSYNC-72 Slice 4 / finding F4).
+  echo "NOTE: no secure timestamp is applied here; re-sign with --timestamp before notarizing."
+else
+  echo "No APPLE_TEAM_ID/DEVELOPMENT_TEAM set: ad-hoc signing (fine for development and CI, not notarizable)."
 fi
 
 # -scheme is required with -derivedDataPath on recent Xcode; keeps all output under native/.../build/.
@@ -44,7 +59,7 @@ xcodebuild \
   -destination "generic/platform=macOS" \
   build \
   CODE_SIGNING_ALLOWED="${CODE_SIGNING_ALLOWED:-YES}" \
-  "${TEAM_ARGS[@]+"${TEAM_ARGS[@]}"}"
+  "${SIGN_ARGS[@]+"${SIGN_ARGS[@]}"}"
 
 OUT="${DERIVED}/Build/Products/${CONFIG}/${SCHEME}.appex"
 echo "Built: $OUT"

--- a/apps/desktop/native/macos/FinderSyncExtension/build-appex.sh
+++ b/apps/desktop/native/macos/FinderSyncExtension/build-appex.sh
@@ -32,6 +32,17 @@ echo "Building ${SCHEME}.appex (${CONFIG})…"
 #   error: No signing certificate "Mac Development" found
 # A Developer ID-only account (the distribution model for this app) never has that certificate. So whenever a
 # team is present we switch to manual signing and name the identity explicitly.
+# This signature is FINAL: Tauri does not re-sign it. `copy_custom_files_to_bundle()` places the appex from
+# bundle.macOS.files into Contents/PlugIns/ without adding it to the bundler's sign_paths, and the bundler's
+# codesign invocation carries no --deep (verified in tauri-bundler 2.8.1, the version behind @tauri-apps/cli
+# 2.10.1). Whatever is wrong here reaches notarization unchanged, so the two extra settings below are not
+# optional polish — without them Apple rejects the build:
+#
+#   CODE_SIGN_INJECT_BASE_ENTITLEMENTS=NO   `xcodebuild build` otherwise injects
+#                                           com.apple.security.get-task-allow, a debugging entitlement that
+#                                           notarization refuses and that defeats part of Hardened Runtime.
+#   OTHER_CODE_SIGN_FLAGS=--timestamp       Xcode signs build products with --timestamp=none; notarization
+#                                           requires a secure TSA timestamp on every nested bundle.
 SIGN_ARGS=()
 TEAM="${APPLE_TEAM_ID:-${DEVELOPMENT_TEAM:-}}"
 APPEX_IDENTITY="${APPEX_CODE_SIGN_IDENTITY:-Developer ID Application}"
@@ -40,17 +51,16 @@ if [[ -n "$TEAM" ]]; then
     DEVELOPMENT_TEAM="$TEAM"
     CODE_SIGN_STYLE=Manual
     CODE_SIGN_IDENTITY="$APPEX_IDENTITY"
+    CODE_SIGN_INJECT_BASE_ENTITLEMENTS=NO
+    OTHER_CODE_SIGN_FLAGS="--timestamp"
   )
-  echo "Signing appex as '${APPEX_IDENTITY}' for team ${TEAM}."
-  # Xcode signs build products with --timestamp=none. A secure timestamp is mandatory for notarization, so
-  # the appex must be re-signed with --timestamp before submission (see DBSYNC-72 Slice 4 / finding F4).
-  echo "NOTE: no secure timestamp is applied here; re-sign with --timestamp before notarizing."
+  echo "Signing appex as '${APPEX_IDENTITY}' for team ${TEAM} (hardened runtime, secure timestamp, no injected entitlements)."
 else
   echo "No APPLE_TEAM_ID/DEVELOPMENT_TEAM set: ad-hoc signing (fine for development and CI, not notarizable)."
 fi
 
 # -scheme is required with -derivedDataPath on recent Xcode; keeps all output under native/.../build/.
-# With `set -u`, a plain "${TEAM_ARGS[@]}" can fail when the array is empty (macOS Bash 3.2).
+# With `set -u`, a plain "${SIGN_ARGS[@]}" can fail when the array is empty (macOS Bash 3.2).
 xcodebuild \
   -project "$PROJECT" \
   -scheme "$SCHEME" \

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -3,16 +3,22 @@
   // macOS: Finder Sync extension is bundled via bundle.macOS.files; build it with `npm run build:finder-sync`
   // (runs automatically on macOS from beforeBuildCommand).
   //
-  // Signing is ENV-DRIVEN, never committed. bundle.macOS.signingIdentity is deliberately ABSENT so that
-  // APPLE_SIGNING_IDENTITY governs: a value here would take precedence over the env var and silently pin
-  // whatever it names. Export both before a release build, using the same Apple team for app and .appex:
+  // Signing is ENV-DRIVEN. APPLE_SIGNING_IDENTITY WINS over the value below — tauri-cli reads the env var
+  // first and falls back to this key only when it is unset (interface/rust.rs, verified in 2.10.1). So
+  // exporting an identity is all it takes; nothing here has to change:
   //
   //   export APPLE_SIGNING_IDENTITY="Developer ID Application: Your Name (TEAMID)"
-  //   export APPLE_TEAM_ID=TEAMID     # xcodebuild reads it as DEVELOPMENT_TEAM; also used for notarization
+  //   export APPLE_TEAM_ID=TEAMID     # build-appex.sh passes it to xcodebuild as DEVELOPMENT_TEAM,
+  //                                   # and notarization uses it too
   //
-  // With neither exported the build is ad-hoc signed and unnotarizable — correct for CI, which has no
-  // certificate, and for local development. Do NOT hardcode an identity: besides breaking those unsigned
-  // paths, this machine may hold identities belonging to other organisations.
+  // signingIdentity is pinned to "-" (ad-hoc) ON PURPOSE, and must stay. It is the fallback for builds with
+  // no identity exported — CI, and ordinary local builds. Deleting it does NOT make them "unsigned but
+  // otherwise fine": tauri-bundler skips its whole signing block when no identity resolves, so the .app
+  // would come out with no signature and no CodeResources seal over Contents/PlugIns/*.appex at all. An
+  // unsealed host bundle is a plausible reason for Finder to refuse to load the extension.
+  //
+  // Never hardcode a real identity here. This machine also holds Developer ID identities owned by other
+  // organisations, and a committed value would make one of them selectable by accident.
   "productName": "DropboxSyncDesktop",
   "version": "0.1.0",
   "identifier": "com.mobsanchez.dropboxsyncdesktop",
@@ -55,6 +61,7 @@
     "macOS": {
       "minimumSystemVersion": "12.0",
       "infoPlist": "Info.plist",
+      "signingIdentity": "-",
       "files": {
         "PlugIns/DropboxSyncFinderSync.appex": "../native/macos/FinderSyncExtension/build/DropboxSyncFinderSync.appex"
       }

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -1,10 +1,18 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   // macOS: Finder Sync extension is bundled via bundle.macOS.files; build it with `npm run build:finder-sync`
-  // (runs automatically on macOS from beforeBuildCommand). For badges to load reliably, avoid ad-hoc signing:
-  // set bundle.macOS.signingIdentity to your certificate (e.g. "Apple Development: Your Name (TEAMID)" or
-  // "Developer ID Application: …"). Use the same Apple team for the .appex: export APPLE_TEAM_ID=XXXXXXXX
-  // before `npm run tauri build` so xcodebuild picks DEVELOPMENT_TEAM (also used for notarization env vars).
+  // (runs automatically on macOS from beforeBuildCommand).
+  //
+  // Signing is ENV-DRIVEN, never committed. bundle.macOS.signingIdentity is deliberately ABSENT so that
+  // APPLE_SIGNING_IDENTITY governs: a value here would take precedence over the env var and silently pin
+  // whatever it names. Export both before a release build, using the same Apple team for app and .appex:
+  //
+  //   export APPLE_SIGNING_IDENTITY="Developer ID Application: Your Name (TEAMID)"
+  //   export APPLE_TEAM_ID=TEAMID     # xcodebuild reads it as DEVELOPMENT_TEAM; also used for notarization
+  //
+  // With neither exported the build is ad-hoc signed and unnotarizable — correct for CI, which has no
+  // certificate, and for local development. Do NOT hardcode an identity: besides breaking those unsigned
+  // paths, this machine may hold identities belonging to other organisations.
   "productName": "DropboxSyncDesktop",
   "version": "0.1.0",
   "identifier": "com.mobsanchez.dropboxsyncdesktop",
@@ -47,7 +55,6 @@
     "macOS": {
       "minimumSystemVersion": "12.0",
       "infoPlist": "Info.plist",
-      "signingIdentity": "-",
       "files": {
         "PlugIns/DropboxSyncFinderSync.appex": "../native/macos/FinderSyncExtension/build/DropboxSyncFinderSync.appex"
       }


### PR DESCRIPTION
## Summary

DBSYNC-72 Slice 2 (#82): make the Finder Sync appex sign with a real Developer ID instead of ad-hoc, driven entirely by the environment, and record the no-sandbox decision where implementers will read it.

Two of the slice's acceptance criteria turned out to be wrong. Both are documented below with the evidence, because the corrections matter more than the diff.

## The AC that would have made things worse

> re-running `build-appex.sh` with `APPLE_TEAM_ID=XCAA3WMJM6` exported must stop producing `codesign --sign -`

It does not. It fails the build:

```
$ APPLE_TEAM_ID=XCAA3WMJM6 bash build-appex.sh
Using DEVELOPMENT_TEAM from APPLE_TEAM_ID.
error: No signing certificate "Mac Development" found: No "Mac Development" signing
certificate matching team ID "XCAA3WMJM6" with a private key was found.
** BUILD FAILED **
```

`CODE_SIGN_STYLE = Automatic` resolves a **development** certificate for a build action. A Developer ID-only account — this project's distribution model, per the ADR — never has a *Mac Development* certificate. So the fix belongs in `build-appex.sh`, not in `project.pbxproj`: manual signing with an explicit `CODE_SIGN_IDENTITY` whenever a team is present.

Verified on the produced artifact, not the build log:

| Environment | `codesign -dv` on `build/DropboxSyncFinderSync.appex` |
|---|---|
| `APPLE_TEAM_ID=XCAA3WMJM6` | `Authority=Developer ID Application: Manuel Sanchez (XCAA3WMJM6)` → Developer ID CA → Apple Root CA · `flags=0x10000(runtime)` · `TeamIdentifier=XCAA3WMJM6` |
| nothing exported | `flags=0x10002(adhoc,runtime)` · `Signature=adhoc` · `TeamIdentifier=not set` |

The second row is the important one: CI and ordinary local builds are untouched.

## The AC I deliberately did not implement

> `DEVELOPMENT_TEAM` supplied env-driven via `APPLE_TEAM_ID` in BOTH configurations

`project.pbxproj` keeps `DEVELOPMENT_TEAM = ""`. The script already passes the team as an xcodebuild command-line override, which takes precedence, so writing it into the project file would pin an identity in git and buy nothing. `XCAA3WMJM6` appears **0 times** in tracked sources. This machine also holds Developer ID identities belonging to other organisations; no committed value may ever make one of them selectable by accident.

## New evidence for finding F4 — this shapes Slice 4 (#84)

Xcode signs build products with **`--timestamp=none`**. The signed appex has the full Developer ID chain and hardened runtime but **no secure timestamp**, which notarization requires on every nested bundle. The appex as produced is therefore **not notarizable**; it must be re-signed with `--timestamp` before submission.

F4 asked whether Tauri re-signs the nested appex. It is now a requirement, not a curiosity: if Tauri's pass does not re-sign *with a timestamp*, Slice 4 must add an explicit step. Both `build-appex.sh` and the README say so at the point where someone would otherwise lose an afternoon to a notarization rejection.

## Stack

`desktop-tauri` — build configuration and documentation only. No Rust, Swift or TypeScript source changed.

## Jira Ticket

DBSYNC-72 — https://manuelbsan.atlassian.net/browse/DBSYNC-72

## Test Plan

- [x] `cargo test` → **163 passed**. This also exercises the config edit: `tauri_build::build()` parses `tauri.conf.json`, so a malformed JSONC would fail the build.
- [x] `cargo clippy --all-targets` → no new warnings
- [x] `npm --workspace apps/desktop run build` → clean
- [x] `build-appex.sh` → BUILD SUCCEEDED with a team exported **and** with nothing exported

### Assertion criteria ("confirm what is already true")

- `ENABLE_HARDENED_RUNTIME = YES` → 2 (Debug + Release)
- `CODE_SIGN_ENTITLEMENTS` → 0 · `*.entitlements` under `apps/desktop` → 0
- `DEVELOPMENT_TEAM = "";` → 2 · `XCAA3WMJM6` in tracked sources → 0
- `Group Containers` in `src-tauri/src` → 0 · `storage/db.rs` unmodified
- `PRODUCT_BUNDLE_IDENTIFIER = com.mobsanchez.dropboxsyncdesktop.findersync` in both configs, unchanged

## What this PR does NOT prove

Notarization acceptance and badge rendering. Those are Slices 4 (#84) and 3 (#83). Nothing here was verified by CI either — the `ci` workflow is still `disabled_manually` (DBSYNC-74).

Refs: DBSYNC-72, #82 · Related: DBSYNC-73, DBSYNC-74, DBSYNC-75
