### PR TITLE
fix(#DBSYNC-85): make the flyout geometry pure and anchor it below the menu bar

### DIFF
--- a/apps/desktop/src-tauri/src/flyout_geometry.rs
+++ b/apps/desktop/src-tauri/src/flyout_geometry.rs
@@ -1,0 +1,210 @@
+//! Where the tray flyout goes (DBSYNC-85).
+//!
+//! Split out of `position_flyout` in `lib.rs` so the placement math takes the **monitor list
+//! as an input** instead of looking it up. That is not tidiness: the development machine has
+//! one display, and the bug being chased only appears with two. Once a layout is four numbers
+//! in a parameter, the arrangements nobody here owns become ordinary test data.
+//!
+//! **What this module deliberately does NOT do** is correct the reported multi-monitor
+//! inversion. The suspicion is that `tray-icon` reports clicks in Cocoa coordinates (origin
+//! bottom-left) while `monitor_from_point` expects winit's top-left space — but that is
+//! unmeasured, and a coordinate flip has roughly a coin-flip chance of looking correct on one
+//! arrangement while being wrong on another. Measurement is GitHub #112, the fix is #113.
+
+/// A display, as far as placement is concerned. Physical pixels, top-left origin — the space
+/// Tauri's `Monitor` reports in.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub(crate) struct MonitorBox {
+    pub x: f64,
+    pub y: f64,
+    pub width: f64,
+    pub height: f64,
+}
+
+impl MonitorBox {
+    fn contains(&self, px: f64, py: f64) -> bool {
+        px >= self.x && px < self.x + self.width && py >= self.y && py < self.y + self.height
+    }
+}
+
+/// The tray icon's rectangle, in physical pixels.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub(crate) struct TrayRect {
+    pub x: f64,
+    pub y: f64,
+    pub width: f64,
+    pub height: f64,
+}
+
+/// Picks the display a click at `(px, py)` landed on.
+///
+/// Falls back to the first entry — the caller passes the primary first — when the point is
+/// outside every display. That happens more often than it sounds: it is exactly what a
+/// coordinate-space mismatch produces, and returning `None` here would leave the window
+/// unplaced rather than merely misplaced.
+pub(crate) fn monitor_for_point(monitors: &[MonitorBox], px: f64, py: f64) -> Option<MonitorBox> {
+    monitors
+        .iter()
+        .find(|m| m.contains(px, py))
+        .or_else(|| monitors.first())
+        .copied()
+}
+
+/// The flyout's top-left corner, clamped to stay wholly inside `monitor`.
+///
+/// Right-aligned to the tray icon, and **below** it on macOS: the menu bar is at the top of the
+/// screen, so a window anchored above it would be off-screen. The previous code subtracted the
+/// window height — a bottom-taskbar assumption inherited from Windows — and the clamp then
+/// pushed the result back to the top of the display, which made it look correct by accident on
+/// a single monitor. Windows keeps the original behaviour: its taskbar really is at the bottom.
+pub(crate) fn flyout_origin(
+    tray: TrayRect,
+    monitor: MonitorBox,
+    win_w: f64,
+    win_h: f64,
+    gap: f64,
+) -> (f64, f64) {
+    let x = tray.x + tray.width - win_w;
+
+    #[cfg(target_os = "macos")]
+    let y = tray.y + tray.height + gap;
+    #[cfg(not(target_os = "macos"))]
+    let y = tray.y - win_h - gap;
+
+    clamp_into(x, y, monitor, win_w, win_h)
+}
+
+/// Keeps the window inside the display.
+///
+/// When the window is larger than the display, `max < min` and `clamp` would panic, so that
+/// case pins to the origin instead. A window wider than the screen is a bad look; a panic in
+/// the click handler is a crash.
+fn clamp_into(x: f64, y: f64, m: MonitorBox, win_w: f64, win_h: f64) -> (f64, f64) {
+    let min_x = m.x;
+    let max_x = m.x + m.width - win_w;
+    let min_y = m.y;
+    let max_y = m.y + m.height - win_h;
+
+    let cx = if max_x >= min_x { x.clamp(min_x, max_x) } else { min_x };
+    let cy = if max_y >= min_y { y.clamp(min_y, max_y) } else { min_y };
+    (cx, cy)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{flyout_origin, monitor_for_point, MonitorBox, TrayRect};
+
+    // Two 1440x900@2x displays side by side, primary on the left. Physical pixels.
+    fn side_by_side() -> Vec<MonitorBox> {
+        vec![
+            MonitorBox { x: 0.0, y: 0.0, width: 2880.0, height: 1800.0 },
+            MonitorBox { x: 2880.0, y: 0.0, width: 2880.0, height: 1800.0 },
+        ]
+    }
+
+    // The same two, stacked with the secondary ABOVE the primary — the arrangement under which
+    // a Y-axis flip would map each menu bar onto the other screen. The layout is data, so this
+    // is testable on a machine with one display.
+    fn stacked() -> Vec<MonitorBox> {
+        vec![
+            MonitorBox { x: 0.0, y: 0.0, width: 2880.0, height: 1800.0 },
+            MonitorBox { x: 0.0, y: -1800.0, width: 2880.0, height: 1800.0 },
+        ]
+    }
+
+    #[test]
+    fn a_click_on_the_primary_picks_the_primary() {
+        let m = monitor_for_point(&side_by_side(), 100.0, 20.0).unwrap();
+        assert_eq!(m.x, 0.0);
+    }
+
+    #[test]
+    fn a_click_on_the_second_screen_picks_the_second_screen() {
+        let m = monitor_for_point(&side_by_side(), 3000.0, 20.0).unwrap();
+        assert_eq!(m.x, 2880.0);
+    }
+
+    #[test]
+    fn a_click_on_a_screen_above_the_primary_picks_that_screen() {
+        let m = monitor_for_point(&stacked(), 100.0, -1700.0).unwrap();
+        assert_eq!(m.y, -1800.0);
+    }
+
+    /// A point outside every display is what a coordinate-space mismatch produces. Falling back
+    /// beats returning nothing: the window ends up misplaced rather than never shown.
+    #[test]
+    fn a_point_outside_every_display_falls_back_to_the_first() {
+        let m = monitor_for_point(&side_by_side(), 99_999.0, 99_999.0).unwrap();
+        assert_eq!(m.x, 0.0);
+    }
+
+    #[test]
+    fn no_monitors_yields_none() {
+        assert!(monitor_for_point(&[], 0.0, 0.0).is_none());
+    }
+
+    /// DBSYNC-85's second defect. On macOS the menu bar is at the TOP, so the flyout belongs
+    /// below the icon. The old code subtracted the window height and relied on the clamp to
+    /// drag it back — correct-looking on one display, wrong in principle.
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn macos_hangs_the_flyout_below_the_menu_bar() {
+        let tray = TrayRect { x: 1400.0, y: 0.0, width: 44.0, height: 48.0 };
+        let m = side_by_side()[0];
+        let (_, y) = flyout_origin(tray, m, 720.0, 1200.0, 16.0);
+        assert_eq!(y, 64.0, "below the 48px tray rect plus the 16px gap");
+    }
+
+    #[cfg(not(target_os = "macos"))]
+    #[test]
+    fn other_platforms_keep_the_bottom_taskbar_anchor() {
+        let tray = TrayRect { x: 1400.0, y: 1752.0, width: 44.0, height: 48.0 };
+        let m = side_by_side()[0];
+        let (_, y) = flyout_origin(tray, m, 720.0, 1200.0, 16.0);
+        assert!(y < 1752.0, "the window sits above a bottom taskbar");
+    }
+
+    #[test]
+    fn the_flyout_is_right_aligned_to_the_icon() {
+        let tray = TrayRect { x: 1400.0, y: 0.0, width: 44.0, height: 48.0 };
+        let m = side_by_side()[0];
+        let (x, _) = flyout_origin(tray, m, 720.0, 1200.0, 16.0);
+        assert_eq!(x, 1400.0 + 44.0 - 720.0);
+    }
+
+    /// The icon sits near the right edge of the SECOND screen. The window must stay on that
+    /// screen — the clamp is relative to the chosen monitor, not to the desktop origin.
+    #[test]
+    fn clamping_keeps_the_window_on_the_second_screen() {
+        let monitors = side_by_side();
+        let tray = TrayRect { x: 5700.0, y: 0.0, width: 44.0, height: 48.0 };
+        let m = monitor_for_point(&monitors, 5720.0, 20.0).unwrap();
+        let (x, _) = flyout_origin(tray, m, 720.0, 1200.0, 16.0);
+        assert!(x >= 2880.0, "must not spill onto the primary");
+        assert!(x + 720.0 <= 5760.0, "must not run off the right edge");
+    }
+
+    /// A display smaller than the window makes `max < min`; `f64::clamp` panics on that.
+    /// A crash in the click handler is worse than an awkwardly placed window.
+    #[test]
+    fn a_window_larger_than_the_display_does_not_panic() {
+        let tiny = MonitorBox { x: 0.0, y: 0.0, width: 400.0, height: 300.0 };
+        let tray = TrayRect { x: 300.0, y: 0.0, width: 44.0, height: 48.0 };
+        let (x, y) = flyout_origin(tray, tiny, 720.0, 1200.0, 16.0);
+        assert_eq!((x, y), (0.0, 0.0));
+    }
+
+    /// Scale factors differ between a Retina laptop and an external display, so the numbers
+    /// arrive already in physical pixels and the function must not assume they match.
+    #[test]
+    fn a_non_retina_second_display_is_handled_by_its_own_geometry() {
+        let monitors = vec![
+            MonitorBox { x: 0.0, y: 0.0, width: 2880.0, height: 1800.0 },
+            MonitorBox { x: 2880.0, y: 0.0, width: 1920.0, height: 1080.0 },
+        ];
+        let m = monitor_for_point(&monitors, 3000.0, 10.0).unwrap();
+        let tray = TrayRect { x: 4700.0, y: 0.0, width: 22.0, height: 24.0 };
+        let (x, _) = flyout_origin(tray, m, 360.0, 600.0, 8.0);
+        assert!(x >= 2880.0 && x + 360.0 <= 4800.0);
+    }
+}

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -70,6 +70,52 @@ pub(crate) fn recently_toggled(within: Duration) -> bool {
     }
 }
 
+/// Every display, primary first.
+///
+/// The ordering is load-bearing: [`flyout_geometry::monitor_for_point`] falls back to `[0]`
+/// when a point lands outside every display, which is exactly what a coordinate-space mismatch
+/// produces — so the fallback should be the primary rather than whichever display the OS
+/// happened to enumerate first.
+fn collect_monitor_boxes(app: &AppHandle) -> Vec<flyout_geometry::MonitorBox> {
+    use flyout_geometry::MonitorBox;
+    let mut boxes: Vec<MonitorBox> = Vec::new();
+    let mut push = |m: &tauri::Monitor| {
+        let b = MonitorBox {
+            x: m.position().x as f64,
+            y: m.position().y as f64,
+            width: m.size().width as f64,
+            height: m.size().height as f64,
+        };
+        if !boxes.contains(&b) {
+            boxes.push(b);
+        }
+    };
+    if let Ok(Some(m)) = app.primary_monitor() {
+        push(&m);
+    }
+    if let Ok(all) = app.available_monitors() {
+        for m in all {
+            push(&m);
+        }
+    }
+    boxes
+}
+
+/// Logs the display layout once, at startup (DBSYNC-85).
+///
+/// The click-time line in [`position_flyout`] is the one that answers GitHub #112, but it only
+/// appears when someone clicks the tray icon — and the icon can be invisible when the menu bar
+/// overflows, which is exactly what happened while trying to verify this. Logging the layout at
+/// launch means the plumbing is provably alive without depending on a click, and it gives the
+/// measurement half its context for free.
+pub(crate) fn log_display_layout(app: &AppHandle) {
+    tracing::info!(
+        target: "dbsync85",
+        monitors = ?collect_monitor_boxes(app),
+        "display layout at startup"
+    );
+}
+
 /// Positions the `main` flyout window just above the tray icon, right-aligned to
 /// it — anchored to the primary/tray monitor's bottom-right corner (bottom taskbar
 /// assumption; no multi-monitor/taskbar-edge detection). All math is done in
@@ -83,31 +129,8 @@ fn position_flyout(
 ) {
     use flyout_geometry::{flyout_origin, monitor_for_point, MonitorBox, TrayRect};
 
-    // Primary first: `monitor_for_point` falls back to `[0]` when the click lands outside every
-    // display, which is exactly what a coordinate-space mismatch produces.
-    let mut boxes: Vec<MonitorBox> = Vec::new();
     let primary = app.primary_monitor().ok().flatten();
-    if let Some(m) = primary.as_ref() {
-        boxes.push(MonitorBox {
-            x: m.position().x as f64,
-            y: m.position().y as f64,
-            width: m.size().width as f64,
-            height: m.size().height as f64,
-        });
-    }
-    if let Ok(all) = app.available_monitors() {
-        for m in all {
-            let b = MonitorBox {
-                x: m.position().x as f64,
-                y: m.position().y as f64,
-                width: m.size().width as f64,
-                height: m.size().height as f64,
-            };
-            if !boxes.contains(&b) {
-                boxes.push(b);
-            }
-        }
-    }
+    let boxes = collect_monitor_boxes(app);
 
     // DBSYNC-85 instrumentation. One line per click, not per frame. It prints the raw tray
     // position, the tray rect and every display together so the coordinate space can be named
@@ -214,6 +237,8 @@ pub fn run() {
         .setup(|app| {
             #[cfg(target_os = "macos")]
             app.set_dock_visibility(false);
+
+            log_display_layout(app.handle());
 
             #[cfg(windows)]
             {

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -8,6 +8,7 @@ mod commands;
 mod dropbox_transfer;
 mod error;
 mod finder_extension;
+mod flyout_geometry;
 mod fs_watcher;
 mod logging;
 mod models;
@@ -80,47 +81,64 @@ fn position_flyout(
     position: PhysicalPosition<f64>,
     rect: Rect,
 ) {
-    let monitor = app
-        .monitor_from_point(position.x, position.y)
-        .ok()
-        .flatten()
-        .or_else(|| app.primary_monitor().ok().flatten());
+    use flyout_geometry::{flyout_origin, monitor_for_point, MonitorBox, TrayRect};
 
-    let Some(monitor) = monitor else {
+    // Primary first: `monitor_for_point` falls back to `[0]` when the click lands outside every
+    // display, which is exactly what a coordinate-space mismatch produces.
+    let mut boxes: Vec<MonitorBox> = Vec::new();
+    let primary = app.primary_monitor().ok().flatten();
+    if let Some(m) = primary.as_ref() {
+        boxes.push(MonitorBox {
+            x: m.position().x as f64,
+            y: m.position().y as f64,
+            width: m.size().width as f64,
+            height: m.size().height as f64,
+        });
+    }
+    if let Ok(all) = app.available_monitors() {
+        for m in all {
+            let b = MonitorBox {
+                x: m.position().x as f64,
+                y: m.position().y as f64,
+                width: m.size().width as f64,
+                height: m.size().height as f64,
+            };
+            if !boxes.contains(&b) {
+                boxes.push(b);
+            }
+        }
+    }
+
+    // DBSYNC-85 instrumentation. One line per click, not per frame. It prints the raw tray
+    // position, the tray rect and every display together so the coordinate space can be named
+    // from a SINGLE line rather than reconstructed from three — see GitHub #112. The reported
+    // multi-monitor inversion is deliberately NOT corrected until this has been read on a
+    // two-display machine; guessing the sign would look right on one arrangement half the time.
+    tracing::info!(
+        target: "dbsync85",
+        tray_click_x = position.x,
+        tray_click_y = position.y,
+        monitors = ?boxes,
+        "tray click geometry"
+    );
+
+    let scale = primary.as_ref().map(|m| m.scale_factor()).unwrap_or(1.0);
+    let rect_pos = rect.position.to_physical::<f64>(scale);
+    let rect_size = rect.size.to_physical::<f64>(scale);
+
+    let Some(monitor) = monitor_for_point(&boxes, position.x, position.y) else {
         let _ = window.show();
         return;
     };
 
-    let scale = monitor.scale_factor();
-    let mon_pos = monitor.position();
-    let mon_size = monitor.size();
-
-    let rect_pos = rect.position.to_physical::<f64>(scale);
-    let rect_size = rect.size.to_physical::<f64>(scale);
-
-    // `main` window is a fixed LOGICAL 360x600 (tauri.conf.json); convert to physical.
-    let win_w = 360.0 * scale;
-    let win_h = 600.0 * scale;
-    let gap = 8.0 * scale;
-
-    let mut x = rect_pos.x + rect_size.width - win_w;
-    let mut y = rect_pos.y - win_h - gap;
-
-    let min_x = mon_pos.x as f64;
-    let max_x = min_x + mon_size.width as f64 - win_w;
-    let min_y = mon_pos.y as f64;
-    let max_y = min_y + mon_size.height as f64 - win_h;
-
-    x = if max_x >= min_x {
-        x.clamp(min_x, max_x)
-    } else {
-        min_x
+    let tray = TrayRect {
+        x: rect_pos.x,
+        y: rect_pos.y,
+        width: rect_size.width,
+        height: rect_size.height,
     };
-    y = if max_y >= min_y {
-        y.clamp(min_y, max_y)
-    } else {
-        min_y
-    };
+    // `main` is a fixed LOGICAL 360x600 (tauri.conf.json); convert to physical.
+    let (x, y) = flyout_origin(tray, monitor, 360.0 * scale, 600.0 * scale, 8.0 * scale);
 
     let _ = window.set_position(PhysicalPosition::new(x, y));
     let _ = window.show();


### PR DESCRIPTION
## Summary

Two defects in `position_flyout`, and this PR fixes one of them on purpose.

**Fixed — the Y anchor.** `y = rect_pos.y - win_h - gap` put the flyout *above* the tray rect: a bottom-taskbar assumption inherited from Windows. On macOS the menu bar is at the top, and the clamp then dragged the result back to `min_y`, which is why it has looked correct **by accident** on a single display. Windows keeps its original anchor, `cfg`-split.

**Not fixed — the multi-monitor inversion.** Deliberately. See below.

Closes slice [#111](https://github.com/mbsanchez/DropboxSync/issues/111). [#112](https://github.com/mbsanchez/DropboxSync/issues/112) (measure) and [#113](https://github.com/mbsanchez/DropboxSync/issues/113) (fix) remain open.

## The constraint that shaped the design

**This machine has one display.** Checked, not assumed:

```
screen 0  origin=(0, 0)  size=1440x900  scale=2.0  Built-in Retina Display
```

So the reported bug cannot be reproduced here and a fix could not be validated. Rather than block, the placement math now takes the **monitor list as an input** instead of looking it up through `AppHandle`.

That is the whole point: a layout is four numbers. Once they are a parameter, the two-display arrangements nobody here owns — stacked, side-by-side, mixed scale factors — become ordinary test data. **Two-monitor behaviour is now testable on a one-monitor machine.**

## Why the inversion is untouched

The theory is that `tray-icon` reports clicks in Cocoa coordinates (origin bottom-left) while `monitor_from_point` expects winit's top-left space. It is **unmeasured**.

A coordinate flip has roughly a coin-flip chance of *appearing* correct on one arrangement while being wrong on another — the worst outcome available, because it would look like a fix and ship as one. This project already carries four premises falsified by running a command, and an ADR that failed because it reasoned instead of measuring.

So instead this PR ships the instrumentation: one log line per click carrying the raw tray position, the tray rect and every display's origin/size **together**, so the space can be named from a single line rather than reconstructed from three. That turns #112 into one click instead of a debugging session.

## Stack

`desktop-tauri` — Rust only. No frontend, no IPC, no capability change, no new dependency.

## Jira Ticket

DBSYNC-85

## Test Plan

- [x] **10 new tests**, 189 total (was 179). They cover layouts this machine does not have: side-by-side, stacked with the secondary above the primary, a non-Retina second display, clamping onto the correct screen, and a window larger than its display.
- [x] **The tests can fail** — verified by mutation, not assumed:
  ```
  restore the Windows anchor on macOS      -> macos_hangs_the_flyout_below_the_menu_bar FAILED
  make monitor lookup always pick [0]      -> 5 tests FAILED
  restored                                 -> 10 passed
  ```
- [x] **The Windows arm was compiled and executed**, via the `cfg`-pivot technique DBSYNC-81 established: `other_platforms_keep_the_bottom_taskbar_anchor ... ok`. Pivot reverted. Without this the Windows guarantee would rest on a test that never runs.
- [x] `cargo clippy --all-targets` — same 4 pre-existing warnings, none new.
- [x] Release bundle builds and installs.

### Not verified — read before merging

**The instrumentation has never been seen to emit, and single-display placement has not been re-checked visually.** The machine's display went to sleep partway through validation, so the click never reached the tray and `screencapture` returned *"could not create image from rect"*.

What that leaves unverified:
- That the `dbsync85` log line actually appears on a real click. It compiles and the global filter is `info`, so it *should* — but "should" is what this project keeps getting wrong.
- That the corrected Y anchor looks right on screen. The arithmetic is tested; the pixels are not.

Neither blocks the merge in my view — both are covered by tests or trivially observable — but they are stated rather than glossed, and the first one matters because **#112 depends on that log line existing**.

🤖 Generated with Claude Code