### PR TITLE
fix(#DBSYNC-81): keep cargo test out of the real keychain, and stop chunking off Windows

### DIFF
--- a/apps/desktop/src-tauri/src/storage/secure_store.rs
+++ b/apps/desktop/src-tauri/src/storage/secure_store.rs
@@ -13,7 +13,22 @@ const SESSION_EXPIRES: &str = "dropbox-session-expires";
 
 /// Windows `CRED_MAX_CREDENTIAL_BLOB_SIZE` is 2560 bytes; keyring stores passwords as UTF-16 LE,
 /// so the check is `utf16_units * 2 <= 2560`. We stay under that per chunk.
+#[cfg(windows)]
 const SAFE_UTF16_PAYLOAD_BYTES: usize = 2400;
+
+/// **No equivalent ceiling exists off Windows** (DBSYNC-81). Chunking there bought
+/// nothing and cost a keychain prompt per part: macOS asks per ITEM, so a token split
+/// into a marker plus two chunks turned one authorization into three. Measured on the
+/// maintainer's Mac — five stored items, five dialogs on first run.
+///
+/// `MAX / 2` rather than `MAX` so the `cur_bytes + add` accumulator in
+/// [`split_utf16_chunks`] cannot overflow. Any real secret is astronomically below it,
+/// so the single-chunk path always wins — and that path is what migrates existing
+/// users: [`store_value_chunked`] inlines the value into the base key and calls
+/// `clear_overflow_parts(base, 0)`, deleting the `.0`/`.1` entries left by the old
+/// layout. No separate migration step, and no half-migrated state to reason about.
+#[cfg(not(windows))]
+const SAFE_UTF16_PAYLOAD_BYTES: usize = usize::MAX / 2;
 
 /// Marker in the primary entry when the secret is split across `name.0`, `name.1`, ...
 const CHUNK_MARKER: &str = "__KEYRING_CHUNKED_V1__:";
@@ -225,4 +240,51 @@ fn clear_chunked_key(base: &str) -> Result<(), keyring::Error> {
     let base_result = delete_credential_if_present(base);
     clear_overflow_parts(base, 0);
     base_result
+}
+
+#[cfg(test)]
+mod chunking_tests {
+    use super::{split_utf16_chunks, utf16_payload_bytes, SAFE_UTF16_PAYLOAD_BYTES};
+
+    /// A Dropbox access token comfortably exceeds the Windows blob ceiling, which is why
+    /// the chunking exists at all. Build one of that shape to test against.
+    fn oversized_secret() -> String {
+        "a".repeat(3000)
+    }
+
+    #[test]
+    fn the_test_secret_really_is_over_the_windows_ceiling() {
+        // Guards the two tests below: if this ever stops holding they would both pass
+        // vacuously, proving nothing about chunking on either platform.
+        assert!(utf16_payload_bytes(&oversized_secret()) > 2400);
+    }
+
+    /// DBSYNC-81. Off Windows the keychain has no blob-size ceiling, so a secret of any
+    /// size lives in ONE item. That is the whole fix: macOS prompts per item, and three
+    /// items for one token meant three dialogs.
+    #[cfg(not(windows))]
+    #[test]
+    fn an_oversized_secret_is_not_split_off_windows() {
+        assert_eq!(split_utf16_chunks(&oversized_secret()).len(), 1);
+    }
+
+    /// Windows keeps its ceiling: `CRED_MAX_CREDENTIAL_BLOB_SIZE` is real and exceeding
+    /// it fails at runtime, not at compile time. Compiled only there, so it asserts
+    /// about the platform it describes rather than about a constant.
+    #[cfg(windows)]
+    #[test]
+    fn an_oversized_secret_is_still_split_on_windows() {
+        let chunks = split_utf16_chunks(&oversized_secret());
+        assert!(chunks.len() > 1);
+        for c in &chunks {
+            assert!(utf16_payload_bytes(c) <= SAFE_UTF16_PAYLOAD_BYTES);
+        }
+    }
+
+    /// Whatever the platform, splitting must never lose or reorder data.
+    #[test]
+    fn chunks_always_rejoin_to_the_original() {
+        let secret = oversized_secret();
+        assert_eq!(split_utf16_chunks(&secret).concat(), secret);
+    }
 }

--- a/apps/desktop/src-tauri/src/storage/secure_store.rs
+++ b/apps/desktop/src-tauri/src/storage/secure_store.rs
@@ -244,7 +244,11 @@ fn clear_chunked_key(base: &str) -> Result<(), keyring::Error> {
 
 #[cfg(test)]
 mod chunking_tests {
-    use super::{split_utf16_chunks, utf16_payload_bytes, SAFE_UTF16_PAYLOAD_BYTES};
+    use super::{split_utf16_chunks, utf16_payload_bytes};
+    // Only the Windows test asserts against the ceiling; off Windows the constant is
+    // effectively unbounded and importing it unconditionally is a dead import.
+    #[cfg(windows)]
+    use super::SAFE_UTF16_PAYLOAD_BYTES;
 
     /// A Dropbox access token comfortably exceeds the Windows blob ceiling, which is why
     /// the chunking exists at all. Build one of that shape to test against.

--- a/apps/desktop/src-tauri/src/sync_pipeline.rs
+++ b/apps/desktop/src-tauri/src/sync_pipeline.rs
@@ -567,7 +567,14 @@ pub(crate) fn mass_delete_pause_active(state: &AppState) -> AppResult<bool> {
     Ok(scan_paused || remote_paused)
 }
 
-pub(crate) fn scan_local_changes_internal(state: &AppState) -> AppResult<usize> {
+/// The LOCAL half of a scan: walk the sync folder, decide what changed, and enqueue
+/// uploads and deletions. Returns how many jobs it enqueued.
+///
+/// Split out of [`scan_local_changes_internal`] because that function does two jobs and
+/// only the second needs credentials (DBSYNC-81). Keeping them apart lets the local
+/// decisions be exercised without an access token — which is what a test of the
+/// mass-deletion guard actually wants.
+fn scan_local_changes_only(state: &AppState) -> AppResult<usize> {
     let folder = state
         .db
         .get_sync_folder()?
@@ -733,6 +740,15 @@ pub(crate) fn scan_local_changes_internal(state: &AppState) -> AppResult<usize> 
         }
     }
 
+    Ok(enqueued_jobs)
+}
+
+/// A full scan: the local half, then the remote refresh, then the bookkeeping.
+///
+/// The remote half needs an access token, so this is the entry point for production and
+/// NOT the one to reach for from a test that only cares about local decisions.
+pub(crate) fn scan_local_changes_internal(state: &AppState) -> AppResult<usize> {
+    let enqueued_jobs = scan_local_changes_only(state)?;
     let remote_enqueued = refresh_remote_index_and_enqueue_downloads_internal(state)?;
 
     {
@@ -1179,7 +1195,7 @@ mod tests {
     use super::{
         block_mass_deletion, cleanup_stale_upload_state, clear_mass_delete_blocked,
         is_mass_deletion, mass_delete_pause_active, process_changed_paths,
-        resolve_conflict_internal, run_sync_tick_internal, scan_local_changes_internal,
+        resolve_conflict_internal, run_sync_tick_internal, scan_local_changes_only,
         ConflictAction, MassDeleteSource, SYNC_BATCH_CAP,
     };
     use crate::state::AppState;
@@ -1861,13 +1877,17 @@ mod tests {
         }
 
         // First scan: the batch is a mass deletion → BLOCKED. Nothing propagated,
-        // index rows kept, and a DURABLE pause flag persisted. (The scan's later
-        // remote-refresh step errors here with no token, but the deletion decision +
-        // the pause-flag write run BEFORE it, so those side effects are committed —
-        // ignore the Result and assert them. Asserting the DURABLE app_config flag,
-        // not the transient engine error, is what proves the pause survives a full
-        // scan in production — `refresh_queue_depth_internal` reads this flag.)
-        let _ = scan_local_changes_internal(&state);
+        // index rows kept, and a DURABLE pause flag persisted. Asserting the DURABLE
+        // app_config flag, not the transient engine error, is what proves the pause
+        // survives a full scan in production — `refresh_queue_depth_internal` reads it.
+        //
+        // DBSYNC-81: this calls the LOCAL half only. It used to call the full scan and
+        // discard the Result, on the assumption that the remote-refresh step "errors
+        // here with no token". That holds on a machine with an empty keychain and is
+        // FALSE on a developer's: there the step finds a real token, prompts for it and
+        // reads production credentials. Calling the local half means the Result can be
+        // asserted instead of swallowed.
+        scan_local_changes_only(&state).expect("local scan must succeed");
         assert!(
             job_targets(&state, "delete").is_empty(),
             "a mass deletion must be blocked — no remote deletes enqueued"
@@ -1892,7 +1912,7 @@ mod tests {
             .db
             .set_app_config("mass_delete_override_once", "1")
             .unwrap();
-        let _ = scan_local_changes_internal(&state);
+        scan_local_changes_only(&state).expect("local scan must succeed");
         assert_eq!(
             job_targets(&state, "delete").len(),
             30,


### PR DESCRIPTION
## Summary

Two defects behind "the keychain asks me about five times", both **measured**. The reported symptom turned out to have a cause nobody had suspected — and the ticket's original hypothesis was refuted along the way.

## 1. One test was reading production credentials

`sync_pipeline::tests::scan_blocks_mass_deletion_until_overridden` — one test out of 174 — called the full scan and discarded the Result, on an assumption it stated in a comment:

> *"The scan's later remote-refresh step **errors here with no token**…"*

That holds on CI, where the keychain is empty. On a developer's machine it is **false**: there *is* a token, so the step does not error — it prompts and reads the real session. Every `cargo test` compiles a fresh binary with a fresh cdhash, which macOS treats as a different application, so it prompts again and leaves a dead ACL entry behind. **Six had accumulated.**

**The fix**: `scan_local_changes_internal` was doing two jobs. Split so both are named — `scan_local_changes_only` (walk, decide, enqueue; no credentials) and the original composing it with the remote refresh and bookkeeping. The test calls the local half and now **asserts the Result** instead of swallowing it; it was only ignoring that error because of the wrong assumption.

### How it was found — the part worth stealing

The planned measurement (poll `SecurityAgent`, diff the ACL) gave a **contradiction**: the agent was up for 34 samples, yet the ACL looked unchanged. That was **my measurement error** — I counted one of the five stored items. Recounting all five showed `dropbox-session-access` going 7 → 8 while the rest held at 7.

It still did not name the test. A `panic!` at the top of `get_session` under `#[cfg(test)]` did: it aborts **before** the keychain call, so the harness reports the offending test through its thread name and **costs zero dialogs**. For anything like this it beats watching for prompts.

## 2. Chunking off Windows bought nothing and cost prompts

`SAFE_UTF16_PAYLOAD_BYTES = 2400` exists for `CRED_MAX_CREDENTIAL_BLOB_SIZE` — a **Windows** limit. macOS has none, and macOS prompts per keychain **item**, so splitting the access token into a marker plus two chunks turned one authorization into three. Measured: five stored items, five dialogs on first run.

The constant is now platform-conditional. `MAX / 2` rather than `MAX` so the accumulator in `split_utf16_chunks` cannot overflow.

**No migration code was needed and none was written.** `store_value_chunked` already inlines a single-chunk value into the base key and calls `clear_overflow_parts(base, 0)`, deleting `.0`/`.1`. The next session write collapses the layout and cleans up after itself — nobody is asked to sign in again.

## Stack

`desktop-tauri` (Rust only — no IPC, no capabilities, no new dependency)

## Jira Ticket

#DBSYNC-81 — slices [#99](https://github.com/mbsanchez/DropboxSync/issues/99), [#100](https://github.com/mbsanchez/DropboxSync/issues/100); [#101](https://github.com/mbsanchez/DropboxSync/issues/101) still open.

## Test Plan

- [x] `cargo test` — **177 passed** (174 + 3 new).
- [x] `cargo clippy --all-targets` — no new warnings; the four that remain are pre-existing and in untouched files.
  **This line was false when first written** and CTO review caught it: the run it quoted predated the chunking tests, and the final diff emitted `unused import: SAFE_UTF16_PAYLOAD_BYTES`. Fixed in 609325c and re-run against the final diff with a forced rebuild (`touch src/lib.rs`) so nothing came from cache. The four survivors are in `cloudsc_ops.rs`, `dropbox_transfer.rs` and `open_handlers.rs` — the branch touches neither file.
- [x] **No test reaches the keychain.** Proven by re-installing the probe on **both** `get_session` *and* `get_token` and running the full suite: 174 pass, **zero panics**. Before the fix exactly one panicked. Stronger than an ACL diff — it shows no path *reaches* the call, not merely that no entry appeared.
- [x] **The Windows arm was compiled and executed**, by pivoting its `cfg` predicate so the Windows branch goes live on this host. `an_oversized_secret_is_still_split_on_windows ... ok` — the 2400 constant still splits and every chunk respects the ceiling. Pivot reverted; `grep cfg(unix)` → 0. This matters because that test lives *inside* the arm that never compiles here, so writing it proves nothing on its own.
- [x] Probe removed before commit: `grep DBSYNC81` → 0.

### On the new tests

`split_utf16_chunks` is pure, so chunking is testable without a keychain. Four tests, and one of them is a guard: `the_test_secret_really_is_over_the_windows_ceiling` exists because without it the two platform tests could pass **vacuously** on a secret that never needed splitting.

## What this does NOT do

- **It reaches three prompts on first run, not one.** Collapsing `access`/`refresh`/`expires` into a single item is a genuine schema migration — runs once per user, no second chance — and buys the smaller half of the win. Left for its own change.
- **The item-count drop is predicted from the code, not observed.** Confirming it means writing a session and re-reading the store, which is #101's job.
- ~~**`security dump-keychain` now hangs** on this machine past 20 s~~ — it responded normally on the post-review run, so the hang was transient rather than a standing limitation. The probe evidence stands either way.

## And a hypothesis this refutes

The ticket suspected repeated `codesign --force` re-signing of causing the recurrence. **Refuted**: the app's ACL entry is keyed on the designated requirement (identifier + Apple anchor + team `XCAA3WMJM6`), not a cdhash, so it survives rebuilds with the same identity. Confirmed by quitting and relaunching the installed app: `SecurityAgent` absent across 25 one-second samples — **zero prompts**.

The recurring dialogs were test runs, not app use.

🤖 Generated with Claude Code
