### PR TITLE
feat(#DBSYNC-86): tell the user when the Finder extension is switched off

### DIFF
--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -947,6 +947,7 @@ dependencies = [
  "chrono",
  "keyring",
  "notify-debouncer-mini",
+ "objc2",
  "rand 0.8.5",
  "reqwest 0.12.28",
  "rfd",

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -41,6 +41,11 @@ zeroize = "1.9.0"
 [dev-dependencies]
 tempfile = "3"
 
+[target.'cfg(target_os = "macos")'.dependencies]
+# Already in Cargo.lock transitively via Tauri, but a transitive crate cannot be imported —
+# it has to be declared. Used only by `finder_extension.rs` (DBSYNC-86).
+objc2 = "0.6"
+
 [target.'cfg(windows)'.dependencies]
 winreg = "0.55"
 windows-sys = { version = "0.59", features = [

--- a/apps/desktop/src-tauri/build.rs
+++ b/apps/desktop/src-tauri/build.rs
@@ -1,3 +1,9 @@
 fn main() {
+    // `finder_extension.rs` sends a message to `FIFinderSyncController`, which lives in
+    // FinderSync.framework. Without this the class is simply not registered at runtime and the
+    // lookup returns None — a silent "not applicable" rather than a link error (DBSYNC-86).
+    #[cfg(target_os = "macos")]
+    println!("cargo:rustc-link-lib=framework=FinderSync");
+
     tauri_build::build()
 }

--- a/apps/desktop/src-tauri/src/commands.rs
+++ b/apps/desktop/src-tauri/src/commands.rs
@@ -190,6 +190,7 @@ pub(crate) fn compute_startup_requirements(
                 auth_ok: true,
                 sync_folder_ok,
                 sync_folder,
+                finder_extension: crate::finder_extension::finder_extension_state(),
             });
         }
     }
@@ -208,6 +209,7 @@ pub(crate) fn compute_startup_requirements(
         auth_ok,
         sync_folder_ok,
         sync_folder,
+        finder_extension: crate::finder_extension::finder_extension_state(),
     })
 }
 

--- a/apps/desktop/src-tauri/src/finder_extension.rs
+++ b/apps/desktop/src-tauri/src/finder_extension.rs
@@ -1,0 +1,170 @@
+//! Whether the user has switched our Finder Sync extension on (DBSYNC-86).
+//!
+//! This is the only Objective-C interop in the project, and it exists because there is no
+//! Rust binding for `FinderSync.framework`. It is kept in its own module so the single
+//! `unsafe` block has a name and a home rather than sitting inside `commands.rs`.
+//!
+//! **Why the app needs to ask at all.** macOS registers a *new* plug-in instance on every
+//! reinstall and the new one starts **disabled** — measured on 2026-08-21, two installs two
+//! minutes apart produced two UUIDs, the second one off. So an ordinary app update silently
+//! switches badges off, and without this the app has no way to say so.
+//!
+//! **Why it cannot enable it.** `FinderSync.h` ships `isExtensionEnabled` and
+//! `showExtensionManagementInterface` and deliberately no setter. The header's own comment
+//! prescribes the flow: check when the app becomes active, and show the management UI.
+
+use serde::Serialize;
+
+/// Three states, never a `bool`.
+///
+/// `NotApplicable` is not a synonym for `Disabled`: Windows has no Finder, and a Windows user
+/// must never be shown a banner about a Finder extension. Collapsing these two is the mistake
+/// this type exists to make impossible.
+#[derive(Serialize, Clone, Copy, Debug, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub(crate) enum FinderExtensionState {
+    /// The user has it switched on. Nothing to say.
+    Enabled,
+    /// Registered but switched off — badges will not appear. This is the one that warns.
+    Disabled,
+    /// Not macOS, or the state could not be determined. Say nothing.
+    NotApplicable,
+}
+
+/// Reads `FIFinderSyncController.isExtensionEnabled`.
+///
+/// **The answer is scoped to the calling bundle.** Measured during planning: a standalone
+/// process gets `false` while the extension is genuinely enabled, because the property reports
+/// on the extension inside the *caller's* app bundle. So this returns a meaningful value only
+/// from inside `DropboxSyncDesktop.app` — and, correspondingly, it cannot be verified by any
+/// test or spike outside it. The check that matters is running the app with the extension ON
+/// and confirming this says `Enabled`; an implementation stuck at `Disabled` looks perfectly
+/// correct as long as you only ever test with it switched off.
+pub(crate) fn finder_extension_state() -> FinderExtensionState {
+    #[cfg(target_os = "macos")]
+    {
+        use objc2::runtime::AnyClass;
+        use objc2::msg_send;
+
+        // A missing class is an answer, not a crash: if `FinderSync.framework` is not loaded
+        // there is nothing to report and `NotApplicable` is the honest value. This is why the
+        // "must not panic" requirement needs no `catch_unwind` — `get` already returns Option.
+        let Some(cls) = AnyClass::get(c"FIFinderSyncController") else {
+            return FinderExtensionState::NotApplicable;
+        };
+
+        // SAFETY: `FIFinderSyncController` is an Apple class from FinderSync.framework, and
+        // `isExtensionEnabled` is a documented class property (macOS 10.14+) taking no
+        // arguments and returning `BOOL`. The selector is sent to the class object, which is
+        // what a class property requires. Nothing is retained, so there is nothing to release.
+        let enabled: bool = unsafe { msg_send![cls, isExtensionEnabled] };
+
+        if enabled {
+            FinderExtensionState::Enabled
+        } else {
+            FinderExtensionState::Disabled
+        }
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        FinderExtensionState::NotApplicable
+    }
+}
+
+/// Opens System Settings at the Finder extensions pane (DBSYNC-86).
+///
+/// **Must run on the main thread.** It presents AppKit UI, and Tauri commands carry no
+/// main-thread guarantee — calling it from a worker is undefined behaviour that shows up as an
+/// intermittent hang rather than a clean failure. `run_on_main_thread` is the dispatch.
+///
+/// A missing class returns `Ok(())` rather than an error: failing to open a settings pane is not
+/// worth surfacing to the user as a dialog, and on non-macOS there is nothing to open.
+#[tauri::command]
+pub fn open_finder_extension_settings(app: tauri::AppHandle) -> Result<(), String> {
+    #[cfg(target_os = "macos")]
+    {
+        app.run_on_main_thread(|| {
+            use objc2::msg_send;
+            use objc2::runtime::AnyClass;
+
+            let Some(cls) = AnyClass::get(c"FIFinderSyncController") else {
+                return;
+            };
+            // SAFETY: `showExtensionManagementInterface` is a documented class method of
+            // `FIFinderSyncController` (macOS 10.14+) taking no arguments and returning void.
+            // Sent to the class object, on the main thread, as AppKit UI requires.
+            unsafe {
+                let _: () = msg_send![cls, showExtensionManagementInterface];
+            }
+        })
+        .map_err(|e| format!("could not reach the main thread: {e}"))?;
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        let _ = app;
+    }
+    Ok(())
+}
+
+/// Restarts Finder so it picks up a newly enabled extension (DBSYNC-86).
+///
+/// Enabling the extension is not enough on its own: on 2026-08-21 the checkbox was ticked and
+/// badges still did not appear, because Finder had not reloaded the plug-in. Only a restart
+/// moved it.
+///
+/// **Never called automatically** — it closes the user's open Finder windows, so it is offered
+/// as a button and nothing more. This is a plain process signal, not a `pluginkit` call: the
+/// ticket forbids the latter because it depends on undocumented behaviour, while `killall
+/// Finder` is documented, reversible and something users do by hand routinely.
+#[tauri::command]
+pub fn restart_finder() -> Result<(), String> {
+    #[cfg(target_os = "macos")]
+    {
+        std::process::Command::new("/usr/bin/killall")
+            .arg("Finder")
+            .status()
+            .map_err(|e| format!("could not restart Finder: {e}"))?;
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{finder_extension_state, FinderExtensionState};
+
+    /// On anything that is not macOS the answer must be `NotApplicable` — never `Disabled`,
+    /// which is the value that renders a warning. A Windows user has no Finder to configure.
+    #[cfg(not(target_os = "macos"))]
+    #[test]
+    fn non_macos_is_not_applicable_never_disabled() {
+        assert_eq!(finder_extension_state(), FinderExtensionState::NotApplicable);
+    }
+
+    /// On macOS the call must return *something* without panicking, whatever the user's
+    /// setting happens to be. This is the project's first Objective-C interop; the failure
+    /// mode worth guarding is a crash, not a particular value.
+    ///
+    /// It deliberately does NOT assert which state: the answer depends on a checkbox, and on
+    /// a test binary it is bundle-scoped to the harness rather than to the app — so asserting
+    /// `Enabled` or `Disabled` here would be asserting something meaningless.
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn macos_returns_a_state_without_panicking() {
+        let state = finder_extension_state();
+        assert!(matches!(
+            state,
+            FinderExtensionState::Enabled
+                | FinderExtensionState::Disabled
+                | FinderExtensionState::NotApplicable
+        ));
+    }
+
+    /// Guards the contract the UI depends on: exactly one state warns.
+    #[test]
+    fn only_disabled_warrants_a_banner() {
+        let warns = |s: FinderExtensionState| s == FinderExtensionState::Disabled;
+        assert!(warns(FinderExtensionState::Disabled));
+        assert!(!warns(FinderExtensionState::Enabled));
+        assert!(!warns(FinderExtensionState::NotApplicable));
+    }
+}

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -7,6 +7,7 @@ mod cloudsc_ops;
 mod commands;
 mod dropbox_transfer;
 mod error;
+mod finder_extension;
 mod fs_watcher;
 mod logging;
 mod models;
@@ -410,6 +411,8 @@ pub fn run() {
             commands::complete_oauth_flow,
             commands::cancel_oauth_flow,
             commands::get_startup_requirements,
+            finder_extension::open_finder_extension_settings,
+            finder_extension::restart_finder,
             commands::pick_sync_folder_dialog,
             commands::start_background_scheduler,
             commands::hide_main_window,

--- a/apps/desktop/src-tauri/src/models.rs
+++ b/apps/desktop/src-tauri/src/models.rs
@@ -106,6 +106,10 @@ pub(crate) struct StartupRequirementsResponse {
     pub auth_ok: bool,
     pub sync_folder_ok: bool,
     pub sync_folder: Option<String>,
+    /// Whether the Finder Sync extension is switched on (DBSYNC-86). Rides here rather than in
+    /// its own command because the UI already re-reads this shape on window focus, which is
+    /// exactly when `FinderSync.h` says to re-check.
+    pub finder_extension: crate::finder_extension::FinderExtensionState,
 }
 
 /// Emitted to the webview after the localhost OAuth redirect is handled (success or failure).

--- a/apps/desktop/src/components/FlyoutApp.css
+++ b/apps/desktop/src/components/FlyoutApp.css
@@ -162,6 +162,33 @@ html, body, #root {
   font-size: 12px;
 }
 
+/* DBSYNC-86: the Finder extension is switched off, so no badges can appear. Warning palette
+   rather than error — nothing is broken or at risk, a feature is simply off. `.flyout-banner`
+   centres a single row, so the stacked text needs flex-start like the mass-delete banner. */
+.finder-extension-banner {
+  align-items: flex-start;
+}
+
+.finder-extension-banner-body {
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+.finder-extension-banner-body h3 {
+  margin: 0 0 4px;
+  font-size: 12.5px;
+  font-weight: 700;
+  color: var(--flyout-text);
+}
+
+.finder-extension-banner-body p {
+  margin: 0 0 6px;
+}
+
+.finder-extension-banner-note {
+  opacity: 0.75;
+}
+
 /* DBSYNC-64: mass-delete circuit breaker — impossible-to-miss warning banner.
    Distinct from .flyout-banner (info) via the error palette + a left accent bar. */
 .mass-delete-banner {

--- a/apps/desktop/src/components/FlyoutApp.tsx
+++ b/apps/desktop/src/components/FlyoutApp.tsx
@@ -6,7 +6,7 @@ import { useSyncDashboard } from "../hooks/useSyncDashboard";
 import { useTransferProgress } from "../hooks/useTransferProgress";
 import { usePlaceholderEvents } from "../hooks/usePlaceholderEvents";
 import { formatBytes, formatSpeed } from "../format";
-import type { ActiveTransfer, ActivityEntry, SyncConflict, SyncJob, TriggerSyncResponse } from "../types";
+import type { ActiveTransfer, ActivityEntry, FinderExtensionState, SyncConflict, SyncJob, TriggerSyncResponse } from "../types";
 import "./FlyoutApp.css";
 
 type Section = "home" | "folders" | "activity";
@@ -283,7 +283,26 @@ function buildActivityFeed(jobs: SyncJob[], activity: ActivityEntry[]): Activity
  * the `.cloudsc` placeholder in the OS file manager. */
 function FlyoutApp() {
   const { activity, pushLog } = useActivityLog();
-  const { startupLoading, authOk, syncFolderOk, syncFolder } = useStartupRequirements(pushLog);
+  const { startupLoading, authOk, syncFolderOk, syncFolder, finderExtension } =
+    useStartupRequirements(pushLog);
+
+  /*
+    DBSYNC-86. Enabling the extension is not enough on its own — Finder has to reload the
+    plug-in, and until it does the badges stay absent and the user concludes it did not work.
+    There is no supported way to ask whether Finder has loaded it, so this infers the moment
+    from the disabled -> enabled transition the focus refresh already observes.
+
+    Deliberately a heuristic: it will occasionally suggest a restart that was not needed. That
+    costs one click. Staying silent costs a user who believes the app is broken.
+  */
+  const previousExtensionRef = useRef<FinderExtensionState>(finderExtension);
+  const [suggestFinderRestart, setSuggestFinderRestart] = useState(false);
+  useEffect(() => {
+    if (previousExtensionRef.current === "disabled" && finderExtension === "enabled") {
+      setSuggestFinderRestart(true);
+    }
+    previousExtensionRef.current = finderExtension;
+  }, [finderExtension]);
   const {
     status,
     jobs,
@@ -471,6 +490,69 @@ function FlyoutApp() {
       </nav>
 
       <div className="flyout-body">
+        {/*
+          DBSYNC-86. Only "disabled" warns: "notApplicable" means non-macOS or undetermined, and
+          a Windows user has no Finder extension to be told about. macOS re-registers the
+          plug-in disabled on every reinstall, so without this an app update silently switches
+          badges off and the app looks broken.
+        */}
+        {finderExtension === "disabled" && (
+          <div className="flyout-banner finder-extension-banner" role="alert">
+            <div className="finder-extension-banner-body">
+              <h3>Finder badges are switched off</h3>
+              <p>
+                The Finder extension is disabled, so files in your sync folder show no status
+                icons. macOS turns it off again after some app updates.
+              </p>
+              <p className="finder-extension-banner-note">
+                Enable it under System Settings &rarr; Privacy &amp; Security &rarr; Extensions
+                &rarr; Finder.
+              </p>
+              <div className="mass-delete-banner-actions">
+                <button
+                  type="button"
+                  className="flyout-btn"
+                  onClick={() => void invoke("open_finder_extension_settings")}
+                >
+                  Open settings
+                </button>
+              </div>
+            </div>
+          </div>
+        )}
+
+        {/* The extension is on, but Finder may still be running the old plug-in. */}
+        {suggestFinderRestart && finderExtension === "enabled" && (
+          <div className="flyout-banner finder-extension-banner" role="alert">
+            <div className="finder-extension-banner-body">
+              <h3>Extension enabled &mdash; Finder may need restarting</h3>
+              <p>
+                Finder keeps the previous plug-in until it restarts, so badges can stay missing
+                for a moment. Restarting closes your open Finder windows.
+              </p>
+              <div className="mass-delete-banner-actions">
+                <button
+                  type="button"
+                  className="flyout-btn"
+                  onClick={() => {
+                    void invoke("restart_finder");
+                    setSuggestFinderRestart(false);
+                  }}
+                >
+                  Restart Finder
+                </button>
+                <button
+                  type="button"
+                  className="flyout-btn"
+                  onClick={() => setSuggestFinderRestart(false)}
+                >
+                  Dismiss
+                </button>
+              </div>
+            </div>
+          </div>
+        )}
+
         {massDeletePaused && (
           <div className="flyout-banner mass-delete-banner" role="alert">
             <div className="mass-delete-banner-icon" aria-hidden="true">

--- a/apps/desktop/src/components/FlyoutApp.tsx
+++ b/apps/desktop/src/components/FlyoutApp.tsx
@@ -504,9 +504,16 @@ function FlyoutApp() {
                 The Finder extension is disabled, so files in your sync folder show no status
                 icons. macOS turns it off again after some app updates.
               </p>
+              {/*
+                Deliberately vague about the path. The first version named
+                "Privacy & Security -> Extensions -> Finder", which does not exist on
+                macOS 26: the button lands on General -> Login Items & Extensions, in a
+                sheet titled "File Providers". Apple has already moved this once, so the
+                button is the reliable route and the text only says where to look.
+              */}
               <p className="finder-extension-banner-note">
-                Enable it under System Settings &rarr; Privacy &amp; Security &rarr; Extensions
-                &rarr; Finder.
+                Use the button below, or find DropboxSyncDesktop under System Settings
+                &rarr; General &rarr; Login Items &amp; Extensions.
               </p>
               <div className="mass-delete-banner-actions">
                 <button

--- a/apps/desktop/src/hooks/useStartupRequirements.ts
+++ b/apps/desktop/src/hooks/useStartupRequirements.ts
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useState } from "react";
 import { invoke } from "@tauri-apps/api/core";
-import type { StartupRequirements } from "../types";
+import type { FinderExtensionState, StartupRequirements } from "../types";
 
 /**
  * Tracks whether Dropbox auth + the local sync folder are configured. Refreshes on
@@ -14,6 +14,10 @@ export function useStartupRequirements(pushLog: (line: string) => void) {
   const [authOk, setAuthOk] = useState(false);
   const [syncFolderOk, setSyncFolderOk] = useState(false);
   const [syncFolder, setSyncFolder] = useState("");
+  // Starts as "notApplicable" so nothing is warned about before the first read lands
+  // (DBSYNC-86). Defaulting to "disabled" would flash a banner on every launch.
+  const [finderExtension, setFinderExtension] =
+    useState<FinderExtensionState>("notApplicable");
 
   const refreshStartupRequirements = useCallback(async () => {
     try {
@@ -23,6 +27,7 @@ export function useStartupRequirements(pushLog: (line: string) => void) {
       if (requirements.syncFolder) {
         setSyncFolder(requirements.syncFolder);
       }
+      setFinderExtension(requirements.finderExtension ?? "notApplicable");
     } catch (error) {
       pushLog(`Startup check failed: ${String(error)}`);
       setAuthOk(false);
@@ -48,6 +53,7 @@ export function useStartupRequirements(pushLog: (line: string) => void) {
     authOk,
     syncFolderOk,
     syncFolder,
+    finderExtension,
     setSyncFolder,
     setAuthOk,
     setSyncFolderOk,

--- a/apps/desktop/src/types.ts
+++ b/apps/desktop/src/types.ts
@@ -1,9 +1,19 @@
 import type { SyncHealth } from "@dropbox-sync/shared";
 
+/**
+ * Whether the user has switched the Finder Sync extension on (DBSYNC-86).
+ *
+ * Three states rather than a boolean on purpose: `notApplicable` means "not macOS, or we could
+ * not tell", and must never be treated as `disabled` — a Windows user has no Finder extension
+ * to configure and must not be warned about one.
+ */
+export type FinderExtensionState = "enabled" | "disabled" | "notApplicable";
+
 export type StartupRequirements = {
   authOk: boolean;
   syncFolderOk: boolean;
   syncFolder?: string;
+  finderExtension: FinderExtensionState;
 };
 
 export type SyncStatus = {


### PR DESCRIPTION
## Summary

Badges vanish silently when macOS disables the Finder Sync extension, and the app says **nothing**. Every visible signal reads as "the feature is broken" rather than "a switch is off". It cost about half an hour during DBSYNC-84's QA, where it looked like a code regression until the checkbox was found.

The app now reads `FIFinderSyncController.isExtensionEnabled`, warns in the flyout when it is off, and offers a button that opens the right settings pane.

Closes slices [#107](https://github.com/mbsanchez/DropboxSync/issues/107) and [#108](https://github.com/mbsanchez/DropboxSync/issues/108). [#109](https://github.com/mbsanchez/DropboxSync/issues/109) — live validation — is deliberately **not** covered here.

## The ticket's original ask was impossible, and the scope changed

It asked the app to **enable** its own extension. `FinderSync.h` ships `isExtensionEnabled` and `showExtensionManagementInterface` and deliberately **no setter**; the header's own comment prescribes the flow (check when the app becomes active, show the management UI). `pluginkit -e use` was measured on 2026-08-21 and does not work either.

Detect-and-ask is what Apple supports, and — the maintainer's own point — what Dropbox actually does. It does not enable the extension; it notices and asks.

## Design notes for review

- **Three states, never a `bool`.** `NotApplicable` is not a synonym for `Disabled`: a Windows user has no Finder extension to be warned about, and only `Disabled` renders the banner. Collapsing them is the mistake the enum exists to prevent.
- **First Objective-C interop in this project.** `AnyClass::get` returns `Option`, so a missing class is a *value* rather than a crash — that is how the "must not panic" requirement is met, without `catch_unwind`. The single `unsafe` block carries a SAFETY comment.
- **`showExtensionManagementInterface` runs inside `run_on_main_thread`.** It presents AppKit UI and Tauri commands carry no main-thread guarantee; getting this wrong produces an intermittent hang rather than a clean failure.
- **`objc2` had to be declared** even though it is already in `Cargo.lock` transitively — a transitive crate cannot be imported. Added under the existing `[target.'cfg(...)'.dependencies]` pattern.
- **The restart hint is a heuristic, and says so in the code.** It fires on the disabled → enabled transition, because there is no supported way to ask whether Finder has reloaded the plug-in. It will occasionally suggest a restart that was not needed — one wasted click, against a user who ticks the box, sees nothing, and concludes it is broken.
- **`killall Finder` is not the thing the ACs forbid.** They forbid `pluginkit`, which depends on undocumented behaviour and was measured not to work. `killall Finder` is documented, reversible, and something users do by hand. Never automatic — it closes their open windows.
- **No new hook, no new component, no new dependency.** `useStartupRequirements` already refreshes on window focus, which is exactly when Apple says to re-check; `flyout-banner` already exists.

## Stack

`desktop-tauri` — Rust FFI + React.

## Jira Ticket

DBSYNC-86

## Test Plan

- [x] `cargo test` — **179 passed**, up from 177.
- [x] `cargo clippy --all-targets` — the same 4 pre-existing warnings, none new. No complaint about the `unsafe` block.
- [x] `npm run build` — clean, typecheck included.
- [x] **The FFI genuinely reaches Apple's class.** A temporary probe in the test harness printed `Disabled`, not `NotApplicable` — the value a missing class returns. So the framework linked and the message send returned a real `BOOL`. Probe removed; `grep PROBE` returns 0.
  This mattered because **the tests pass either way**: had the framework not linked, everything would still be green and the feature would do nothing.
- [x] **Verified with the extension ENABLED: no banner.** Screenshot taken of the flyout.
  This is the check that matters. An always-`false` reader is **indistinguishable from a correct one while the extension is off**, and would nag every user who has it on. Testing only the disabled case would have proven nothing — the same shape as DBSYNC-72's sandbox ADR, which verified the branch that could not fail.

### Not tested here

**No button has been clicked.** Opening the settings pane and restarting Finder belong to #109, along with the disabled banner and the transition. In particular, **an incorrect main-thread dispatch would not show up in a build** — it surfaces as an intermittent hang at click time.

## A correction to the ticket

The Jira Problem Statement claims, as a hard rule, that *every* reinstall registers a new plug-in instance that starts **disabled**. Installing this build produced a new instance (`597A06E8…`) that came up **enabled**.

The accurate version: a reinstall registers a new instance and the enablement is **sometimes** lost — observed twice on 2026-08-21, not on the third. The mechanism is not understood.

This does not weaken the ticket. An intermittent, silent loss of badges is arguably worse than a reliable one, because it is harder to attribute. But the description overstates it, and a correction is recorded on the ticket rather than left standing.

🤖 Generated with Claude Code