### PR TITLE
fix(#DBSYNC-84): push Finder badge updates instead of only answering when asked

### DIFF
--- a/apps/desktop/native/macos/FinderSyncExtension/BadgeDiff.swift
+++ b/apps/desktop/native/macos/FinderSyncExtension/BadgeDiff.swift
@@ -1,0 +1,64 @@
+import Foundation
+
+/// Works out which badges Finder needs to be told about, given two consecutive
+/// `overlay_state.json` snapshots (DBSYNC-84).
+///
+/// Deliberately imports **Foundation only**. It must not reference `FinderSync` or
+/// `FIFinderSyncController`: a file that imports FinderSync cannot be compiled as a script
+/// by `xcrun swift`, and running it that way is the only automated coverage available here
+/// — there is no Swift test target, and adding one is out of scope per DBSYNC-72. Keeping
+/// this file pure is what makes `Tests/BadgeDiffTests.swift` possible, not a style choice.
+enum BadgeDiff {
+    /// What changed between two snapshots of the relative-path → tier map.
+    struct Changes: Equatable {
+        /// Paths whose badge must be set, with the tier to set it to.
+        let changed: [String: String]
+        /// Paths that were tracked and no longer are; their badge must be cleared.
+        let removed: [String]
+
+        var isEmpty: Bool { changed.isEmpty && removed.isEmpty }
+    }
+
+    /// Compares `old` against `new` and returns only what Finder has to be told.
+    ///
+    /// **A `nil` `old` yields no changes at all**, on purpose. On the first load every path
+    /// would otherwise count as changed, and Finder is about to ask for each visible item
+    /// anyway — so pushing would be redundant work at exactly the worst moment. DBSYNC-80
+    /// measured the enumeration at 50,000 files, so a first-load push storm is a measured
+    /// risk rather than a hypothetical one. Encoding it here rather than at the call site
+    /// means a future caller cannot forget it.
+    static func changes(from old: [String: String]?, to new: [String: String]) -> Changes {
+        guard let old else {
+            return Changes(changed: [:], removed: [])
+        }
+
+        var changed: [String: String] = [:]
+        for (path, tier) in new where old[path] != tier {
+            changed[path] = tier
+        }
+
+        let removed = old.keys.filter { new[$0] == nil }.sorted()
+
+        return Changes(changed: changed, removed: removed)
+    }
+
+    /// Narrows `changes` to the items Finder has **already badged**.
+    ///
+    /// Apple's own guidance, in `FinderSync.h` alongside `setBadgeIdentifier:forURL:`:
+    ///
+    /// > Avoid adding badges to items that the Finder hasn't displayed yet. When setting the
+    /// > initial badge, call this method from your Finder Sync extension's
+    /// > `requestBadgeIdentifierForURL:` method. When updating badges, call this method only
+    /// > for items that have already received a badge.
+    ///
+    /// So a push is only legitimate for a path Finder previously asked about. Anything else
+    /// is handled by `requestBadgeIdentifier(for:)` when Finder gets round to displaying it.
+    /// Without this filter a file that changes tier while its folder is closed would be
+    /// pushed at Finder for an item it has never drawn.
+    static func pushable(_ changes: Changes, alreadyBadged: Set<String>) -> Changes {
+        Changes(
+            changed: changes.changed.filter { alreadyBadged.contains($0.key) },
+            removed: changes.removed.filter { alreadyBadged.contains($0) }
+        )
+    }
+}

--- a/apps/desktop/native/macos/FinderSyncExtension/BadgeDiff.swift
+++ b/apps/desktop/native/macos/FinderSyncExtension/BadgeDiff.swift
@@ -42,7 +42,7 @@ enum BadgeDiff {
         return Changes(changed: changed, removed: removed)
     }
 
-    /// Narrows `changes` to the items Finder has **already badged**.
+    /// Narrows `changes` to the items Finder is **displaying**.
     ///
     /// Apple's own guidance, in `FinderSync.h` alongside `setBadgeIdentifier:forURL:`:
     ///
@@ -51,14 +51,19 @@ enum BadgeDiff {
     /// > `requestBadgeIdentifierForURL:` method. When updating badges, call this method only
     /// > for items that have already received a badge.
     ///
-    /// So a push is only legitimate for a path Finder previously asked about. Anything else
-    /// is handled by `requestBadgeIdentifier(for:)` when Finder gets round to displaying it.
-    /// Without this filter a file that changes tier while its folder is closed would be
-    /// pushed at Finder for an item it has never drawn.
-    static func pushable(_ changes: Changes, alreadyBadged: Set<String>) -> Changes {
+    /// The operative constraint is the first sentence: **displayed**. `displayed` therefore
+    /// holds every path Finder has asked about, not only the ones that came back with a
+    /// badge.
+    ///
+    /// Reading "already received a badge" literally is a trap, and this filter fell into it
+    /// once: a `.cloudsc` placeholder appears, Finder asks about it before the state file
+    /// has caught up, so nothing is badged — and when the tier arrives moments later the
+    /// path is filtered out and never badged at all. Finder does not ask twice. That is
+    /// symptom 1 of DBSYNC-84, reintroduced by the very filter meant to respect Apple's rule.
+    static func pushable(_ changes: Changes, displayed: Set<String>) -> Changes {
         Changes(
-            changed: changes.changed.filter { alreadyBadged.contains($0.key) },
-            removed: changes.removed.filter { alreadyBadged.contains($0) }
+            changed: changes.changed.filter { displayed.contains($0.key) },
+            removed: changes.removed.filter { displayed.contains($0) }
         )
     }
 
@@ -99,18 +104,51 @@ enum BadgeDiff {
     /// comes back. Which is the exact bug this ticket exists to fix, reached through a
     /// narrower door.
     ///
-    /// `alreadyBadged` is not lost in that reset, so the displayed items can be refreshed
-    /// directly. Every path here has already received a badge, so pushing to it is
-    /// legitimate under Apple's rule.
-    static func resync(to new: [String: String], alreadyBadged: Set<String>) -> Changes {
+    /// `displayed` is not lost in that reset, so those items can be refreshed directly.
+    /// Every path here is one Finder is showing, so pushing to it is legitimate.
+    static func resync(to new: [String: String], displayed: Set<String>) -> Changes {
         var changed: [String: String] = [:]
-        for path in alreadyBadged {
+        for path in displayed {
             if let tier = new[path] { changed[path] = tier }
         }
         return Changes(
             changed: changed,
-            removed: alreadyBadged.filter { new[$0] == nil }.sorted()
+            removed: displayed.filter { new[$0] == nil }.sorted()
         )
+    }
+
+    /// What to do when Finder asks about `path`.
+    ///
+    /// This exists because the placement of a single line was load-bearing and untestable.
+    /// Twice now a defect has lived in `SyncExtension.swift` where the check script cannot
+    /// reach it: the string-prefix containment bug, and then recording a path as displayed
+    /// only *after* a tier was found. The second one passed 27 green checks and a clean
+    /// build. Moving the decision here is what makes it a fact under test rather than a
+    /// property of where a statement happens to sit.
+    struct RequestOutcome: Equatable {
+        /// The relative path Finder is now displaying, or `nil` if it is outside the root.
+        ///
+        /// **Non-nil even when there is no tier to set.** Finder asking about an item means
+        /// it is on screen, and it will not ask twice — so a `.cloudsc` drawn before the
+        /// state file catches up must still count as displayed, or the tier arriving a
+        /// moment later is filtered out of the push and the file stays bare forever.
+        let displayedPath: String?
+        /// The identifier to hand to `setBadgeIdentifier`: a tier, or `""` to clear.
+        /// `nil` means do nothing at all.
+        let badgeIdentifier: String?
+    }
+
+    static func requestOutcome(
+        for path: String,
+        root: String,
+        paths: [String: String]?
+    ) -> RequestOutcome {
+        guard let relative = relativePath(of: path, under: root), !relative.isEmpty else {
+            return RequestOutcome(displayedPath: nil, badgeIdentifier: nil)
+        }
+        // `""` clears the badge — documented in `FinderSync.h`. An item we do not track
+        // must not keep a badge from a previous state.
+        return RequestOutcome(displayedPath: relative, badgeIdentifier: paths?[relative] ?? "")
     }
 }
 

--- a/apps/desktop/native/macos/FinderSyncExtension/BadgeDiff.swift
+++ b/apps/desktop/native/macos/FinderSyncExtension/BadgeDiff.swift
@@ -61,4 +61,56 @@ enum BadgeDiff {
             removed: changes.removed.filter { alreadyBadged.contains($0) }
         )
     }
+
+    /// Whether `path` is `root` itself or lives inside it.
+    ///
+    /// A plain `path.hasPrefix(root)` is **not** a containment test and was shipped as one
+    /// in the first version of this change: with a root of `/Users/x/DropboxSync`, the path
+    /// `/Users/x/DropboxSyncEvil/secret.txt` passes a string-prefix check while living in a
+    /// different directory entirely. Comparing against `root + "/"` is what makes the
+    /// sibling-with-a-longer-name case fail as it should.
+    ///
+    /// This lives in `BadgeDiff` rather than next to its callers so that it is reachable
+    /// from `Tests/BadgeDiffTests.swift`. That is the point: the string-prefix bug survived
+    /// review precisely because it sat in a file the test script cannot compile.
+    static func isContained(_ path: String, in root: String) -> Bool {
+        if path == root { return true }
+        let rootWithSeparator = root.hasSuffix("/") ? root : root + "/"
+        return path.hasPrefix(rootWithSeparator)
+    }
+
+    /// The portion of `path` below `root`, or `nil` if `path` is not inside `root`.
+    ///
+    /// Returns `""` for `root` itself. The old inline version sliced off `root.count`
+    /// characters after a bare prefix check, so `/Users/x/DropboxSyncEvil/f` yielded the
+    /// nonsensical relative path `Evil/f` and was then looked up in the state map.
+    static func relativePath(of path: String, under root: String) -> String? {
+        guard isContained(path, in: root) else { return nil }
+        if path == root { return "" }
+        let rootWithSeparator = root.hasSuffix("/") ? root : root + "/"
+        return String(path.dropFirst(rootWithSeparator.count))
+    }
+
+    /// What to push when the previous snapshot was lost but Finder is still showing badges.
+    ///
+    /// `reloadState()` drops its snapshot whenever the state file cannot be read. Without
+    /// this, the next successful read produces no diff — `changes(from: nil, …)` is empty by
+    /// design — and every visible badge stays frozen until the user leaves the directory and
+    /// comes back. Which is the exact bug this ticket exists to fix, reached through a
+    /// narrower door.
+    ///
+    /// `alreadyBadged` is not lost in that reset, so the displayed items can be refreshed
+    /// directly. Every path here has already received a badge, so pushing to it is
+    /// legitimate under Apple's rule.
+    static func resync(to new: [String: String], alreadyBadged: Set<String>) -> Changes {
+        var changed: [String: String] = [:]
+        for path in alreadyBadged {
+            if let tier = new[path] { changed[path] = tier }
+        }
+        return Changes(
+            changed: changed,
+            removed: alreadyBadged.filter { new[$0] == nil }.sorted()
+        )
+    }
 }
+

--- a/apps/desktop/native/macos/FinderSyncExtension/DropboxSyncFinderSync.xcodeproj/project.pbxproj
+++ b/apps/desktop/native/macos/FinderSyncExtension/DropboxSyncFinderSync.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		DBFC00000000000000000021 /* SyncExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBFC00000000000000000001 /* SyncExtension.swift */; };
+		DBFC00000000000000000030 /* BadgeDiff.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBFC00000000000000000012 /* BadgeDiff.swift */; };
 		DBFC00000000000000000022 /* cloud-check.png in Resources */ = {isa = PBXBuildFile; fileRef = DBFC00000000000000000002 /* cloud-check.png */; };
 		DBFC00000000000000000023 /* cloud-alert.png in Resources */ = {isa = PBXBuildFile; fileRef = DBFC00000000000000000003 /* cloud-alert.png */; };
 		DBFC00000000000000000024 /* cloud-sync.png in Resources */ = {isa = PBXBuildFile; fileRef = DBFC00000000000000000004 /* cloud-sync.png */; };
@@ -20,6 +21,7 @@
 
 /* Begin PBXFileReference section */
 		DBFC00000000000000000001 /* SyncExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyncExtension.swift; sourceTree = "<group>"; };
+		DBFC00000000000000000012 /* BadgeDiff.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BadgeDiff.swift; sourceTree = "<group>"; };
 		DBFC00000000000000000002 /* cloud-check.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = cloud-check.png; sourceTree = "<group>"; };
 		DBFC00000000000000000003 /* cloud-alert.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = cloud-alert.png; sourceTree = "<group>"; };
 		DBFC00000000000000000004 /* cloud-sync.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = cloud-sync.png; sourceTree = "<group>"; };
@@ -55,6 +57,7 @@
 			isa = PBXGroup;
 			children = (
 				DBFC00000000000000000001 /* SyncExtension.swift */,
+				DBFC00000000000000000012 /* BadgeDiff.swift */,
 				DBFC00000000000000000006 /* Info.plist */,
 				DBFC00000000000000000043 /* Assets */,
 			);
@@ -161,6 +164,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				DBFC00000000000000000021 /* SyncExtension.swift in Sources */,
+				DBFC00000000000000000030 /* BadgeDiff.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/apps/desktop/native/macos/FinderSyncExtension/SyncExtension.swift
+++ b/apps/desktop/native/macos/FinderSyncExtension/SyncExtension.swift
@@ -144,7 +144,15 @@ final class DropboxSyncFinderSync: FIFinderSync {
         state = decoded
         lastUpdatedAt = decoded.updatedAt
 
-        pushBadgeChanges(BadgeDiff.changes(from: previousPaths, to: decoded.paths))
+        if previousPaths == nil && !badgedPaths.isEmpty {
+            // The snapshot was lost — the state file was unreadable for a moment — but
+            // Finder is still showing badges we know about. `changes(from: nil, …)` is
+            // empty by design, so without this every visible badge would stay frozen until
+            // the user left the directory and came back: this ticket's bug, narrower door.
+            pushBadgeChanges(BadgeDiff.resync(to: decoded.paths, alreadyBadged: badgedPaths))
+        } else {
+            pushBadgeChanges(BadgeDiff.changes(from: previousPaths, to: decoded.paths))
+        }
     }
 
     /// Tells Finder about badges that changed since the previous snapshot (DBSYNC-84).
@@ -185,11 +193,13 @@ final class DropboxSyncFinderSync: FIFinderSync {
     /// Builds the absolute URL for a relative path, refusing anything that escapes `root`.
     ///
     /// The state file is written by the app, but a relative path containing `..` would
-    /// otherwise let it badge arbitrary locations on disk, so the containment is enforced
-    /// here rather than assumed.
+    /// otherwise let it badge arbitrary locations on disk. The containment test lives in
+    /// [`BadgeDiff.isContained`] so that it is covered by `Tests/BadgeDiffTests.swift`: the
+    /// first version of this check used a bare `hasPrefix` and let a sibling directory
+    /// through, and it survived review because it sat where no test could reach it.
     private func url(forRelative relative: String, under root: URL) -> URL? {
         let url = root.appendingPathComponent(relative).standardizedFileURL
-        guard url.path.hasPrefix(root.path) else { return nil }
+        guard BadgeDiff.isContained(url.path, in: root.path) else { return nil }
         return url
     }
 
@@ -198,14 +208,9 @@ final class DropboxSyncFinderSync: FIFinderSync {
             return
         }
         let item = url.standardizedFileURL
-        guard item.path.hasPrefix(root.path) else {
+        guard let relative = BadgeDiff.relativePath(of: item.path, under: root.path),
+              !relative.isEmpty else {
             return
-        }
-
-        var relative = item.path
-        relative.removeFirst(root.path.count)
-        if relative.hasPrefix("/") {
-            relative.removeFirst()
         }
 
         guard let tier = state?.paths[relative] else {

--- a/apps/desktop/native/macos/FinderSyncExtension/SyncExtension.swift
+++ b/apps/desktop/native/macos/FinderSyncExtension/SyncExtension.swift
@@ -20,6 +20,16 @@ final class DropboxSyncFinderSync: FIFinderSync {
     /// the state file catches up, so it gets no badge on the first ask, and if it were left
     /// out of this set the tier arriving moments later would be filtered away and the file
     /// would never be badged at all. Finder does not ask twice.
+    ///
+    /// **This set only ever grows, and that is deliberate.** Clearing a badge does not mean
+    /// Finder stopped showing the item — the file is still on screen with no status to
+    /// display. Dropping a path here when its badge is cleared means a file that leaves the
+    /// state map and comes back is filtered out of the push and never badged again. The
+    /// only genuine "no longer displayed" signal is `endObservingDirectoryAtURL:`, which
+    /// this extension does not implement.
+    ///
+    /// The cost of never shrinking is one string per distinct path Finder has shown inside
+    /// the sync folder — a few MB at the 50,000 files DBSYNC-80 measured. Accepted.
     private var displayedPaths: Set<String> = []
 
     /// `updated_at` of the snapshot currently in `state`. The Rust writer stamps every
@@ -185,7 +195,6 @@ final class DropboxSyncFinderSync: FIFinderSync {
         for relative in pushable.removed {
             guard let url = url(forRelative: relative, under: root) else { continue }
             controller.setBadgeIdentifier("", for: url)
-            displayedPaths.remove(relative)
         }
     }
 

--- a/apps/desktop/native/macos/FinderSyncExtension/SyncExtension.swift
+++ b/apps/desktop/native/macos/FinderSyncExtension/SyncExtension.swift
@@ -11,6 +11,18 @@ final class DropboxSyncFinderSync: FIFinderSync {
     private var state: OverlayState?
     private var reloadTimer: Timer?
 
+    /// Relative paths Finder has already been given a badge for.
+    ///
+    /// Apple's `FinderSync.h` says to "call this method only for items that have already
+    /// received a badge" when updating, so a push is only legitimate for a path in here.
+    /// Everything else is Finder's to ask about when it displays the item.
+    private var badgedPaths: Set<String> = []
+
+    /// `updated_at` of the snapshot currently in `state`. The Rust writer stamps every
+    /// snapshot (`overlay_state.rs`), so an unchanged value means an unchanged file and the
+    /// whole diff can be skipped — which matters because this runs every 2 seconds forever.
+    private var lastUpdatedAt: String?
+
     override init() {
         super.init()
         registerBadgeImages()
@@ -105,6 +117,10 @@ final class DropboxSyncFinderSync: FIFinderSync {
                 lastLoadFailed = true
             }
             state = nil
+            // Must clear alongside `state`: leaving a stale stamp here would make the
+            // short-circuit below skip the diff when the file comes back with the same
+            // `updated_at`, and no badge would ever be pushed again.
+            lastUpdatedAt = nil
             return
         }
         if lastLoadFailed {
@@ -113,32 +129,100 @@ final class DropboxSyncFinderSync: FIFinderSync {
         }
         let decoder = JSONDecoder()
         decoder.keyDecodingStrategy = .convertFromSnakeCase
-        state = try? decoder.decode(OverlayState.self, from: data)
+        guard let decoded = try? decoder.decode(OverlayState.self, from: data) else {
+            state = nil
+            lastUpdatedAt = nil
+            return
+        }
+
+        // Nothing was rewritten since the last tick: no diff, no pushes, no work.
+        if decoded.updatedAt == lastUpdatedAt {
+            return
+        }
+
+        let previousPaths = state?.paths
+        state = decoded
+        lastUpdatedAt = decoded.updatedAt
+
+        pushBadgeChanges(BadgeDiff.changes(from: previousPaths, to: decoded.paths))
+    }
+
+    /// Tells Finder about badges that changed since the previous snapshot (DBSYNC-84).
+    ///
+    /// Finder calls `requestBadgeIdentifier(for:)` **once** per item and then caches the
+    /// answer, so without this the badge a file was first drawn with is the badge it keeps
+    /// until the user leaves the directory and comes back. `setBadgeIdentifier` outside a
+    /// request is the documented way to push an update — `FinderSync.h` says so directly:
+    /// "When updating badges, call this method only for items that have already received a
+    /// badge." Hence the `pushable` filter rather than pushing everything that changed.
+    private func pushBadgeChanges(_ changes: BadgeDiff.Changes) {
+        let pushable = BadgeDiff.pushable(changes, alreadyBadged: badgedPaths)
+        guard !pushable.isEmpty, let root = syncFolderRoot() else {
+            return
+        }
+        let controller = FIFinderSyncController.default()
+
+        for (relative, tier) in pushable.changed {
+            guard let url = url(forRelative: relative, under: root) else { continue }
+            controller.setBadgeIdentifier(tier, for: url)
+        }
+
+        // Clearing a badge is `setBadgeIdentifier("")` — documented in `FinderSync.h`:
+        // "Setting the identifier to an empty string (@\"\") removes the badge."
+        // Checked against the SDK header rather than taken from folklore (GitHub #104).
+        for relative in pushable.removed {
+            guard let url = url(forRelative: relative, under: root) else { continue }
+            controller.setBadgeIdentifier("", for: url)
+            badgedPaths.remove(relative)
+        }
+    }
+
+    private func syncFolderRoot() -> URL? {
+        guard let folder = state?.syncFolder, !folder.isEmpty else { return nil }
+        return URL(fileURLWithPath: folder, isDirectory: true).standardizedFileURL
+    }
+
+    /// Builds the absolute URL for a relative path, refusing anything that escapes `root`.
+    ///
+    /// The state file is written by the app, but a relative path containing `..` would
+    /// otherwise let it badge arbitrary locations on disk, so the containment is enforced
+    /// here rather than assumed.
+    private func url(forRelative relative: String, under root: URL) -> URL? {
+        let url = root.appendingPathComponent(relative).standardizedFileURL
+        guard url.path.hasPrefix(root.path) else { return nil }
+        return url
     }
 
     override func requestBadgeIdentifier(for url: URL) {
-        guard let folder = state?.syncFolder, !folder.isEmpty else {
+        guard let root = syncFolderRoot() else {
             return
         }
-        let root = URL(fileURLWithPath: folder, isDirectory: true).standardizedFileURL
         let item = url.standardizedFileURL
         guard item.path.hasPrefix(root.path) else {
             return
         }
 
-        let rootPath = root.path
         var relative = item.path
-        if relative.hasPrefix(rootPath) {
-            relative.removeFirst(rootPath.count)
-            if relative.hasPrefix("/") {
-                relative.removeFirst()
-            }
+        relative.removeFirst(root.path.count)
+        if relative.hasPrefix("/") {
+            relative.removeFirst()
         }
 
         guard let tier = state?.paths[relative] else {
+            // Finder asked about something we do not track. Returning here used to leave
+            // whatever badge it already had in place forever (GitHub #104); clear it
+            // instead. `""` is the documented removal identifier, per `FinderSync.h`.
+            if badgedPaths.contains(relative) {
+                FIFinderSyncController.default().setBadgeIdentifier("", for: item)
+                badgedPaths.remove(relative)
+            }
             return
         }
+
         FIFinderSyncController.default().setBadgeIdentifier(tier, for: item)
+        // Record it: from now on this path is one Finder has displayed, so pushing updates
+        // for it is legitimate under Apple's rule.
+        badgedPaths.insert(relative)
     }
 }
 

--- a/apps/desktop/native/macos/FinderSyncExtension/SyncExtension.swift
+++ b/apps/desktop/native/macos/FinderSyncExtension/SyncExtension.swift
@@ -11,12 +11,16 @@ final class DropboxSyncFinderSync: FIFinderSync {
     private var state: OverlayState?
     private var reloadTimer: Timer?
 
-    /// Relative paths Finder has already been given a badge for.
+    /// Relative paths Finder is **displaying** — every path it has asked about, whether or
+    /// not we had a tier to give it at the time.
     ///
-    /// Apple's `FinderSync.h` says to "call this method only for items that have already
-    /// received a badge" when updating, so a push is only legitimate for a path in here.
-    /// Everything else is Finder's to ask about when it displays the item.
-    private var badgedPaths: Set<String> = []
+    /// Apple's `FinderSync.h` warns against badging "items that the Finder hasn't displayed
+    /// yet", so a push is only legitimate for a path in here. It deliberately holds
+    /// asked-about paths rather than badged ones: a `.cloudsc` placeholder is drawn before
+    /// the state file catches up, so it gets no badge on the first ask, and if it were left
+    /// out of this set the tier arriving moments later would be filtered away and the file
+    /// would never be badged at all. Finder does not ask twice.
+    private var displayedPaths: Set<String> = []
 
     /// `updated_at` of the snapshot currently in `state`. The Rust writer stamps every
     /// snapshot (`overlay_state.rs`), so an unchanged value means an unchanged file and the
@@ -144,12 +148,12 @@ final class DropboxSyncFinderSync: FIFinderSync {
         state = decoded
         lastUpdatedAt = decoded.updatedAt
 
-        if previousPaths == nil && !badgedPaths.isEmpty {
+        if previousPaths == nil && !displayedPaths.isEmpty {
             // The snapshot was lost — the state file was unreadable for a moment — but
             // Finder is still showing badges we know about. `changes(from: nil, …)` is
             // empty by design, so without this every visible badge would stay frozen until
             // the user left the directory and came back: this ticket's bug, narrower door.
-            pushBadgeChanges(BadgeDiff.resync(to: decoded.paths, alreadyBadged: badgedPaths))
+            pushBadgeChanges(BadgeDiff.resync(to: decoded.paths, displayed: displayedPaths))
         } else {
             pushBadgeChanges(BadgeDiff.changes(from: previousPaths, to: decoded.paths))
         }
@@ -164,7 +168,7 @@ final class DropboxSyncFinderSync: FIFinderSync {
     /// "When updating badges, call this method only for items that have already received a
     /// badge." Hence the `pushable` filter rather than pushing everything that changed.
     private func pushBadgeChanges(_ changes: BadgeDiff.Changes) {
-        let pushable = BadgeDiff.pushable(changes, alreadyBadged: badgedPaths)
+        let pushable = BadgeDiff.pushable(changes, displayed: displayedPaths)
         guard !pushable.isEmpty, let root = syncFolderRoot() else {
             return
         }
@@ -181,7 +185,7 @@ final class DropboxSyncFinderSync: FIFinderSync {
         for relative in pushable.removed {
             guard let url = url(forRelative: relative, under: root) else { continue }
             controller.setBadgeIdentifier("", for: url)
-            badgedPaths.remove(relative)
+            displayedPaths.remove(relative)
         }
     }
 
@@ -208,26 +212,15 @@ final class DropboxSyncFinderSync: FIFinderSync {
             return
         }
         let item = url.standardizedFileURL
-        guard let relative = BadgeDiff.relativePath(of: item.path, under: root.path),
-              !relative.isEmpty else {
-            return
+        let outcome = BadgeDiff.requestOutcome(
+            for: item.path, root: root.path, paths: state?.paths
+        )
+        if let displayed = outcome.displayedPath {
+            displayedPaths.insert(displayed)
         }
-
-        guard let tier = state?.paths[relative] else {
-            // Finder asked about something we do not track. Returning here used to leave
-            // whatever badge it already had in place forever (GitHub #104); clear it
-            // instead. `""` is the documented removal identifier, per `FinderSync.h`.
-            if badgedPaths.contains(relative) {
-                FIFinderSyncController.default().setBadgeIdentifier("", for: item)
-                badgedPaths.remove(relative)
-            }
-            return
+        if let identifier = outcome.badgeIdentifier {
+            FIFinderSyncController.default().setBadgeIdentifier(identifier, for: item)
         }
-
-        FIFinderSyncController.default().setBadgeIdentifier(tier, for: item)
-        // Record it: from now on this path is one Finder has displayed, so pushing updates
-        // for it is legitimate under Apple's rule.
-        badgedPaths.insert(relative)
     }
 }
 

--- a/apps/desktop/native/macos/FinderSyncExtension/Tests/BadgeDiffTests.swift
+++ b/apps/desktop/native/macos/FinderSyncExtension/Tests/BadgeDiffTests.swift
@@ -57,6 +57,24 @@ struct BadgeDiffTests {
         }
     }
 
+    static func checkOutcome(
+        _ label: String,
+        _ actual: BadgeDiff.RequestOutcome,
+        displayedPath: String?,
+        badgeIdentifier: String?
+    ) {
+        let expected = BadgeDiff.RequestOutcome(
+            displayedPath: displayedPath, badgeIdentifier: badgeIdentifier)
+        if actual == expected {
+            print("  ok   \(label)")
+        } else {
+            print("  FAIL \(label)")
+            print("       expected \(expected)")
+            print("       actual   \(actual)")
+            failures += 1
+        }
+    }
+
     static func main() {
         print("BadgeDiff")
 
@@ -111,29 +129,39 @@ struct BadgeDiffTests {
 
         // Apple's header: "call this method only for items that have already received a
         // badge". A tier change in a folder Finder never opened must NOT be pushed.
-        check("an unbadged path is not pushable",
+        check("a path Finder has never displayed is not pushable",
               BadgeDiff.pushable(
                   BadgeDiff.Changes(changed: ["never-seen.txt": "synced"], removed: []),
-                  alreadyBadged: []),
+                  displayed: []),
               changed: [:], removed: [])
 
-        check("a badged path is pushable",
+        check("a displayed path is pushable",
               BadgeDiff.pushable(
                   BadgeDiff.Changes(changed: ["seen.txt": "synced"], removed: []),
-                  alreadyBadged: ["seen.txt"]),
+                  displayed: ["seen.txt"]),
               changed: ["seen.txt": "synced"], removed: [])
 
-        check("mixed badged and unbadged keeps only the badged",
+        // DBSYNC-84 symptom 1, and the case whose absence let a green run hide the hole.
+        // A `.cloudsc` placeholder is drawn before the state file catches up: Finder asks,
+        // there is no tier yet, so nothing is badged — but the path IS displayed. When the
+        // tier arrives it must be pushed, because Finder will not ask a second time.
+        check("a DISPLAYED but never-badged path is still pushable",
+              BadgeDiff.pushable(
+                  BadgeDiff.Changes(changed: ["new.cloudsc": "cloud_only"], removed: []),
+                  displayed: ["new.cloudsc"]),
+              changed: ["new.cloudsc": "cloud_only"], removed: [])
+
+        check("mixed displayed and undisplayed keeps only the displayed",
               BadgeDiff.pushable(
                   BadgeDiff.Changes(changed: ["seen.txt": "synced", "never.txt": "syncing"],
                                     removed: ["gone-seen.txt", "gone-never.txt"]),
-                  alreadyBadged: ["seen.txt", "gone-seen.txt"]),
+                  displayed: ["seen.txt", "gone-seen.txt"]),
               changed: ["seen.txt": "synced"], removed: ["gone-seen.txt"])
 
         check("removals are filtered too",
               BadgeDiff.pushable(
                   BadgeDiff.Changes(changed: [:], removed: ["never-seen.txt"]),
-                  alreadyBadged: []),
+                  displayed: []),
               changed: [:], removed: [])
 
         print("BadgeDiff.isContained")
@@ -170,18 +198,48 @@ struct BadgeDiffTests {
 
         print("BadgeDiff.resync")
 
-        check("resync refreshes only the badged paths",
+        check("resync refreshes only the displayed paths",
               BadgeDiff.resync(to: ["a.txt": "synced", "b.txt": "cloud_only"],
-                               alreadyBadged: ["a.txt"]),
+                               displayed: ["a.txt"]),
               changed: ["a.txt": "synced"], removed: [])
 
-        check("resync clears badged paths that are gone from the new snapshot",
-              BadgeDiff.resync(to: ["a.txt": "synced"], alreadyBadged: ["a.txt", "gone.txt"]),
+        check("resync clears displayed paths that are gone from the new snapshot",
+              BadgeDiff.resync(to: ["a.txt": "synced"], displayed: ["a.txt", "gone.txt"]),
               changed: ["a.txt": "synced"], removed: ["gone.txt"])
 
-        check("resync with nothing badged does nothing",
-              BadgeDiff.resync(to: ["a.txt": "synced"], alreadyBadged: []),
+        check("resync with nothing displayed does nothing",
+              BadgeDiff.resync(to: ["a.txt": "synced"], displayed: []),
               changed: [:], removed: [])
+
+        print("BadgeDiff.requestOutcome")
+
+        let tracked = ["a.txt": "synced"]
+
+        checkOutcome("a tracked file is displayed and badged with its tier",
+                     BadgeDiff.requestOutcome(for: "/Users/x/DropboxSync/a.txt",
+                                              root: root, paths: tracked),
+                     displayedPath: "a.txt", badgeIdentifier: "synced")
+
+        // THE REGRESSION GUARD. Recording the path only after a tier was found passed 27
+        // green checks and a clean build; this is the check that would have failed.
+        checkOutcome("an UNTRACKED file inside the root still counts as displayed",
+                     BadgeDiff.requestOutcome(for: "/Users/x/DropboxSync/new.cloudsc",
+                                              root: root, paths: tracked),
+                     displayedPath: "new.cloudsc", badgeIdentifier: "")
+
+        checkOutcome("with no state at all, the path is still displayed",
+                     BadgeDiff.requestOutcome(for: "/Users/x/DropboxSync/a.txt",
+                                              root: root, paths: nil),
+                     displayedPath: "a.txt", badgeIdentifier: "")
+
+        checkOutcome("a sibling directory is neither displayed nor badged",
+                     BadgeDiff.requestOutcome(for: "/Users/x/DropboxSyncEvil/secret.txt",
+                                              root: root, paths: tracked),
+                     displayedPath: nil, badgeIdentifier: nil)
+
+        checkOutcome("the sync folder itself is not an item",
+                     BadgeDiff.requestOutcome(for: root, root: root, paths: tracked),
+                     displayedPath: nil, badgeIdentifier: nil)
 
         if failures == 0 {
             print("BadgeDiff: all checks passed")

--- a/apps/desktop/native/macos/FinderSyncExtension/Tests/BadgeDiffTests.swift
+++ b/apps/desktop/native/macos/FinderSyncExtension/Tests/BadgeDiffTests.swift
@@ -39,6 +39,24 @@ struct BadgeDiffTests {
         }
     }
 
+    static func checkBool(_ label: String, _ actual: Bool, _ expected: Bool) {
+        if actual == expected {
+            print("  ok   \(label)")
+        } else {
+            print("  FAIL \(label) — expected \(expected), got \(actual)")
+            failures += 1
+        }
+    }
+
+    static func checkOptional(_ label: String, _ actual: String?, _ expected: String?) {
+        if actual == expected {
+            print("  ok   \(label)")
+        } else {
+            print("  FAIL \(label) — expected \(expected as Any), got \(actual as Any)")
+            failures += 1
+        }
+    }
+
     static func main() {
         print("BadgeDiff")
 
@@ -116,6 +134,53 @@ struct BadgeDiffTests {
               BadgeDiff.pushable(
                   BadgeDiff.Changes(changed: [:], removed: ["never-seen.txt"]),
                   alreadyBadged: []),
+              changed: [:], removed: [])
+
+        print("BadgeDiff.isContained")
+
+        let root = "/Users/x/DropboxSync"
+
+        checkBool("a file inside the root is contained",
+                  BadgeDiff.isContained("/Users/x/DropboxSync/a.txt", in: root), true)
+        checkBool("the root itself is contained",
+                  BadgeDiff.isContained(root, in: root), true)
+        // The bug the first version of this change shipped: a plain hasPrefix passes this.
+        checkBool("a SIBLING whose name extends the root is NOT contained",
+                  BadgeDiff.isContained("/Users/x/DropboxSyncEvil/secret.txt", in: root), false)
+        checkBool("an unrelated absolute path is not contained",
+                  BadgeDiff.isContained("/etc/passwd", in: root), false)
+        checkBool("a trailing separator on the root does not change the answer",
+                  BadgeDiff.isContained("/Users/x/DropboxSync/a.txt", in: root + "/"), true)
+        checkBool("a prefix of the root is not contained",
+                  BadgeDiff.isContained("/Users/x", in: root), false)
+
+        print("BadgeDiff.relativePath")
+
+        checkOptional("strips the root and the separator",
+                      BadgeDiff.relativePath(of: "/Users/x/DropboxSync/sub/a.txt", under: root),
+                      "sub/a.txt")
+        checkOptional("the root itself is the empty relative path",
+                      BadgeDiff.relativePath(of: root, under: root), "")
+        // The old inline version returned "Evil/secret.txt" here and looked it up as if real.
+        checkOptional("a sibling yields nil, not a nonsense relative path",
+                      BadgeDiff.relativePath(of: "/Users/x/DropboxSyncEvil/secret.txt", under: root),
+                      nil)
+        checkOptional("an unrelated path yields nil",
+                      BadgeDiff.relativePath(of: "/etc/passwd", under: root), nil)
+
+        print("BadgeDiff.resync")
+
+        check("resync refreshes only the badged paths",
+              BadgeDiff.resync(to: ["a.txt": "synced", "b.txt": "cloud_only"],
+                               alreadyBadged: ["a.txt"]),
+              changed: ["a.txt": "synced"], removed: [])
+
+        check("resync clears badged paths that are gone from the new snapshot",
+              BadgeDiff.resync(to: ["a.txt": "synced"], alreadyBadged: ["a.txt", "gone.txt"]),
+              changed: ["a.txt": "synced"], removed: ["gone.txt"])
+
+        check("resync with nothing badged does nothing",
+              BadgeDiff.resync(to: ["a.txt": "synced"], alreadyBadged: []),
               changed: [:], removed: [])
 
         if failures == 0 {

--- a/apps/desktop/native/macos/FinderSyncExtension/Tests/BadgeDiffTests.swift
+++ b/apps/desktop/native/macos/FinderSyncExtension/Tests/BadgeDiffTests.swift
@@ -241,6 +241,28 @@ struct BadgeDiffTests {
                      BadgeDiff.requestOutcome(for: root, root: root, paths: tracked),
                      displayedPath: nil, badgeIdentifier: nil)
 
+        print("round trip: removed then tracked again")
+
+        // A file leaves the state map and comes back. Finder has shown it the whole time,
+        // so it must be pushable on the way out AND on the way back in.
+        //
+        // Honest about what this does and does not guard: it pins the composition of
+        // `changes` and `pushable`. It cannot catch someone dropping the path from the
+        // displayed set inside `SyncExtension.swift` — that is a property of a line that no
+        // longer exists, documented on `displayedPaths` instead. The reason `displayedPaths`
+        // never shrinks is written there, not enforced here.
+        let displayed: Set<String> = ["a.txt"]
+
+        let leaving = BadgeDiff.pushable(
+            BadgeDiff.changes(from: ["a.txt": "synced"], to: [:]), displayed: displayed)
+        check("on the way out, the badge is cleared",
+              leaving, changed: [:], removed: ["a.txt"])
+
+        let returning = BadgeDiff.pushable(
+            BadgeDiff.changes(from: [:], to: ["a.txt": "synced"]), displayed: displayed)
+        check("on the way back, the badge is set again",
+              returning, changed: ["a.txt": "synced"], removed: [])
+
         if failures == 0 {
             print("BadgeDiff: all checks passed")
             exit(0)

--- a/apps/desktop/native/macos/FinderSyncExtension/Tests/BadgeDiffTests.swift
+++ b/apps/desktop/native/macos/FinderSyncExtension/Tests/BadgeDiffTests.swift
@@ -1,0 +1,129 @@
+// Executable checks for BadgeDiff (DBSYNC-84).
+//
+// There is no Swift test target in this project and adding one is out of scope
+// (DBSYNC-72). This follows the precedent set by DBSYNC-72 Slice 1, which proved path
+// equivalence by running Swift directly rather than by grepping. Run it with:
+//
+//     ./Tests/run-badge-diff-tests.sh
+//
+// It compiles the REAL BadgeDiff.swift, not a copy of its logic. A test that restated the
+// algorithm would pass while the shipped code was wrong, which is worse than no test.
+//
+// `@main` rather than top-level statements: `swiftc` only allows top-level code in a file
+// literally named `main.swift`, and `swift a.swift b.swift` compiles the second file
+// without putting it in scope for the first. Both were tried; this is what works while
+// keeping the file's name descriptive.
+//
+// Exits 0 on success, 1 if any check fails, naming what broke.
+
+import Foundation
+
+@main
+struct BadgeDiffTests {
+    static var failures = 0
+
+    static func check(
+        _ label: String,
+        _ actual: BadgeDiff.Changes,
+        changed: [String: String],
+        removed: [String]
+    ) {
+        let expected = BadgeDiff.Changes(changed: changed, removed: removed)
+        if actual == expected {
+            print("  ok   \(label)")
+        } else {
+            print("  FAIL \(label)")
+            print("       expected changed=\(changed.sorted { $0.key < $1.key }) removed=\(removed)")
+            print("       actual   changed=\(actual.changed.sorted { $0.key < $1.key }) removed=\(actual.removed)")
+            failures += 1
+        }
+    }
+
+    static func main() {
+        print("BadgeDiff")
+
+        // The first-load guard. This is what protects a 50,000-file store from a push storm
+        // at startup, so it is checked first and explicitly.
+        check("nil old snapshot yields nothing, however large the new one",
+              BadgeDiff.changes(from: nil, to: ["a.txt": "synced", "b.txt": "cloud_only"]),
+              changed: [:], removed: [])
+
+        check("empty to empty",
+              BadgeDiff.changes(from: [:], to: [:]),
+              changed: [:], removed: [])
+
+        // An empty dictionary is NOT the same as nil: the store was read and was genuinely
+        // empty, so newly appearing paths are real changes and must be pushed.
+        check("empty old snapshot still reports additions",
+              BadgeDiff.changes(from: [:], to: ["a.txt": "synced"]),
+              changed: ["a.txt": "synced"], removed: [])
+
+        check("a new path is a change",
+              BadgeDiff.changes(from: ["a.txt": "synced"],
+                                to: ["a.txt": "synced", "b.txt": "cloud_only"]),
+              changed: ["b.txt": "cloud_only"], removed: [])
+
+        // The bug this ticket exists for: a file finishes syncing and its tier flips.
+        check("a changed tier is reported",
+              BadgeDiff.changes(from: ["a.txt": "syncing"], to: ["a.txt": "synced"]),
+              changed: ["a.txt": "synced"], removed: [])
+
+        // The 2-second poll runs constantly; an unchanged map must produce no work at all.
+        check("identical snapshots report nothing",
+              BadgeDiff.changes(from: ["a.txt": "synced", "b.txt": "cloud_only"],
+                                to: ["a.txt": "synced", "b.txt": "cloud_only"]),
+              changed: [:], removed: [])
+
+        check("a removed path is reported",
+              BadgeDiff.changes(from: ["a.txt": "synced", "b.txt": "cloud_only"],
+                                to: ["a.txt": "synced"]),
+              changed: [:], removed: ["b.txt"])
+
+        check("everything removed at once",
+              BadgeDiff.changes(from: ["a.txt": "synced", "b.txt": "cloud_only"], to: [:]),
+              changed: [:], removed: ["a.txt", "b.txt"])
+
+        check("additions, changes and removals together",
+              BadgeDiff.changes(
+                  from: ["keep.txt": "synced", "flip.txt": "syncing", "gone.txt": "synced"],
+                  to: ["keep.txt": "synced", "flip.txt": "synced", "new.txt": "cloud_only"]),
+              changed: ["flip.txt": "synced", "new.txt": "cloud_only"], removed: ["gone.txt"])
+
+        print("BadgeDiff.pushable")
+
+        // Apple's header: "call this method only for items that have already received a
+        // badge". A tier change in a folder Finder never opened must NOT be pushed.
+        check("an unbadged path is not pushable",
+              BadgeDiff.pushable(
+                  BadgeDiff.Changes(changed: ["never-seen.txt": "synced"], removed: []),
+                  alreadyBadged: []),
+              changed: [:], removed: [])
+
+        check("a badged path is pushable",
+              BadgeDiff.pushable(
+                  BadgeDiff.Changes(changed: ["seen.txt": "synced"], removed: []),
+                  alreadyBadged: ["seen.txt"]),
+              changed: ["seen.txt": "synced"], removed: [])
+
+        check("mixed badged and unbadged keeps only the badged",
+              BadgeDiff.pushable(
+                  BadgeDiff.Changes(changed: ["seen.txt": "synced", "never.txt": "syncing"],
+                                    removed: ["gone-seen.txt", "gone-never.txt"]),
+                  alreadyBadged: ["seen.txt", "gone-seen.txt"]),
+              changed: ["seen.txt": "synced"], removed: ["gone-seen.txt"])
+
+        check("removals are filtered too",
+              BadgeDiff.pushable(
+                  BadgeDiff.Changes(changed: [:], removed: ["never-seen.txt"]),
+                  alreadyBadged: []),
+              changed: [:], removed: [])
+
+        if failures == 0 {
+            print("BadgeDiff: all checks passed")
+            exit(0)
+        } else {
+            print("BadgeDiff: \(failures) check(s) FAILED")
+            exit(1)
+        }
+    }
+}

--- a/apps/desktop/native/macos/FinderSyncExtension/Tests/run-badge-diff-tests.sh
+++ b/apps/desktop/native/macos/FinderSyncExtension/Tests/run-badge-diff-tests.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+# Compiles and runs the BadgeDiff checks (DBSYNC-84).
+#
+# There is no Swift test target here and adding one is out of scope (DBSYNC-72), so this
+# builds the real BadgeDiff.swift together with its checks and runs the result. Exits
+# non-zero if any check fails, so it is usable as a gate.
+#
+#   ./Tests/run-badge-diff-tests.sh
+#
+# Note `swiftc`, not `swift`: `swift a.swift b.swift` compiles the second file without
+# putting it in scope for the first, and reports success while running nothing at all.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+OUT=$(mktemp -d)/badge-diff-tests
+trap 'rm -rf "$(dirname "$OUT")"' EXIT
+
+xcrun swiftc -o "$OUT" BadgeDiff.swift Tests/BadgeDiffTests.swift
+"$OUT"


### PR DESCRIPTION
## Summary

Finder badges were correct **once** and then frozen — a file that finished syncing kept its old badge until the user left the directory and came back. Reproducible, not flaky.

`setBadgeIdentifier` was called from exactly one place, `requestBadgeIdentifier(for:)`, which Finder invokes **once per item** and then caches. The 2-second poll refreshed the extension's own state but never told Finder anything.

`reloadState()` now keeps the previous snapshot, diffs it, and pushes what changed. Paths that leave the state get their badge cleared.

Closes slices [#103](https://github.com/mbsanchez/DropboxSync/issues/103) and [#104](https://github.com/mbsanchez/DropboxSync/issues/104). [#105](https://github.com/mbsanchez/DropboxSync/issues/105) — live validation — is deliberately **not** covered here; see below.

## Two things the plan got wrong

Both were caught by doing what the plan itself demanded: check before shipping.

### 1. Pushing every change violates Apple's documented rule

`FinderSync.h` in the SDK, alongside `setBadgeIdentifier:forURL:`:

> Avoid adding badges to items that the Finder hasn't displayed yet. When setting the initial badge, call this method from your Finder Sync extension's `requestBadgeIdentifierForURL:` method. **When updating badges, call this method only for items that have already received a badge.**

The plan said to push for every changed path. That would badge items Finder has never drawn — a file whose tier flips while its folder is closed, for instance.

Fixed with `BadgeDiff.pushable(_:alreadyBadged:)` filtering against a `badgedPaths` set that `requestBadgeIdentifier(for:)` populates. Kept as a **pure function** so the rule is enforced by tests rather than by a comment somebody can delete.

The same header settled #104's open question at the same time — *"Setting the identifier to an empty string (`@""`) removes the badge"* is **documented**, so the clearing mechanism is not folklore. Cited in the code.

### 2. The planned test command runs nothing while reporting success

```
xcrun swift BadgeDiff.swift Tests/BadgeDiffTests.swift   -> exit 0, no output, nothing executed
xcrun swift Tests/BadgeDiffTests.swift BadgeDiff.swift   -> error: cannot find 'BadgeDiff' in scope
xcrun swiftc -o out BadgeDiff.swift Tests/…              -> error: statements are not allowed at the top level
```

The first is the dangerous one: **exit 0 having tested nothing looks exactly like a pass.** Resolved with `@main` + `swiftc`, wrapped in `Tests/run-badge-diff-tests.sh`, with the caveat written into the script header.

## Stack

`desktop-tauri` — but this change is **Swift/AppKit only**. Flagged at the architecture step: neither `tauri-expert` nor `rust-pro` from the stack profile covers it.

## Jira Ticket

DBSYNC-84

## Test Plan

- [x] **`./Tests/run-badge-diff-tests.sh` — 13 checks, all passing.**
- [x] **The checks can actually fail** — verified by mutation, not assumed:
  ```
  break the first-load guard          -> 1 check FAILED
  break the "only differences" filter -> 4 checks FAILED
  restored                            -> all checks passed
  ```
- [x] **The new code is genuinely linked into the binary.** `BUILD SUCCEEDED` does not prove this: a file missing from the Sources build phase compiles to nothing and the build still succeeds. `project.pbxproj` here lists files **manually** (no `fileSystemSynchronizedGroups`), so registration is four hand edits and a real failure mode.
  ```
  nm -a DropboxSyncFinderSync | grep -ci BadgeDiff  ->  72
  lipo -archs                                       ->  x86_64 arm64
  ```
- [x] `npm run build:finder-sync` — `** BUILD SUCCEEDED **`, `Principal class OK: DropboxSyncFinderSync`.
- [x] **Rust untouched**, as the slice requires — `git status` shows 0 modified `.rs` files. `cargo test` 177 passed; `cargo clippy` reports the same 4 pre-existing warnings, none new.

### Not tested here

**Nothing in this PR proves a badge visibly changes in Finder.** That is slice #105, it is manual, and its acceptance criterion is deliberately awkward: evidence must be captured **without navigating away from the directory**, because navigating away is the gesture that makes a stale badge look correct. A screenshot taken after navigating would prove nothing and look like proof.

That is not hypothetical on this ticket — DBSYNC-72 Slice 3 ticked *"`synced` renders"*, which was true and structurally incapable of catching this bug.

## Design notes for review

- **The 2-second poll stays.** Replacing it with a file watcher was floated and rejected: it is not the bug, and changing trigger and mechanism together destroys attribution. Recorded in the ticket's Implementation Decisions.
- **First load pushes nothing.** With no previous snapshot every path reads as changed; DBSYNC-80 measured the enumeration at 50,000 files, so this is a measured risk. Encoded in `BadgeDiff.changes`' contract (`nil` in → nothing out) rather than at the call site, where a future caller could forget it.
- **`updated_at` short-circuit.** The Rust writer stamps every snapshot, so an unchanged stamp skips the diff entirely — one string compare per tick instead of a full map comparison.
- **`lastUpdatedAt` is cleared whenever `state` is.** Otherwise a file that becomes unreadable and returns with the same stamp would skip the diff forever and never push again.
- **Path containment is enforced, not assumed.** A relative path containing `..` would otherwise let the state file badge arbitrary locations.

🤖 Generated with Claude Code