### PR TITLE
fix(#DBSYNC-87): badge files that are born while their folder is open

### DIFF
--- a/apps/desktop/native/macos/FinderSyncExtension/BadgeDiff.swift
+++ b/apps/desktop/native/macos/FinderSyncExtension/BadgeDiff.swift
@@ -60,11 +60,45 @@ enum BadgeDiff {
     /// has caught up, so nothing is badged — and when the tier arrives moments later the
     /// path is filtered out and never badged at all. Finder does not ask twice. That is
     /// symptom 1 of DBSYNC-84, reintroduced by the very filter meant to respect Apple's rule.
-    static func pushable(_ changes: Changes, displayed: Set<String>) -> Changes {
-        Changes(
-            changed: changes.changed.filter { displayed.contains($0.key) },
-            removed: changes.removed.filter { displayed.contains($0) }
+    ///
+    /// `observedDirectories` closes a second hole in the same idea (DBSYNC-87). Finder only
+    /// asks about an item while **enumerating** a directory, so a file that is *created*
+    /// while its folder is already open is never asked about and never enters `displayed`.
+    /// Hydration does exactly that: it downloads `foo.txt` and deletes `foo.txt.cloudsc`, so
+    /// the tier arrives against a path Finder has never named. Every push for it was dropped
+    /// here, and only re-entering the directory — which forces a fresh enumeration — showed
+    /// the badge.
+    ///
+    /// An item in a directory Finder is currently observing **is** displayed, which is the
+    /// condition Apple's first sentence actually states. Widening to "asked about, or sitting
+    /// in a folder on screen" is therefore closer to the documented rule than the narrower
+    /// test it replaces, not a relaxation of it.
+    static func pushable(
+        _ changes: Changes,
+        displayed: Set<String>,
+        observedDirectories: Set<String>
+    ) -> Changes {
+        func isPushable(_ path: String) -> Bool {
+            displayed.contains(path) || observedDirectories.contains(parentDirectory(of: path))
+        }
+        return Changes(
+            changed: changes.changed.filter { isPushable($0.key) },
+            removed: changes.removed.filter(isPushable)
         )
+    }
+
+    /// The directory part of a relative path: `"sub/a.txt"` → `"sub"`, `"a.txt"` → `""`.
+    ///
+    /// `""` is the sync folder itself, which is a real answer rather than a missing one —
+    /// files sitting directly in the sync root are the common case, and their parent has to
+    /// compare equal to the relative path of the root that [`relativePath`] produces.
+    ///
+    /// Only the LAST separator is cut, so a file in a subfolder of an observed directory does
+    /// not match that directory. `"sub/deep/a.txt"` yields `"sub/deep"`, not `"sub"` — and it
+    /// should, because Finder showing `sub` does not put the contents of `sub/deep` on screen.
+    static func parentDirectory(of relative: String) -> String {
+        guard let separator = relative.lastIndex(of: "/") else { return "" }
+        return String(relative[relative.startIndex..<separator])
     }
 
     /// Whether `path` is `root` itself or lives inside it.

--- a/apps/desktop/native/macos/FinderSyncExtension/SyncExtension.swift
+++ b/apps/desktop/native/macos/FinderSyncExtension/SyncExtension.swift
@@ -24,13 +24,27 @@ final class DropboxSyncFinderSync: FIFinderSync {
     /// **This set only ever grows, and that is deliberate.** Clearing a badge does not mean
     /// Finder stopped showing the item — the file is still on screen with no status to
     /// display. Dropping a path here when its badge is cleared means a file that leaves the
-    /// state map and comes back is filtered out of the push and never badged again. The
-    /// only genuine "no longer displayed" signal is `endObservingDirectoryAtURL:`, which
-    /// this extension does not implement.
+    /// state map and comes back is filtered out of the push and never badged again.
     ///
     /// The cost of never shrinking is one string per distinct path Finder has shown inside
     /// the sync folder — a few MB at the 50,000 files DBSYNC-80 measured. Accepted.
+    ///
+    /// It is not the whole story on its own: Finder only asks while enumerating, so a file
+    /// created in an already-open folder never appears here. [`observedDirectories`] covers
+    /// that case (DBSYNC-87).
     private var displayedPaths: Set<String> = []
+
+    /// Absolute paths of the directories Finder is showing right now (DBSYNC-87).
+    ///
+    /// Unlike [`displayedPaths`] this one shrinks, because `endObservingDirectory(at:)` is a
+    /// genuine "no longer on screen" signal — the only one this API provides.
+    ///
+    /// **Absolute rather than relative on purpose.** These callbacks can fire before the
+    /// first `overlay_state.json` read lands, and at that moment there is no sync root to
+    /// make a path relative to. Storing what Finder actually hands us keeps the record
+    /// correct regardless of when state arrives; the conversion to relative paths happens at
+    /// push time, when the root is known or the push is skipped anyway.
+    private var observedDirectories: Set<String> = []
 
     /// `updated_at` of the snapshot currently in `state`. The Rust writer stamps every
     /// snapshot (`overlay_state.rs`), so an unchanged value means an unchanged file and the
@@ -178,8 +192,18 @@ final class DropboxSyncFinderSync: FIFinderSync {
     /// "When updating badges, call this method only for items that have already received a
     /// badge." Hence the `pushable` filter rather than pushing everything that changed.
     private func pushBadgeChanges(_ changes: BadgeDiff.Changes) {
-        let pushable = BadgeDiff.pushable(changes, displayed: displayedPaths)
-        guard !pushable.isEmpty, let root = syncFolderRoot() else {
+        guard let root = syncFolderRoot() else {
+            return
+        }
+        // Converted here rather than stored relative: see `observedDirectories`. Anything
+        // outside the root drops out, which is also the containment guard for this input.
+        let observedRelatives = Set(
+            observedDirectories.compactMap { BadgeDiff.relativePath(of: $0, under: root.path) }
+        )
+        let pushable = BadgeDiff.pushable(
+            changes, displayed: displayedPaths, observedDirectories: observedRelatives
+        )
+        guard !pushable.isEmpty else {
             return
         }
         let controller = FIFinderSyncController.default()
@@ -214,6 +238,21 @@ final class DropboxSyncFinderSync: FIFinderSync {
         let url = root.appendingPathComponent(relative).standardizedFileURL
         guard BadgeDiff.isContained(url.path, in: root.path) else { return nil }
         return url
+    }
+
+    /// Finder started showing a directory inside the sync folder (DBSYNC-87).
+    ///
+    /// This is what makes a badge reach a file that did not exist when the folder was opened.
+    /// Hydration creates such a file every time — `foo.txt` appears while `foo.txt.cloudsc`
+    /// disappears — and Finder never asks about it, because it only asks while enumerating.
+    override func beginObservingDirectory(at url: URL) {
+        observedDirectories.insert(url.standardizedFileURL.path)
+    }
+
+    /// Finder stopped showing a directory. Pushing into it from here on would be badging
+    /// items that are no longer on screen, which is the thing `FinderSync.h` warns against.
+    override func endObservingDirectory(at url: URL) {
+        observedDirectories.remove(url.standardizedFileURL.path)
     }
 
     override func requestBadgeIdentifier(for url: URL) {

--- a/apps/desktop/native/macos/FinderSyncExtension/Tests/BadgeDiffTests.swift
+++ b/apps/desktop/native/macos/FinderSyncExtension/Tests/BadgeDiffTests.swift
@@ -132,13 +132,13 @@ struct BadgeDiffTests {
         check("a path Finder has never displayed is not pushable",
               BadgeDiff.pushable(
                   BadgeDiff.Changes(changed: ["never-seen.txt": "synced"], removed: []),
-                  displayed: []),
+                  displayed: [], observedDirectories: []),
               changed: [:], removed: [])
 
         check("a displayed path is pushable",
               BadgeDiff.pushable(
                   BadgeDiff.Changes(changed: ["seen.txt": "synced"], removed: []),
-                  displayed: ["seen.txt"]),
+                  displayed: ["seen.txt"], observedDirectories: []),
               changed: ["seen.txt": "synced"], removed: [])
 
         // DBSYNC-84 symptom 1, and the case whose absence let a green run hide the hole.
@@ -148,21 +148,96 @@ struct BadgeDiffTests {
         check("a DISPLAYED but never-badged path is still pushable",
               BadgeDiff.pushable(
                   BadgeDiff.Changes(changed: ["new.cloudsc": "cloud_only"], removed: []),
-                  displayed: ["new.cloudsc"]),
+                  displayed: ["new.cloudsc"], observedDirectories: []),
               changed: ["new.cloudsc": "cloud_only"], removed: [])
 
         check("mixed displayed and undisplayed keeps only the displayed",
               BadgeDiff.pushable(
                   BadgeDiff.Changes(changed: ["seen.txt": "synced", "never.txt": "syncing"],
                                     removed: ["gone-seen.txt", "gone-never.txt"]),
-                  displayed: ["seen.txt", "gone-seen.txt"]),
+                  displayed: ["seen.txt", "gone-seen.txt"], observedDirectories: []),
               changed: ["seen.txt": "synced"], removed: ["gone-seen.txt"])
 
         check("removals are filtered too",
               BadgeDiff.pushable(
                   BadgeDiff.Changes(changed: [:], removed: ["never-seen.txt"]),
-                  displayed: []),
+                  displayed: [], observedDirectories: []),
               changed: [:], removed: [])
+
+        print("BadgeDiff.pushable — files born in an open directory (DBSYNC-87)")
+
+        // THE BUG. Hydration downloads `foo.txt` and deletes `foo.txt.cloudsc`, so the tier
+        // arrives against a path Finder never asked about — it only asks while enumerating,
+        // and the folder was already open. Before this, the push was dropped and the file
+        // stayed bare until the user left the directory and came back.
+        check("a path never asked about IS pushable when its directory is on screen",
+              BadgeDiff.pushable(
+                  BadgeDiff.Changes(changed: ["hydrated.txt": "synced"], removed: []),
+                  displayed: [], observedDirectories: [""]),
+              changed: ["hydrated.txt": "synced"], removed: [])
+
+        check("the same path in a subfolder on screen is pushable too",
+              BadgeDiff.pushable(
+                  BadgeDiff.Changes(changed: ["sub/hydrated.txt": "synced"], removed: []),
+                  displayed: [], observedDirectories: ["sub"]),
+              changed: ["sub/hydrated.txt": "synced"], removed: [])
+
+        // The widening must stay narrow. Finder showing `sub` does not put the contents of
+        // `sub/deep` on screen, and badging them would be the thing Apple's header warns
+        // against — the opposite mistake to the one being fixed.
+        check("a file DEEPER than the observed directory is not pushable",
+              BadgeDiff.pushable(
+                  BadgeDiff.Changes(changed: ["sub/deep/buried.txt": "synced"], removed: []),
+                  displayed: [], observedDirectories: ["sub"]),
+              changed: [:], removed: [])
+
+        check("an observed directory does not make a SIBLING directory pushable",
+              BadgeDiff.pushable(
+                  BadgeDiff.Changes(changed: ["other/a.txt": "synced"], removed: []),
+                  displayed: [], observedDirectories: ["sub"]),
+              changed: [:], removed: [])
+
+        // A file deleted from a folder that is open must lose its badge for the same reason
+        // it would gain one: the user is looking at it.
+        check("removals in an observed directory are pushable",
+              BadgeDiff.pushable(
+                  BadgeDiff.Changes(changed: [:], removed: ["gone.txt"]),
+                  displayed: [], observedDirectories: [""]),
+              changed: [:], removed: ["gone.txt"])
+
+        // Closing the window must stop the pushes; `endObservingDirectory` empties the set.
+        check("once the directory is no longer observed, pushes stop",
+              BadgeDiff.pushable(
+                  BadgeDiff.Changes(changed: ["hydrated.txt": "synced"], removed: []),
+                  displayed: [], observedDirectories: []),
+              changed: [:], removed: [])
+
+        // Belt and braces: the two admission routes are independent, not a replacement.
+        check("displayed and observed both admit, in one call",
+              BadgeDiff.pushable(
+                  BadgeDiff.Changes(
+                      changed: ["asked.txt": "synced", "sub/born.txt": "cloud_only",
+                                "elsewhere/no.txt": "syncing"],
+                      removed: []),
+                  displayed: ["asked.txt"], observedDirectories: ["sub"]),
+              changed: ["asked.txt": "synced", "sub/born.txt": "cloud_only"], removed: [])
+
+        // The first-load guard still has the last word: nothing to push means nothing pushed,
+        // however many directories are open. This is what keeps 50,000 files from storming.
+        check("an open directory does not defeat the first-load guard",
+              BadgeDiff.pushable(
+                  BadgeDiff.changes(from: nil, to: ["a.txt": "synced", "b.txt": "cloud_only"]),
+                  displayed: [], observedDirectories: [""]),
+              changed: [:], removed: [])
+
+        print("BadgeDiff.parentDirectory")
+
+        checkOptional("a file in the sync root has the root as its parent",
+                      BadgeDiff.parentDirectory(of: "a.txt"), "")
+        checkOptional("a file in a subfolder yields that subfolder",
+                      BadgeDiff.parentDirectory(of: "sub/a.txt"), "sub")
+        checkOptional("only the last separator is cut",
+                      BadgeDiff.parentDirectory(of: "sub/deep/a.txt"), "sub/deep")
 
         print("BadgeDiff.isContained")
 
@@ -254,14 +329,46 @@ struct BadgeDiffTests {
         let displayed: Set<String> = ["a.txt"]
 
         let leaving = BadgeDiff.pushable(
-            BadgeDiff.changes(from: ["a.txt": "synced"], to: [:]), displayed: displayed)
+            BadgeDiff.changes(from: ["a.txt": "synced"], to: [:]),
+            displayed: displayed, observedDirectories: [])
         check("on the way out, the badge is cleared",
               leaving, changed: [:], removed: ["a.txt"])
 
         let returning = BadgeDiff.pushable(
-            BadgeDiff.changes(from: [:], to: ["a.txt": "synced"]), displayed: displayed)
+            BadgeDiff.changes(from: [:], to: ["a.txt": "synced"]),
+            displayed: displayed, observedDirectories: [])
         check("on the way back, the badge is set again",
               returning, changed: ["a.txt": "synced"], removed: [])
+
+        print("end to end: hydrating a .cloudsc with the folder open (DBSYNC-87)")
+
+        // The reported bug, as a single composition rather than as separate pieces.
+        //
+        // The user is looking at the sync root. `report.pdf.cloudsc` is on screen and badged
+        // `cloud_only`, so Finder has asked about it. They open it; the app downloads
+        // `report.pdf` and deletes the placeholder, so ONE snapshot swaps one path for
+        // another. The old path must lose its badge and the new one must gain the green
+        // check — without the user leaving the directory, because leaving and coming back is
+        // the gesture that hid this bug for two tickets.
+        let beforeHydration = ["report.pdf.cloudsc": "cloud_only"]
+        let afterHydration = ["report.pdf": "synced"]
+
+        check("the hydrated file is badged and the placeholder is cleared, in place",
+              BadgeDiff.pushable(
+                  BadgeDiff.changes(from: beforeHydration, to: afterHydration),
+                  displayed: ["report.pdf.cloudsc"],
+                  observedDirectories: [""]),
+              changed: ["report.pdf": "synced"], removed: ["report.pdf.cloudsc"])
+
+        // And the proof that the observed set is what carries it: with the folder closed,
+        // the same snapshot pair produces exactly the old broken behaviour — the placeholder
+        // is cleared because Finder asked about it, and the hydrated file stays bare.
+        check("with the folder closed, only the placeholder is touched",
+              BadgeDiff.pushable(
+                  BadgeDiff.changes(from: beforeHydration, to: afterHydration),
+                  displayed: ["report.pdf.cloudsc"],
+                  observedDirectories: []),
+              changed: [:], removed: ["report.pdf.cloudsc"])
 
         if failures == 0 {
             print("BadgeDiff: all checks passed")


### PR DESCRIPTION
Fixes the badge that never appears after hydrating a `.cloudsc` — [DBSYNC-87](https://manuelbsan.atlassian.net/browse/DBSYNC-87). Found on a second Mac during the manual validation of DBSYNC-72 Slice 4 (#84).

## The bug

Hydrate a placeholder with its folder open: the `cloud_only` badge is there, the `syncing` animation plays, and then the hydrated file sits with **no badge** until you leave the directory and come back.

This is symptom 3 of DBSYNC-84, verbatim — *"Hydrating a file does not show its green check"* — surviving the fix that closed that ticket.

## Why it survived

Two measurements taken on the affected machine split the problem cleanly:

- **The backend is fine.** Right after hydrating and before navigating anywhere, `overlay_state.json` already lists the hydrated path as `synced`.
- **The push works.** A file whose tier changes *without changing name* updates live, red to green, without leaving the directory.

So the fault is specific to paths that are **new** — and hydration produces exactly that. It downloads `foo.txt` and deletes `foo.txt.cloudsc`; the tier arrives against a path Finder has never named. Finder only asks about an item while *enumerating* a directory, so a file created in an already-open folder never enters `displayedPaths`, and `pushable` dropped every push for it.

Two other explanations were checked and ruled out, so nobody needs to re-walk them: `BadgeDiff.changes` does report a path that is new in the snapshot, and `displayedPaths` is never cleared.

## The fix

`pushable` now admits a path by either of two routes — Finder asked about it, **or** its parent directory is on screen. The second is tracked by implementing `beginObservingDirectory(at:)` / `endObservingDirectory(at:)`, which this extension never implemented; the comment on `displayedPaths` had already named that gap as the only genuine "no longer displayed" signal.

This is not a relaxation of Apple's rule. `FinderSync.h` says *"Avoid adding badges to items that the Finder hasn't displayed yet"*, and an item in a directory Finder is observing **is** displayed. The previous test approximated "displayed" as "individually asked about", which is narrower than what the header states.

Three things kept deliberately tight:

- **Only the last separator is cut**, so `sub/deep/a.txt` does not match an observed `sub`. Badging items that are not on screen is the opposite mistake.
- **Observed directories are stored absolute**, not relative. The callbacks can fire before the first state read lands, when there is no sync root to be relative to. Conversion happens at push time.
- **The new parameter is required**, not defaulted, so a future call site cannot silently get the old behaviour back.

The decision lives in `BadgeDiff.swift`, where `run-badge-diff-tests.sh` reaches it. DBSYNC-84 produced four defects and all four sat in the file the test script cannot compile.

## Evidence

Full suite green. The check that matters replays the reported sequence as one composition:

```
end to end: hydrating a .cloudsc with the folder open (DBSYNC-87)
  ok   the hydrated file is badged and the placeholder is cleared, in place
  ok   with the folder closed, only the placeholder is touched
```

The second one is the control: with the folder closed, the same snapshot pair reproduces the old broken behaviour exactly.

**Mutation check.** Removing the new clause from `pushable` turns five checks red:

```
FAIL a path never asked about IS pushable when its directory is on screen
FAIL the same path in a subfolder on screen is pushable too
FAIL removals in an observed directory are pushable
FAIL displayed and observed both admit, in one call
FAIL the hydrated file is badged and the placeholder is cleared, in place
BadgeDiff: 5 check(s) FAILED
```

A check that cannot fail is not evidence, so this is the part that counts.

**Build.** `npm run build:finder-sync` → BUILD SUCCEEDED, with 22 real Swift compile tasks (the previous run compiled nothing and still said SUCCEEDED). The four new symbols are linked, against a negative control that returns 0:

```
beginObservingDirectory  4     noSuchSymbolXYZ  0
endObservingDirectory    4
observedDirectories     12
parentDirectory          2
```

`override func` also does real work here: it makes the compiler verify both callbacks exist on `FIFinderSync`, so a mistyped selector could not have compiled.

**No Rust changed** — `git diff --name-only -- '*.rs'` returns nothing. `cargo test` was deliberately not run: it has no bearing on a Swift-only diff, and on this machine it overwrites the real `overlay_state.json` and points Finder Sync at a deleted tempdir (DBSYNC-75, still open). Say the word and I will run it anyway.

## What this does NOT prove

The checks prove the decision, not that Finder calls `beginObservingDirectory` for the sync folder. If it does not, the observed set stays empty and the bug is unchanged — a silent failure of exactly the shape this project has paid for before.

Manual validation is still required, and its AC is written to defeat the way this bug hides: **evidence captured without navigating away from the directory**.

#DBSYNC-87
