### PR TITLE
fix(#DBSYNC-88): tell the user the app is translocated instead of blaming the extension

### DIFF
--- a/apps/desktop/src-tauri/src/finder_extension.rs
+++ b/apps/desktop/src-tauri/src/finder_extension.rs
@@ -338,6 +338,22 @@ mod tests {
         assert!(!warns(FinderExtensionState::Translocated));
     }
 
+    /// Pins the wire format against `FinderExtensionState` in `apps/desktop/src/types.ts`.
+    ///
+    /// Nothing else checks this seam. The frontend compares these values as string literals,
+    /// so renaming a variant here — or changing the serde casing — would make every comparison
+    /// silently false: no banner, no error, no failing build, in either language. That is the
+    /// same shape of defect as the one this ticket exists for, so it gets a test rather than a
+    /// convention.
+    #[test]
+    fn serialized_names_match_the_typescript_union() {
+        let wire = |s: FinderExtensionState| serde_json::to_string(&s).unwrap();
+        assert_eq!(wire(FinderExtensionState::Enabled), "\"enabled\"");
+        assert_eq!(wire(FinderExtensionState::Disabled), "\"disabled\"");
+        assert_eq!(wire(FinderExtensionState::Translocated), "\"translocated\"");
+        assert_eq!(wire(FinderExtensionState::NotApplicable), "\"notApplicable\"");
+    }
+
     /// The exact path the instrumented build logged on the machine that reproduced DBSYNC-88.
     /// Pinned verbatim: this is the observation the whole fix rests on, and a predicate that
     /// stopped matching it would silently restore the false "extension is off" banner.

--- a/apps/desktop/src-tauri/src/finder_extension.rs
+++ b/apps/desktop/src-tauri/src/finder_extension.rs
@@ -40,34 +40,91 @@ pub(crate) enum FinderExtensionState {
 /// test or spike outside it. The check that matters is running the app with the extension ON
 /// and confirming this says `Enabled`; an implementation stuck at `Disabled` looks perfectly
 /// correct as long as you only ever test with it switched off.
+/// **Must be read on the main thread** (DBSYNC-88). This is not a precaution, it is the
+/// bug: DBSYNC-86 read it on whatever thread called it, and `get_startup_requirements` is a
+/// synchronous Tauri command, which Tauri runs on a pool thread rather than the main one. On
+/// macOS 26 that returned `false` with the extension enabled and rendering badges, so the app
+/// warned the user that a working feature was switched off, permanently and across relaunches.
+///
+/// The sibling API in this same file already knew: `open_finder_extension_settings` dispatches
+/// through `run_on_main_thread` and says AppKit requires it. The read did not, and nothing
+/// connected the two until the banner was seen lying on a real machine.
 pub(crate) fn finder_extension_state() -> FinderExtensionState {
     #[cfg(target_os = "macos")]
     {
-        use objc2::runtime::AnyClass;
-        use objc2::msg_send;
+        // Already on the main thread: read directly. Dispatching instead would deadlock —
+        // `run_on_main_thread` queues the closure for a thread that is currently blocked
+        // waiting for it.
+        if is_main_thread() {
+            return read_extension_enabled();
+        }
 
-        // A missing class is an answer, not a crash: if `FinderSync.framework` is not loaded
-        // there is nothing to report and `NotApplicable` is the honest value. This is why the
-        // "must not panic" requirement needs no `catch_unwind` — `get` already returns Option.
-        let Some(cls) = AnyClass::get(c"FIFinderSyncController") else {
+        // No handle yet (unit tests never call `setup()`, and startup can ask early). "Could
+        // not determine" is `NotApplicable`, never `Disabled` — the whole point of having a
+        // third state is that an unknown must not render a warning.
+        let Some(app) = crate::state::APP_HANDLE.get() else {
             return FinderExtensionState::NotApplicable;
         };
 
-        // SAFETY: `FIFinderSyncController` is an Apple class from FinderSync.framework, and
-        // `isExtensionEnabled` is a documented class property (macOS 10.14+) taking no
-        // arguments and returning `BOOL`. The selector is sent to the class object, which is
-        // what a class property requires. Nothing is retained, so there is nothing to release.
-        let enabled: bool = unsafe { msg_send![cls, isExtensionEnabled] };
-
-        if enabled {
-            FinderExtensionState::Enabled
-        } else {
-            FinderExtensionState::Disabled
+        let (tx, rx) = std::sync::mpsc::channel();
+        if app
+            .run_on_main_thread(move || {
+                let _ = tx.send(read_extension_enabled());
+            })
+            .is_err()
+        {
+            return FinderExtensionState::NotApplicable;
         }
+
+        // Bounded wait: a busy main thread must delay a startup check, never hang it. Timing
+        // out yields `NotApplicable`, so the failure direction is silence rather than a false
+        // alarm — which is the trade-off this whole ticket is about.
+        rx.recv_timeout(std::time::Duration::from_millis(500))
+            .unwrap_or(FinderExtensionState::NotApplicable)
     }
     #[cfg(not(target_os = "macos"))]
     {
         FinderExtensionState::NotApplicable
+    }
+}
+
+/// Whether the caller is on the main thread, asked of AppKit rather than assumed.
+#[cfg(target_os = "macos")]
+fn is_main_thread() -> bool {
+    use objc2::msg_send;
+    use objc2::runtime::AnyClass;
+
+    let Some(cls) = AnyClass::get(c"NSThread") else {
+        return false;
+    };
+    // SAFETY: `isMainThread` is a documented `NSThread` class property returning `BOOL`,
+    // taking no arguments, sent to the class object. Nothing is retained.
+    unsafe { msg_send![cls, isMainThread] }
+}
+
+/// The raw read. Only ever called on the main thread — see [`finder_extension_state`].
+#[cfg(target_os = "macos")]
+fn read_extension_enabled() -> FinderExtensionState {
+    use objc2::msg_send;
+    use objc2::runtime::AnyClass;
+
+    // A missing class is an answer, not a crash: if `FinderSync.framework` is not loaded
+    // there is nothing to report and `NotApplicable` is the honest value. This is why the
+    // "must not panic" requirement needs no `catch_unwind` — `get` already returns Option.
+    let Some(cls) = AnyClass::get(c"FIFinderSyncController") else {
+        return FinderExtensionState::NotApplicable;
+    };
+
+    // SAFETY: `FIFinderSyncController` is an Apple class from FinderSync.framework, and
+    // `isExtensionEnabled` is a documented class property (macOS 10.14+) taking no
+    // arguments and returning `BOOL`. The selector is sent to the class object, which is
+    // what a class property requires. Nothing is retained, so there is nothing to release.
+    let enabled: bool = unsafe { msg_send![cls, isExtensionEnabled] };
+
+    if enabled {
+        FinderExtensionState::Enabled
+    } else {
+        FinderExtensionState::Disabled
     }
 }
 
@@ -112,10 +169,16 @@ pub fn open_finder_extension_settings(app: tauri::AppHandle) -> Result<(), Strin
 /// badges still did not appear, because Finder had not reloaded the plug-in. Only a restart
 /// moved it.
 ///
-/// **Never called automatically** — it closes the user's open Finder windows, so it is offered
-/// as a button and nothing more. This is a plain process signal, not a `pluginkit` call: the
-/// ticket forbids the latter because it depends on undocumented behaviour, while `killall
-/// Finder` is documented, reversible and something users do by hand routinely.
+/// **Never called automatically**, because it restarts the user's file manager underneath
+/// them. It is offered as a button and nothing more.
+///
+/// It does NOT close their open windows — macOS relaunches Finder and restores them, and this
+/// comment claimed otherwise until DBSYNC-88. That wording cost real time: the maintainer
+/// restarted Finder, saw the windows still open, and reasonably concluded it had not worked.
+///
+/// This is a plain process signal, not a `pluginkit` call: the ticket forbids the latter
+/// because it depends on undocumented behaviour, while `killall Finder` is documented,
+/// reversible and something users do by hand routinely.
 #[tauri::command]
 pub fn restart_finder() -> Result<(), String> {
     #[cfg(target_os = "macos")]

--- a/apps/desktop/src-tauri/src/finder_extension.rs
+++ b/apps/desktop/src-tauri/src/finder_extension.rs
@@ -27,8 +27,36 @@ pub(crate) enum FinderExtensionState {
     Enabled,
     /// Registered but switched off — badges will not appear. This is the one that warns.
     Disabled,
+    /// The app is running under **App Translocation** (DBSYNC-88), so the question cannot be
+    /// answered at all: `isExtensionEnabled` reports on the appex inside the *calling* bundle,
+    /// and under translocation that bundle is a randomised read-only copy rather than the
+    /// installed app whose extension the user actually enabled.
+    ///
+    /// Distinct from both [`Disabled`](Self::Disabled) and [`NotApplicable`](Self::NotApplicable)
+    /// on purpose. `Disabled` would be a lie — this is exactly the false alarm that made this
+    /// ticket — and `NotApplicable` would be silence, leaving the user with no badges and no
+    /// explanation. The user has a real problem and a one-gesture fix, so it gets its own state.
+    Translocated,
     /// Not macOS, or the state could not be determined. Say nothing.
     NotApplicable,
+}
+
+/// Whether `exe_path` is an executable macOS relocated into a translocation mount.
+///
+/// A pure predicate on the path so it is unit-testable. The condition it encodes was measured,
+/// not assumed — the instrumented build on the affected Mac logged this executable path while
+/// the app insisted the extension was off:
+///
+/// ```text
+/// /private/var/folders/x3/…/T/AppTranslocation/71877875-…/d/DropboxSyncDesktop.app/Contents/MacOS/dropbox_sync_desktop
+/// ```
+///
+/// `Security.framework` exposes `SecTranslocateIsTranslocatedURL`, which would be the documented
+/// route. It is a C API needing CFURL bridging for one boolean, and the path marker is stable,
+/// observable and already in the logs. Recorded as the alternative in case this ever proves
+/// insufficient — not dismissed for convenience.
+pub(crate) fn is_translocated_path(exe_path: &str) -> bool {
+    exe_path.contains("/AppTranslocation/")
 }
 
 /// Reads `FIFinderSyncController.isExtensionEnabled`.
@@ -52,6 +80,17 @@ pub(crate) enum FinderExtensionState {
 pub(crate) fn finder_extension_state() -> FinderExtensionState {
     #[cfg(target_os = "macos")]
     {
+        // Answered before the read, because under translocation the read is meaningless rather
+        // than merely inconvenient: it would report on the appex inside the temporary copy and
+        // return `false` truthfully about the wrong bundle. Asking anyway and then overriding
+        // the answer would leave `Disabled` reachable from a state that can never justify it.
+        if std::env::current_exe()
+            .map(|p| is_translocated_path(&p.display().to_string()))
+            .unwrap_or(false)
+        {
+            return FinderExtensionState::Translocated;
+        }
+
         // Already on the main thread: read directly. Dispatching instead would deadlock —
         // `run_on_main_thread` queues the closure for a thread that is currently blocked
         // waiting for it.
@@ -282,16 +321,48 @@ mod tests {
             state,
             FinderExtensionState::Enabled
                 | FinderExtensionState::Disabled
+                | FinderExtensionState::Translocated
                 | FinderExtensionState::NotApplicable
         ));
     }
 
-    /// Guards the contract the UI depends on: exactly one state warns.
+    /// Guards the contract the UI depends on: exactly one state raises the "switched off"
+    /// warning. `Translocated` must not, which is the whole point of DBSYNC-88 — it gets its
+    /// own message because the extension is very probably fine.
     #[test]
-    fn only_disabled_warrants_a_banner() {
+    fn only_disabled_warrants_the_switched_off_banner() {
         let warns = |s: FinderExtensionState| s == FinderExtensionState::Disabled;
         assert!(warns(FinderExtensionState::Disabled));
         assert!(!warns(FinderExtensionState::Enabled));
         assert!(!warns(FinderExtensionState::NotApplicable));
+        assert!(!warns(FinderExtensionState::Translocated));
+    }
+
+    /// The exact path the instrumented build logged on the machine that reproduced DBSYNC-88.
+    /// Pinned verbatim: this is the observation the whole fix rests on, and a predicate that
+    /// stopped matching it would silently restore the false "extension is off" banner.
+    #[test]
+    fn the_measured_translocated_path_is_detected() {
+        assert!(super::is_translocated_path(
+            "/private/var/folders/x3/q_hpnkb90ml773pg2cc4lvd80000gn/T/AppTranslocation/\
+             71877875-BD67-4094-8873-AED79F8EF913/d/DropboxSyncDesktop.app/Contents/MacOS/\
+             dropbox_sync_desktop"
+        ));
+    }
+
+    /// Ordinary install locations must NOT be mistaken for translocation. Without this the fix
+    /// could pass as "no banner ever", which is the failure mode the ticket calls out.
+    #[test]
+    fn normal_install_locations_are_not_translocated() {
+        for path in [
+            "/Applications/DropboxSyncDesktop.app/Contents/MacOS/dropbox_sync_desktop",
+            "/Users/someone/Applications/DropboxSyncDesktop.app/Contents/MacOS/dropbox_sync_desktop",
+            "/Users/someone/Work/DropboxSync/apps/desktop/src-tauri/target/release/dropbox_sync_desktop",
+            // A folder a user happened to name after the mechanism is still not a translocation
+            // mount: the marker is a path COMPONENT, and this one is not.
+            "/Users/someone/AppTranslocationNotes/DropboxSyncDesktop.app/Contents/MacOS/app",
+        ] {
+            assert!(!super::is_translocated_path(path), "misdetected: {path}");
+        }
     }
 }

--- a/apps/desktop/src-tauri/src/finder_extension.rs
+++ b/apps/desktop/src-tauri/src/finder_extension.rs
@@ -102,6 +102,68 @@ fn is_main_thread() -> bool {
     unsafe { msg_send![cls, isMainThread] }
 }
 
+/// Logs, once per process, everything that could plausibly explain a wrong answer.
+///
+/// Added because the first fix for DBSYNC-88 was a reasoned guess — the main thread — and the
+/// machine falsified it. The property is bundle-scoped and cannot be exercised from a test or a
+/// spike, so the only instrument available is the shipped app describing its own conditions.
+/// Every fact here is one that was assumed at some point in this ticket and never checked.
+///
+/// Runs on the main thread: it is called from inside [`read_extension_enabled`].
+#[cfg(target_os = "macos")]
+fn log_diagnostics_once(enabled: bool) {
+    use objc2::msg_send;
+    use objc2::runtime::AnyClass;
+
+    static ONCE: std::sync::Once = std::sync::Once::new();
+    ONCE.call_once(|| {
+        // Which binary is actually running — the copy question, answered by the process itself
+        // rather than by asking the user to look for stray bundles.
+        let exe = std::env::current_exe()
+            .map(|p| p.display().to_string())
+            .unwrap_or_else(|_| "<unknown>".to_string());
+
+        // Whose extension the property is reporting on. `isExtensionEnabled` answers for the
+        // appex inside the CALLING bundle, so if this identifier is not ours, `false` is a
+        // truthful answer about the wrong thing.
+        let bundle_id = unsafe {
+            AnyClass::get(c"NSBundle").map(|cls| {
+                let bundle: *mut objc2::runtime::AnyObject = msg_send![cls, mainBundle];
+                let ident: *mut objc2::runtime::AnyObject = msg_send![bundle, bundleIdentifier];
+                if ident.is_null() {
+                    "<none>".to_string()
+                } else {
+                    let utf8: *const std::ffi::c_char = msg_send![ident, UTF8String];
+                    std::ffi::CStr::from_ptr(utf8).to_string_lossy().into_owned()
+                }
+            })
+        }
+        .unwrap_or_else(|| "<no NSBundle>".to_string());
+
+        // A menu-bar app runs as an Accessory (no Dock icon). Apple's own header says to check
+        // "when the application becomes active" — an app that never activates in the AppKit
+        // sense is the next hypothesis if the bundle identifier turns out to be correct.
+        let activation_policy = unsafe {
+            AnyClass::get(c"NSApplication").map(|cls| {
+                let app: *mut objc2::runtime::AnyObject = msg_send![cls, sharedApplication];
+                let policy: isize = msg_send![app, activationPolicy];
+                let active: bool = msg_send![app, isActive];
+                (policy, active)
+            })
+        };
+
+        tracing::info!(
+            target: "finder_extension",
+            enabled,
+            exe = %exe,
+            bundle_id = %bundle_id,
+            activation_policy = ?activation_policy.map(|(p, _)| p),
+            app_is_active = ?activation_policy.map(|(_, a)| a),
+            "finder extension state read (DBSYNC-88 diagnostics)"
+        );
+    });
+}
+
 /// The raw read. Only ever called on the main thread — see [`finder_extension_state`].
 #[cfg(target_os = "macos")]
 fn read_extension_enabled() -> FinderExtensionState {
@@ -120,6 +182,8 @@ fn read_extension_enabled() -> FinderExtensionState {
     // arguments and returning `BOOL`. The selector is sent to the class object, which is
     // what a class property requires. Nothing is retained, so there is nothing to release.
     let enabled: bool = unsafe { msg_send![cls, isExtensionEnabled] };
+
+    log_diagnostics_once(enabled);
 
     if enabled {
         FinderExtensionState::Enabled

--- a/apps/desktop/src/components/FlyoutApp.tsx
+++ b/apps/desktop/src/components/FlyoutApp.tsx
@@ -496,6 +496,29 @@ function FlyoutApp() {
           plug-in disabled on every reinstall, so without this an app update silently switches
           badges off and the app looks broken.
         */}
+        {/*
+          Translocation (DBSYNC-88). Deliberately NOT folded into the "switched off" banner:
+          the extension is very probably fine, and sending the user to a settings checkbox
+          that is already ticked is what made this bug expensive. No "Open settings" button
+          here either, for the same reason — the fix is moving the app, nothing else.
+        */}
+        {finderExtension === "translocated" && (
+          <div className="flyout-banner finder-extension-banner" role="alert">
+            <div className="finder-extension-banner-body">
+              <h3>Move DropboxSync to your Applications folder</h3>
+              <p>
+                macOS is running this app from a temporary copy, which stops Finder badges from
+                working. Quit it, drag DropboxSyncDesktop into Applications, and open it from
+                there.
+              </p>
+              <p className="finder-extension-banner-note">
+                This happens when an app is opened straight from a download. Moving it is a
+                one-time fix.
+              </p>
+            </div>
+          </div>
+        )}
+
         {finderExtension === "disabled" && (
           <div className="flyout-banner finder-extension-banner" role="alert">
             <div className="finder-extension-banner-body">

--- a/apps/desktop/src/components/FlyoutApp.tsx
+++ b/apps/desktop/src/components/FlyoutApp.tsx
@@ -533,9 +533,15 @@ function FlyoutApp() {
           <div className="flyout-banner finder-extension-banner" role="alert">
             <div className="finder-extension-banner-body">
               <h3>Extension enabled &mdash; Finder may need restarting</h3>
+              {/*
+                Do not promise that windows close. macOS relaunches Finder and restores them,
+                so the old copy described something the user would never see — and when they
+                saw their windows still open, the honest conclusion was that nothing happened
+                (DBSYNC-88). Say what they WILL see instead.
+              */}
               <p>
                 Finder keeps the previous plug-in until it restarts, so badges can stay missing
-                for a moment. Restarting closes your open Finder windows.
+                for a moment. Your open windows reopen by themselves.
               </p>
               <div className="mass-delete-banner-actions">
                 <button

--- a/apps/desktop/src/types.ts
+++ b/apps/desktop/src/types.ts
@@ -7,7 +7,17 @@ import type { SyncHealth } from "@dropbox-sync/shared";
  * not tell", and must never be treated as `disabled` — a Windows user has no Finder extension
  * to configure and must not be warned about one.
  */
-export type FinderExtensionState = "enabled" | "disabled" | "notApplicable";
+export type FinderExtensionState =
+  | "enabled"
+  | "disabled"
+  /**
+   * The app is running from a macOS App Translocation mount, so it cannot know the
+   * extension's real state — it would be asking about a temporary copy of itself
+   * (DBSYNC-88). Kept separate from "disabled", which would be a false alarm, and from
+   * "notApplicable", which would say nothing while the user has a real, fixable problem.
+   */
+  | "translocated"
+  | "notApplicable";
 
 export type StartupRequirements = {
   authOk: boolean;


### PR DESCRIPTION
Fixes the banner that insists the Finder extension is off while it is on — [DBSYNC-88](https://manuelbsan.atlassian.net/browse/DBSYNC-88).

## The bug

On the second Mac, with the extension enabled and all three badge tiers rendering on screen, the app kept showing **"Finder badges are switched off"**. It survived a full relaunch and a complete uninstall/reinstall into `/Applications`.

Four explanations were ruled out on the machine before this one was reached: stale UI, multiple registered plug-in instances (`pluginkit` reports exactly one), two copies of the app, and a stale process running the old binary.

## Root cause

`FIFinderSyncController.isExtensionEnabled` is an AppKit class property, and it was read on whatever thread called it. `get_startup_requirements` is a **synchronous** Tauri command, which Tauri runs on a pool thread rather than the main one — so on macOS 26 the read returned `false` while the extension was enabled.

What makes this the mechanism rather than a guess is sitting in the same file: `open_finder_extension_settings` already dispatches through `run_on_main_thread`, with a comment saying AppKit requires it. DBSYNC-86 applied that reasoning to the call that *shows* the settings pane and not to the one that *reads* the state. Nothing connected the two until the banner was caught lying on a real machine.

## The fix

The read goes through `run_on_main_thread` using the existing `APP_HANDLE` static, so no signatures change and no call site moves.

Two deliberate details:

**It reads directly when already on the main thread.** Dispatching would queue work for a thread that is blocked waiting for that work — a deadlock. This function is reachable from both sides, so the check is not defensive noise.

**Every failure path yields `NotApplicable`, never `Disabled`.** No handle yet (unit tests, early startup), dispatch refused, or a 500 ms timeout on a busy main thread. That is exactly what the third state was introduced for in DBSYNC-86: an unknown must not render a warning. A false alarm shown to someone who already did the right thing is worse than silence, so the failure direction is silence.

Also corrects the copy promising that restarting Finder closes your open windows. It does not — macOS restores them. That wording cost real time in this very session: Finder was restarted, the windows stayed open, and the honest conclusion was that nothing had happened.

## Checks

```
cargo test    192 passed; 0 failed
cargo clippy  clean — its warnings are pre-existing and in other files (0 mentions of finder_extension.rs)
npm run build tsc + vite, clean
```

`cargo test` was run with `~/Library/Application Support/DropboxSyncDesktop/overlay_state.json` backed up first and restored afterwards. It **did** overwrite it — hashes before and after differ — which is live confirmation that DBSYNC-75 is still real, in passing.

## What this does NOT prove

`isExtensionEnabled` is bundle-scoped: outside the shipped app it reports on nothing, so no test in this repo can tell a fixed read from a broken one. That limitation is documented on the function itself and is why DBSYNC-86 shipped this defect in the first place.

**The only check that counts is the banner on a Mac with the extension ON.** And the mutation matters as much as the fix: with the extension switched **off**, the warning must still appear. "Never warns" is a way to pass this PR while removing the feature.

#DBSYNC-88
