### PR TITLE
fix(#DBSYNC-75): write overlay_state.json beside the database, not into the user's real data dir

### DIFF
--- a/apps/desktop/src-tauri/src/overlay_state.rs
+++ b/apps/desktop/src-tauri/src/overlay_state.rs
@@ -31,7 +31,7 @@ pub enum OverlayTier {
 /// Versioned shell **status contract** (DBSYNC-51): the single source of per-path
 /// sync state read by every native surface — macOS Finder Sync badges, Linux
 /// file-manager emblems, and the Windows status column. Written atomically to
-/// `overlay_state.json` under [`db::app_data_dir`].
+/// `overlay_state.json` beside the database that produced it (DBSYNC-75).
 ///
 /// Schema (`version = 1`):
 /// - `version`: contract version; bump on a breaking change.
@@ -72,9 +72,11 @@ pub(crate) fn refresh_overlay_state_internal(state: &AppState) {
 /// Per-path tiers for the current state — the whole decision, with no I/O of its own
 /// beyond reading the database and the sync folder.
 ///
-/// Split out of [`refresh_overlay_state_inner`] so it can be tested directly: that
-/// function writes to the real [`db::app_data_dir`], and a test calling it would clobber
-/// the running user's `overlay_state.json` (DBSYNC-75).
+/// Split out of [`refresh_overlay_state_inner`] so it can be tested directly. That was
+/// originally a workaround: the writer resolved its destination globally, so any test
+/// calling it clobbered the running user's `overlay_state.json`. Fixed in DBSYNC-75 — the
+/// writer now follows the database — so the split is no longer load-bearing, but it is
+/// kept: a pure decision function is worth having on its own terms.
 fn compute_overlay_paths(state: &AppState) -> AppResult<HashMap<String, OverlayTier>> {
     let job_paths = active_job_paths(&state.db)?;
     let conflict_paths = unresolved_conflict_paths(&state.db)?;
@@ -140,8 +142,12 @@ fn refresh_overlay_state_inner(state: &AppState) -> AppResult<()> {
         paths,
     };
 
-    let dir = db::app_data_dir()?;
-    let dest = overlay_state_path(&dir);
+    // Beside the database, NOT via the global `app_data_dir()` (DBSYNC-75). In production
+    // these are the same directory. Under `cargo test` they are not: the harness builds its
+    // `AppState` on a `tempdir()`, and resolving globally here overwrote the running user's
+    // real `overlay_state.json` with a sync folder the test then deleted — leaving the
+    // Finder Sync extension pointed at nothing and every badge gone until it was repaired.
+    let dest = overlay_state_path(state.db.data_dir());
     let json = serde_json::to_string_pretty(&payload)?;
 
     let tmp = dest.with_extension("json.tmp");
@@ -330,6 +336,44 @@ mod tests {
         let paths = compute_overlay_paths(&state).expect("compute");
 
         assert_eq!(paths.get("Anteproyecto.docx"), Some(&OverlayTier::Synced));
+    }
+
+    /// The guard for DBSYNC-75, and the only test here that exercises the **writer**.
+    ///
+    /// Before the fix this function resolved its destination with `db::app_data_dir()`, so
+    /// running it under `cargo test` overwrote the running user's real `overlay_state.json`
+    /// with a sync folder pointing at a tempdir the test then deleted. The Finder Sync
+    /// extension reads that file every two seconds, so the user's badges silently stopped
+    /// rendering — and the next person to validate badges by hand would have been debugging
+    /// the wrong thing entirely.
+    ///
+    /// Asserting the destination lands under the tempdir is what makes the regression
+    /// impossible to reintroduce quietly: resolving globally again puts the file somewhere
+    /// else, and this fails. It deliberately does NOT call `db::app_data_dir()` to compare
+    /// against — that function creates the directory, and a test for "never touch the real
+    /// data dir" must not touch the real data dir.
+    #[test]
+    fn the_writer_follows_the_database_and_never_the_global_data_dir() {
+        let tmp = tempfile::tempdir().unwrap();
+        let sync = tmp.path().join("sync");
+        let state = build_state(&sync);
+
+        refresh_overlay_state_inner(&state).expect("refresh");
+
+        let dest = overlay_state_path(state.db.data_dir());
+        assert!(
+            dest.is_file(),
+            "no overlay file beside the database at {}",
+            dest.display()
+        );
+
+        // The database lives in its own tempdir (see `build_state`), which is not this
+        // test's `tmp` — so the check is "somewhere temporary", not "under this handle".
+        let written = std::fs::read_to_string(&dest).expect("read written overlay");
+        assert!(
+            written.contains(&sync.to_string_lossy().replace('\\', "\\\\")),
+            "the written file should describe this test's sync folder, got: {written}"
+        );
     }
 
     /// No sync folder configured must be an empty map, not an error: the overlay refresh

--- a/apps/desktop/src-tauri/src/storage/db.rs
+++ b/apps/desktop/src-tauri/src/storage/db.rs
@@ -59,6 +59,19 @@ pub struct ConflictRow {
 pub struct Db {
     write: Mutex<Connection>,
     read: Mutex<Connection>,
+    /// The directory this database lives in, and therefore the directory every other
+    /// per-instance artefact belongs in (DBSYNC-75).
+    ///
+    /// Recorded so that writers of sibling files do not have to reach for the global
+    /// [`app_data_dir`]. `overlay_state.json` did exactly that, which meant `cargo test` —
+    /// whose `AppState` is built against a `tempdir()` — overwrote the **running user's**
+    /// real overlay file with a sync folder that the test then deleted. The Finder Sync
+    /// extension reads that file every two seconds, so the user's badges stopped rendering
+    /// until it was repaired by hand.
+    ///
+    /// `new_at`'s own doc already promised that "running `cargo test` never touches a
+    /// user's real DB". This extends the same promise to everything written beside it.
+    data_dir: PathBuf,
 }
 
 impl Db {
@@ -88,7 +101,16 @@ impl Db {
         Ok(Self {
             write: Mutex::new(write),
             read: Mutex::new(read),
+            // A database path always has a parent in practice; `.` keeps the type total
+            // without inventing a location, and is only reachable for a bare filename.
+            data_dir: path.parent().unwrap_or_else(|| std::path::Path::new(".")).to_path_buf(),
         })
+    }
+
+    /// The directory this database lives in. See the field's documentation for why sibling
+    /// files must be resolved from here rather than from [`app_data_dir`] (DBSYNC-75).
+    pub(crate) fn data_dir(&self) -> &std::path::Path {
+        &self.data_dir
     }
 
     pub fn set_sync_folder(&self, folder: &str) -> AppResult<()> {

--- a/apps/desktop/src-tauri/src/storage/db.rs
+++ b/apps/desktop/src-tauri/src/storage/db.rs
@@ -101,9 +101,17 @@ impl Db {
         Ok(Self {
             write: Mutex::new(write),
             read: Mutex::new(read),
-            // A database path always has a parent in practice; `.` keeps the type total
-            // without inventing a location, and is only reachable for a bare filename.
-            data_dir: path.parent().unwrap_or_else(|| std::path::Path::new(".")).to_path_buf(),
+            // `parent()` is not the same as "the directory it is in": for a bare filename
+            // it returns `Some("")`, not `None` (measured, not assumed). An empty data dir
+            // would silently place sibling files in the process's working directory, so the
+            // empty case is folded in with the `None` case and both become `.` — the same
+            // directory, said out loud. Neither is reachable from the two call sites, which
+            // pass absolute paths; this exists so that a future third one cannot be subtly
+            // wrong.
+            data_dir: match path.parent() {
+                Some(parent) if !parent.as_os_str().is_empty() => parent.to_path_buf(),
+                _ => PathBuf::from("."),
+            },
         })
     }
 
@@ -1295,6 +1303,26 @@ pub fn app_data_dir() -> AppResult<PathBuf> {
     let path = resolve_app_data_dir()?;
     std::fs::create_dir_all(&path)?;
     Ok(path)
+}
+
+#[cfg(test)]
+mod data_dir_tests {
+    use super::Db;
+
+    /// `data_dir` must never be the empty path (DBSYNC-75). `Path::parent()` returns
+    /// `Some("")` for a bare filename rather than `None` — verified, because the first
+    /// version of this code assumed `None` and its fallback was therefore dead. An empty
+    /// data dir would put `overlay_state.json` in the process's working directory, which is
+    /// a quieter version of the very bug this ticket fixes.
+    #[test]
+    fn a_bare_filename_still_yields_a_usable_data_dir() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        // Opened through a relative name, with the cwd irrelevant to the assertion: what
+        // matters is that the recorded directory is usable, never "".
+        let db = Db::new_at(&tmp.path().join("app.db")).expect("db");
+        assert!(!db.data_dir().as_os_str().is_empty());
+        assert_eq!(db.data_dir(), tmp.path());
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Stops `cargo test` from overwriting the running user's real `overlay_state.json` — [DBSYNC-75](https://manuelbsan.atlassian.net/browse/DBSYNC-75), open since 2026-08-19.

## The problem

`refresh_overlay_state_inner` resolved its destination with the global `db::app_data_dir()`. The test harness redirects only the **database** to a `tempdir()`, so every test that reached the writer wrote to `~/Library/Application Support/DropboxSyncDesktop/overlay_state.json` — with a `sync_folder` pointing at a temporary directory the test then deleted.

The Finder Sync extension reads that file every two seconds and feeds `sync_folder` into `directoryURLs`. So after any `cargo test` run, the user's badges silently stopped rendering.

**The mess is not the point; the trap is.** Anyone validating badges by hand after running the tests sees no badges and starts debugging the extension — the one place the fault is not. It cost real time this week, and during one session the file had to be backed up and restored by hand six times just to keep working.

## The fix

`Db` records the directory it was opened in, and the overlay writer follows it instead of reaching for a global.

In production nothing moves: the database and the overlay file already live in the same directory. Under test the overlay lands in the same tempdir as the database, which is what the harness intended all along.

`Db::new_at`'s own doc already promised that *"running `cargo test` never touches a user's real DB"*. This extends the same promise to everything written beside it, and puts the guarantee somewhere a future sibling writer will trip over rather than in a convention nobody reads.

Chosen over threading a `data_dir` through `AppState`: that would have meant editing all 13 construction sites, 12 of them test helpers, for the same result. Following the database also says something true — these files belong together — rather than merely passing a value around.

## Evidence

The ticket's acceptance criterion is "a full `cargo test` run must not create or modify anything under the real app data dir". Measured directly, on the real file:

```
hash BEFORE:  11762ac30f7f1a9c3d31b14aff1e3f1a9ea4f3955d11d422da81b2a95e3453b2
cargo test →  196 passed; 0 failed
hash AFTER:   11762ac30f7f1a9c3d31b14aff1e3f1a9ea4f3955d11d422da81b2a95e3453b2
```

Byte-identical.

**Mutation check.** Reverting the writer to `db::app_data_dir()` and running the new guard:

```
test overlay_state::tests::the_writer_follows_the_database_and_never_the_global_data_dir ... FAILED
```

and the real file's hash changed to `14110c16…` — the damage is observable, not theoretical. Restored afterwards; the tree is clean.

The guard deliberately does **not** call `db::app_data_dir()` to compare against: that function creates the directory, and a test for "never touch the real data dir" must not touch the real data dir.

## Notes

`clippy` clean, and it says nothing about either changed file. Two stale doc comments corrected in passing — one described the writer as global, and one justified a function split as a workaround for this very bug. The split is kept on its own merits, with the reason rewritten.

#DBSYNC-75
