### PR TITLE
ci(#DBSYNC-38): compile and test the Windows code, for the first time ever

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,17 @@ on:
     branches: [main, master]
   pull_request:
 
+# Read-only by default: nothing in this workflow writes to the repo, and a token that
+# cannot write is one that cannot be abused by a compromised action.
+permissions:
+  contents: read
+
+# One run per ref. Pushing twice to a PR should not leave the first run burning a Windows
+# runner nobody will read.
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
 # Literals, not secrets. The app reads these through `option_env!` with fallbacks
 # (auth/oauth.rs), so CI only needs them to be present, never to be real. Hoisted to the
 # workflow level in DBSYNC-38 so every job inherits them and none can be forgotten.
@@ -19,17 +30,28 @@ env:
 # old job's steps cannot run on Windows — the Finder Sync checks shell out to `xcrun
 # swiftc`, and `bundle:dev` produces a macOS `.app`. Adding `strategy.matrix.os` to the
 # monolith would have broken all three. Slices #121 and #122 add Windows on top of this
-# shape; this change deliberately adds no platform of its own, so that a later red build
-# on Windows is attributable to Windows rather than to the restructuring.
+# shape. Splitting first is what made a later red build on Windows attributable to
+# Windows rather than to the restructuring.
 #
-# Everything runs on macOS for now. The frontend job is platform-independent and would be
-# roughly ten times cheaper on `ubuntu-latest`, but moving it is an optimisation with its
-# own risk (npm's platform-specific optional packages) and does not belong in a change
-# whose whole point is to be provably green first.
+# `rust` now runs on both platforms (#121). `macos-app` and `frontend` stay on macOS:
+# the first is macOS-only by construction, the second is platform-independent and would
+# be cheaper on `ubuntu-latest` — an optimisation with its own risk (npm's
+# platform-specific optional packages), worth doing on its own and not here.
 jobs:
-  # Portable Rust. Becomes a macOS + Windows matrix in #121 — the reason this ticket exists.
+  # Portable Rust, on every platform that ships.
   rust:
-    runs-on: macos-latest
+    # THE POINT OF DBSYNC-38 (GitHub #121). Until this leg existed, everything behind
+    # `#[cfg(windows)]` — five modules, ~4000 lines, `cloud_filter.rs` alone at 2024 —
+    # had never been compiled by any pipeline, and the ~22 unit tests inside them had
+    # only ever run on the maintainer's own machine. A PR could delete a function
+    # `cloud_filter.rs` calls and CI would report green.
+    strategy:
+      # NOT the default. With fail-fast on, a macOS failure cancels the Windows job —
+      # cancelling precisely the signal this leg exists to buy. Load-bearing, not taste.
+      fail-fast: false
+      matrix:
+        os: [macos-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
       - name: Install Rust
@@ -39,10 +61,24 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           # Distinct per job, or `rust` and `macos-app` evict each other and the cache
-          # buys nothing. The runner OS is part of the key by default, which is what keeps
-          # the Windows leg from thrashing against this one later.
+          # buys nothing. rust-cache appends the runner OS and arch to the key, so the
+          # two matrix legs get separate caches without any help from us.
           prefix-key: rust-checks
           workspaces: apps/desktop/src-tauri
+          # Only the default branch writes. A 10 GB budget shared by every open PR would
+          # evict main's cache — the one every new PR starts from — to store caches that
+          # no other branch can even read.
+          save-if: ${{ github.ref == 'refs/heads/main' }}
+          # Keep the cache from a red run. This leg is expected to go red while the
+          # Windows code is compiled for the first time, and discarding the cache on
+          # each failure would make every retry a cold build of the `windows` 0.61
+          # family plus `rusqlite` compiling SQLite from C.
+          cache-on-failure: true
+          # `option_env!` does not force a rebuild when this changes, so without it in the
+          # key a cached artifact can embed a stale value and nothing reports it. Harmless
+          # at `dummy`; a green-but-wrong binary the day the release workflow wires a real
+          # key.
+          env-vars: CARGO CC CFLAGS CXX CMAKE RUST DROPBOX_APP_KEY
 
       # No `npm install` here, and the reason is narrower than "the Rust tests don't need
       # the frontend" — it is conditional, so read this before changing the command.
@@ -82,9 +118,15 @@ jobs:
         with:
           prefix-key: macos-app
           workspaces: apps/desktop/src-tauri
+          save-if: ${{ github.ref == 'refs/heads/main' }}
+          cache-on-failure: true
+          env-vars: CARGO CC CFLAGS CXX CMAKE RUST DROPBOX_APP_KEY
 
       - name: Install dependencies
-        run: npm install
+        # `ci`, not `install`: it fails when package-lock.json disagrees with package.json
+        # instead of quietly resolving something new. A check that cannot fail is not a
+        # check, and on a runner the lockfile is the whole point.
+        run: npm ci
 
       - name: Finder Sync extension checks
         # Compiles the real BadgeDiff.swift with `swiftc` and runs its checks. macOS-only
@@ -113,7 +155,10 @@ jobs:
           cache: 'npm'
 
       - name: Install dependencies
-        run: npm install
+        # `ci`, not `install`: it fails when package-lock.json disagrees with package.json
+        # instead of quietly resolving something new. A check that cannot fail is not a
+        # check, and on a runner the lockfile is the whole point.
+        run: npm ci
 
       - name: Frontend build and typecheck
         # `npm run build` is `tsc && vite build`, so this is the typecheck too.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,11 +10,16 @@ on:
 permissions:
   contents: read
 
-# One run per ref. Pushing twice to a PR should not leave the first run burning a Windows
-# runner nobody will read.
+# One run per ref, but cancellation ONLY on pull requests. Pushing twice to a PR should
+# not leave the first run burning a Windows runner nobody will read.
+#
+# On a push to main, cancelling would discard the only automated verification a merged
+# commit ever gets: two merges inside six minutes and the first commit is never tested on
+# any platform, silently. With a manual QA strategy this pipeline is the sole automated
+# gate, so a merged commit must always finish its run.
 concurrency:
   group: ci-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 # Literals, not secrets. The app reads these through `option_env!` with fallbacks
 # (auth/oauth.rs), so CI only needs them to be present, never to be real. Hoisted to the
@@ -52,6 +57,10 @@ jobs:
       matrix:
         os: [macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
+    # A hang, not an assertion, is the characteristic failure of Win32 I/O-callback code
+    # under test — and the default here is 360 minutes on a runner billed at 2x. Twenty is
+    # generous against a 6m25s cold Windows run.
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v4
       - name: Install Rust
@@ -69,16 +78,22 @@ jobs:
           # evict main's cache — the one every new PR starts from — to store caches that
           # no other branch can even read.
           save-if: ${{ github.ref == 'refs/heads/main' }}
-          # Keep the cache from a red run. This leg is expected to go red while the
-          # Windows code is compiled for the first time, and discarding the cache on
-          # each failure would make every retry a cold build of the `windows` 0.61
-          # family plus `rusqlite` compiling SQLite from C.
+          # Two things, and NOT the one the first draft of this comment claimed. It does
+          # not rescue red PR runs: `save-if` gates the save body outright, so on a PR
+          # branch nothing is written whatever this says. What it does do is let main keep
+          # a cache from a failed run, and — because it drives the action's `post-if` — let
+          # the save step run at all when a job is cancelled.
           cache-on-failure: true
-          # `option_env!` does not force a rebuild when this changes, so without it in the
-          # key a cached artifact can embed a stale value and nothing reports it. Harmless
-          # at `dummy`; a green-but-wrong binary the day the release workflow wires a real
-          # key.
-          env-vars: CARGO CC CFLAGS CXX CMAKE RUST DROPBOX_APP_KEY
+          # Both values `auth/oauth.rs` reads through `option_env!` — DROPBOX_APP_KEY and
+          # DROPBOX_REDIRECT_URI. `option_env!` does not force a rebuild when they change,
+          # so without them in the key a cached artifact can embed a stale value and
+          # nothing reports it. Harmless at `dummy`; a green-but-wrong binary the day the
+          # release workflow wires a real key.
+          #
+          # The prefix is enough: rust-cache matches with `startsWith`, and this list is
+          # ADDED to its built-ins (CARGO CC CFLAGS CXX CMAKE RUST) rather than replacing
+          # them.
+          env-vars: DROPBOX
 
       # No `npm install` here, and the reason is narrower than "the Rust tests don't need
       # the frontend" — it is conditional, so read this before changing the command.
@@ -106,6 +121,7 @@ jobs:
   # macOS-only artefacts: the Swift appex and the `.app` bundle.
   macos-app:
     runs-on: macos-latest
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -120,7 +136,7 @@ jobs:
           workspaces: apps/desktop/src-tauri
           save-if: ${{ github.ref == 'refs/heads/main' }}
           cache-on-failure: true
-          env-vars: CARGO CC CFLAGS CXX CMAKE RUST DROPBOX_APP_KEY
+          env-vars: DROPBOX
 
       - name: Install dependencies
         # `ci`, not `install`: it fails when package-lock.json disagrees with package.json
@@ -147,6 +163,7 @@ jobs:
   # TypeScript typecheck + production bundle. Portable, so it runs exactly once.
   frontend:
     runs-on: macos-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4


### PR DESCRIPTION
Slice 2 of 3 for [DBSYNC-38](https://manuelbsan.atlassian.net/browse/DBSYNC-38) — GitHub #121. Blocked by #120, which is merged.

**This is the slice the ticket exists for.**

## What has never been checked until now

Five modules sit behind `#[cfg(windows)]`:

```
cloud_filter          2024 lines / 92 KB
windows_file_assoc
windows_identity
windows_shell_menu
windows_startup
```

plus a Windows-only dependency block (`winreg`, `windows-sys`, `windows` 0.61 with `Win32_Storage_CloudFilters`, `Storage_Provider`, `Win32_System_IO`).

Roughly 4000 lines that **no pipeline has ever compiled**, containing ~22 unit tests that have only ever run on one machine. `cargo clippy --all-targets` has never linted a line of the CfAPI layer.

Concretely: until this merges, a PR can delete a function `cloud_filter.rs` calls and CI reports green — on the largest single module in the codebase.

## The change

`rust` becomes a matrix over `macos-latest` and `windows-latest`, with **`fail-fast: false`**.

That flag is load-bearing, not taste. On the default, a macOS failure cancels the Windows job — hiding the result being bought at exactly the moment something is already known to be wrong.

## Review findings from #120, folded in here

#120 deferred these deliberately: changing a cache in the same PR that introduces it makes later behaviour unattributable. This is where they get exercised.

- **`save-if` restricted to `main`.** A 10 GB budget shared by every open PR evicts main's cache — the one every new PR starts from — to store caches no other branch can read.
- **`cache-on-failure: true`.** This leg is *expected* to go red while the Windows code compiles for the first time. Discarding the cache on each failure would make every retry a cold build of the `windows` 0.61 family plus `rusqlite` compiling SQLite from C. This is the warning most likely to bite this very slice.
- **`DROPBOX_APP_KEY` in the cache key.** `option_env!` does not force a rebuild when it changes, so a cached artifact can embed a stale value with nothing reporting it. Nil impact at `dummy`; a green-but-wrong binary the day the release workflow wires a real key.
- **`npm ci` replaces `npm install`** — it fails when the lockfile disagrees with `package.json` instead of quietly resolving something new. Verified against the current lockfile with `npm ci --dry-run` before committing, so this does not ship a red pipeline for a self-inflicted reason.

Plus `permissions: contents: read` and a `concurrency` group: nothing here writes to the repo, and a superseded push should not keep burning a Windows runner nobody will read.

## Stack

`desktop-tauri`

## Test Plan

- [ ] Both matrix legs green — or, if Windows is red, **that is a finding, not a setback** (see below)
- [ ] **Windows test count quoted below and higher than the macOS count.** That difference is the proof the `cfg(windows)` tests actually ran, rather than the job merely passing
- [ ] Clippy runs on both legs, still without `-D warnings`
- [ ] **Mutation check**: on a throwaway branch, break something in `cloud_filter.rs`, confirm the Windows leg goes red while macOS stays green, quote it here, delete the branch. A job nobody has watched fail is not yet known to work
- [ ] Total wall-clock recorded, warm and cold

## If the Windows leg is red

**Do not fix it in this PR.** File the failure as its own bug and let this land the job. Folding "fix what the check found" into "add the check" makes both unreviewable, and the plan on the Jira ticket calls this out in advance. Binding drift, a stale call, or tests assuming `/` path separators are all plausible after ~4000 lines went uncompiled this long.

## Evidence

Test counts, timings and the mutation check to be added here once the run completes.

#DBSYNC-38
