### PR TITLE
fix(#DBSYNC-82): give the tray's left click to the flyout, the right click to the menu

### DIFF
--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -264,10 +264,21 @@ pub fn run() {
                 .icon(tray_image)
                 .icon_as_template(idle_as_template)
                 .menu(&menu)
+                // DBSYNC-82. `tray-icon` defaults `menu_on_left_click` to TRUE, so without
+                // this the left click opened the menu as well as running the handler below,
+                // and the menu stealing focus made the flyout blur-hide itself. Three
+                // behaviours on one gesture; it took about three clicks to land the window.
+                // Off, the menu belongs to the right click — which `tray-icon` shows
+                // unconditionally, so nothing is lost and the handler needs no change.
+                .show_menu_on_left_click(false)
                 .tooltip("DropboxSyncDesktop - Idle")
                 .on_tray_icon_event(move |_tray, event| {
-                    // Single source of truth for the flyout: a left-click toggles it
-                    // (shows+positions if hidden, hides if visible). No more DoubleClick.
+                    // The flyout's only trigger — true because `show_menu_on_left_click`
+                    // above takes the menu off this gesture, not because nothing else
+                    // could claim it. A left-click toggles the window (shows+positions if
+                    // hidden, hides if visible). No DoubleClick. The right click also
+                    // arrives here carrying `MouseButton::Right` and is ignored by the
+                    // match below, so it opens the menu without touching the flyout.
                     if let TrayIconEvent::Click {
                         button: MouseButton::Left,
                         button_state: MouseButtonState::Up,


### PR DESCRIPTION
## Summary

Clicking the menu-bar icon took **about three attempts** to show the window, and which attempt worked was not predictable. One builder call fixes it.

## Three behaviours on one gesture, not two

The ticket originally said two. The architecture review found a third, which is what makes the symptom non-deterministic:

1. **The menu opened on left click.** `tray-icon 0.21.3` defaults `menu_on_left_click` to `true` (`src/lib.rs:209`) and the builder never overrode it.
2. **The flyout toggled on the same click** via `on_tray_icon_event`.
3. **The blur-hide then fired**, because the menu had taken key focus from the flyout that had just been shown (`run_events.rs`).

The third one is the tell: that blur-hide **already carries a 250 ms `recently_toggled` suppression**, and its own doc comment describes this exact race — *"a click that both focuses the (already-visible) window and re-triggers the tray toggle doesn't race a blur-driven hide immediately followed by a click-driven show"*. Someone met this symptom before and put a timer over it instead of removing its cause.

## The fix

`show_menu_on_left_click(false)`. **The menu is not lost, and this is settled from the dependency source rather than assumed** — `tray-icon-0.21.3/src/platform_impl/macos/mod.rs:477`:

```rust
if button == MouseButton::Right || (menu_on_left_click && button == MouseButton::Left) {
```

Right click shows the menu **unconditionally**; only the left click is gated by the flag. The right click also reaches our handler carrying `MouseButton::Right`, which the existing match already ignores — so no handler change was needed, and none was made.

Both comments are rewritten. The old one called itself the *"single source of truth for the flyout"* while the builder default was quietly competing with it. The new text **names the precondition** that makes the claim true rather than restating the claim — a comment that only became correct by accident is worth replacing, not preserving.

## Stack

`desktop-tauri` (Rust only — no IPC, no capabilities, no new dependency)

## Jira Ticket

#DBSYNC-82 — slices [#95](https://github.com/mbsanchez/DropboxSync/issues/95) (AFK) and [#96](https://github.com/mbsanchez/DropboxSync/issues/96) (manual).

## Test Plan

- [x] `cargo test` — **174 passed**. Their role here is regression only.
- [x] `cargo clippy --all-targets` — no new warnings, and **zero deprecation warnings**, which is the one automated signal that actually distinguishes the correct API from the deprecated `menu_on_left_click`.
- [x] **No new unit test, and none was invented.** `cargo test` cannot press a mouse button, and the builder lives inside `run()`'s `setup` closure with no seam. Creating one purely to assert a boolean would add indirection to production code to buy a test that restates a source line. Stated rather than papered over.

### Manual desktop validation (macOS menu bar)

Clicks synthesised with `CGEvent` — accessibility's `click` only performs a menu-bar item's *default* action, so the right-click half cannot be exercised through AppleScript. Visibility read via System Events' window count.

- [x] **One** left click shows the flyout: 0 windows → 1.
- [x] A second hides it: → 0.
- [x] **10 alternating rounds: 10 passed, 0 failed** — `show=1 hide=0` every time. This is the criterion that matters; the bug was non-deterministic, so a single success would have proved nothing.
- [x] Right click shows the menu — **Settings** and **Exit** both render.
- [x] Right click does **not** toggle the flyout — window count stayed at 0 across the gesture.

## The 250 ms suppression: measured, and deliberately left alone

Both branches of the gate were instrumented and exercised:

| Scenario | `visible` | `suppressed` | Outcome |
| --- | --- | --- | --- |
| 12 events during tray-click sequences | `false` | `true` | Suppression changed nothing — the hide was already a no-op |
| 1 event on a genuine click-away | `true` | `false` | Hide ran correctly and the flyout closed |

**`visible && suppressed` was true 0 times out of 13.**

Two separate readings, and conflating them would be wrong:

- **The blur-hide is load-bearing.** The click-away case shows it doing its job. Nothing here argues against it.
- **The guard around it never altered an outcome** in these samples.

**It was not removed.** 13 samples across two interaction patterns is evidence, not proof, and timing workarounds fail on the machine you did not test. Deleting one on the same day its suspected cause disappeared is precisely the move that created it. Filed as [#97](https://github.com/mbsanchez/DropboxSync/issues/97) with the data and a better route than more sampling: prove from the code that the set of events which can still trigger the race is empty.

### A discarded measurement, recorded

The first click-away run was **invalid and its data thrown out**. It clicked at (640, 500) intending to land outside the flyout — but the flyout occupies **(331, 30) 360×600**, so that point is *inside the window*. The results were incoherent, and they looked enough like a finding that treating them as one would have produced a confident wrong answer. The window geometry was queried and the test redone at (100, 700).

- [x] Instrumentation removed before commit — `grep DBSYNC82 run_events.rs` → 0; the diff is one file, +13/−2.
- [x] Clean build reinstalled and re-checked: opens on the first click, zero instrumentation lines in the log.

## Not covered

**Windows and Linux.** `menu_on_left_click` has a separate platform implementation on each, and the source reading above is the **macOS** file specifically. Unverified from this machine.

🤖 Generated with Claude Code