### PR TITLE
fix(#DBSYNC-76): resolvable principal class and an AppKit run loop for the appex

### DIFF
--- a/apps/desktop/native/macos/FinderSyncExtension/Info.plist
+++ b/apps/desktop/native/macos/FinderSyncExtension/Info.plist
@@ -29,6 +29,13 @@
 	<true/>
 	<key>NSExtension</key>
 	<dict>
+		<!-- Empty on purpose. Apple's Finder Sync template emits it, and all three working
+		     extensions on a reference Mac carry it. Adding it alone was tested and does NOT fix
+		     registration (DBSYNC-76), but leaving it out would be the last structural difference
+		     between our NSExtension dict and every known-good one — an uncontrolled variable for
+		     the cross-swap experiment in Slice 2. -->
+		<key>NSExtensionAttributes</key>
+		<dict/>
 		<key>NSExtensionPointIdentifier</key>
 		<string>com.apple.FinderSync</string>
 		<!-- BARE class name, not module-qualified. SyncExtension.swift declares

--- a/apps/desktop/native/macos/FinderSyncExtension/Info.plist
+++ b/apps/desktop/native/macos/FinderSyncExtension/Info.plist
@@ -20,12 +20,25 @@
 	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<!-- The extension host needs an AppKit run loop: SyncExtension.swift schedules a repeating
+	     Timer from init(), which never fires without one. Both Dropbox's garcon.appex and
+	     OneDrive's FinderSync.appex declare these two keys. -->
+	<key>NSPrincipalClass</key>
+	<string>NSApplication</string>
+	<key>LSUIElement</key>
+	<true/>
 	<key>NSExtension</key>
 	<dict>
 		<key>NSExtensionPointIdentifier</key>
 		<string>com.apple.FinderSync</string>
+		<!-- BARE class name, not module-qualified. SyncExtension.swift declares
+		     @objc(DropboxSyncFinderSync), and @objc(...) REPLACES the Swift-mangled runtime name
+		     with that literal: the binary exports _OBJC_CLASS_$_DropboxSyncFinderSync and no _TtC
+		     symbol at all, so "$(PRODUCT_MODULE_NAME).DropboxSyncFinderSync" resolves to nil.
+		     Keep both in sync — verify with:
+		       nm -a build/DropboxSyncFinderSync.appex/Contents/MacOS/DropboxSyncFinderSync | grep OBJC_CLASS -->
 		<key>NSExtensionPrincipalClass</key>
-		<string>$(PRODUCT_MODULE_NAME).DropboxSyncFinderSync</string>
+		<string>DropboxSyncFinderSync</string>
 	</dict>
 </dict>
 </plist>

--- a/apps/desktop/native/macos/FinderSyncExtension/Info.plist.example
+++ b/apps/desktop/native/macos/FinderSyncExtension/Info.plist.example
@@ -26,6 +26,8 @@
 	<true/>
 	<key>NSExtension</key>
 	<dict>
+		<key>NSExtensionAttributes</key>
+		<dict/>
 		<key>NSExtensionPointIdentifier</key>
 		<string>com.apple.FinderSync</string>
 		<!-- Bare class name: @objc(DropboxSyncFinderSync) replaces the mangled Swift name. -->

--- a/apps/desktop/native/macos/FinderSyncExtension/Info.plist.example
+++ b/apps/desktop/native/macos/FinderSyncExtension/Info.plist.example
@@ -20,12 +20,17 @@
 	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>NSPrincipalClass</key>
+	<string>NSApplication</string>
+	<key>LSUIElement</key>
+	<true/>
 	<key>NSExtension</key>
 	<dict>
 		<key>NSExtensionPointIdentifier</key>
 		<string>com.apple.FinderSync</string>
+		<!-- Bare class name: @objc(DropboxSyncFinderSync) replaces the mangled Swift name. -->
 		<key>NSExtensionPrincipalClass</key>
-		<string>$(PRODUCT_MODULE_NAME).DropboxSyncFinderSync</string>
+		<string>DropboxSyncFinderSync</string>
 	</dict>
 </dict>
 </plist>

--- a/apps/desktop/native/macos/FinderSyncExtension/build-appex.sh
+++ b/apps/desktop/native/macos/FinderSyncExtension/build-appex.sh
@@ -79,6 +79,21 @@ xcodebuild \
 
 OUT="${DERIVED}/Build/Products/${CONFIG}/${SCHEME}.appex"
 echo "Built: $OUT"
+
+# Guard the coupling between SyncExtension.swift's @objc(...) name and the plist's principal class.
+# Nothing else catches a drift: removing the @objc attribute changes the emitted ObjC symbol to the
+# Swift-mangled form and the plist silently stops resolving, with no build error and no test failure.
+# This ran green on macos-latest in CI via `tauri build` -> beforeBuildCommand -> build:finder-sync.
+if [[ -d "$OUT" ]]; then
+  DECLARED=$(/usr/libexec/PlistBuddy -c "Print :NSExtension:NSExtensionPrincipalClass" "$OUT/Contents/Info.plist" 2>/dev/null || true)
+  EMITTED=$(nm -a "$OUT/Contents/MacOS/${SCHEME}" 2>/dev/null | sed -n 's/.*_OBJC_CLASS_\$_//p' | head -1)
+  if [[ -z "$EMITTED" || "$DECLARED" != "$EMITTED" ]]; then
+    echo "ERROR: NSExtensionPrincipalClass '${DECLARED}' does not match the ObjC class the binary exports ('${EMITTED:-none}')." >&2
+    echo "       NSClassFromString would return nil and the extension could never load. See DBSYNC-76." >&2
+    exit 1
+  fi
+  echo "Principal class OK: ${DECLARED}"
+fi
 if [[ -d "$OUT" ]]; then
   mkdir -p "${ROOT}/build"
   rm -rf "${ROOT}/build/${SCHEME}.appex"


### PR DESCRIPTION
## This PR does not fix the ticket's symptom, and that is by design

macOS still does not register the extension after this change:

```
$ pluginkit -m -A -i com.mobsanchez.dropboxsyncdesktop.findersync
(nothing)
```

That negative result is an **explicit acceptance criterion** of DBSYNC-76 Slice 1, and confirming it matters: it means the analysis holds and the root-cause experiment (Slice 2) is still required. Had it registered, that would have been a surprise worth chasing — `NSPrincipalClass` is a plist key and `pkd` does read the plist, so the possibility was real.

What this PR fixes is two **separate, confirmed** defects queued behind the registration bug.

### 1. The principal class was unresolvable

`SyncExtension.swift:9` declares `@objc(DropboxSyncFinderSync)`. That attribute **replaces** the Swift-mangled runtime name with the bare literal. Measured on the binary, not inferred:

```
$ nm -a .../DropboxSyncFinderSync | grep -c _TtC        → 0
$ nm -a .../DropboxSyncFinderSync | grep OBJC_CLASS     → _OBJC_CLASS_$_DropboxSyncFinderSync
```

The plist asked for `$(PRODUCT_MODULE_NAME).DropboxSyncFinderSync`, so `NSClassFromString(...)` returned nil. **The extension could never have loaded, even with registration working.** Dropbox's `garcon.appex` (`EFFinderExtension`) and OneDrive's `FinderSync.appex` (`FinderSync`) both ship bare names.

### 2. No AppKit run loop in the extension host

Neither `NSPrincipalClass = NSApplication` nor `LSUIElement` was declared, while `SyncExtension.swift:25` schedules a repeating `Timer` from `init()` — which never fires without an AppKit run loop. Badges would not have refreshed even after a successful load. Both working references declare both keys.

## Why before the investigation rather than after

These two make the next step interpretable. When Slice 2 puts our appex under an Xcode-generated host to isolate whether `pkd` rejects the appex or the host, a failure should point at something real — not at a class that was never resolvable to begin with.

Left unfixed, they would have surfaced immediately after the registration fix as *"it registers but does nothing"*, which reads like the fix having failed and costs a diagnosis cycle.

The trade-off is real and was accepted deliberately: this is a PR that goes through review without resolving the headline bug.

## Verification

| Check | Result |
|---|---|
| plist `NSExtensionPrincipalClass` vs `nm` OBJC_CLASS symbol | `DropboxSyncFinderSync` = `DropboxSyncFinderSync` — match |
| `NSPrincipalClass` / `LSUIElement` in the built appex | `NSApplication` / `true` |
| `build-appex.sh` with `APPLE_TEAM_ID` exported | BUILD SUCCEEDED |
| Artifact signature | Developer ID chain, `flags=0x10000(runtime)`, `Timestamp=19 Aug 2026 at 19:40:56`, `TeamIdentifier=XCAA3WMJM6` |
| Entitlements on the artifact | 0 bytes |
| `codesign --verify --strict` | valid on disk, satisfies its Designated Requirement |
| `pluginkit` registration | still absent — **expected**, see above |

Everything was checked against the built product. That distinction has already caught two real defects in DBSYNC-72 that the project files denied.

No Rust or TypeScript file is touched, so `cargo test` and the frontend build are unaffected by this change.

`Info.plist.example` is updated in step: the README declares it a mirror of the committed plist, and leaving it behind would have it documenting the wrong class name.

## Jira

DBSYNC-76 — https://manuelbsan.atlassian.net/browse/DBSYNC-76 (Slice 1 of 4)

Next: Slice 2 — build a minimal Xcode-generated Finder Sync extension, confirm it registers on this Mac, then cross-swap our appex under its host and its appex under ours. Two builds isolate the axis every experiment so far has held constant.
