### PR TITLE
DO NOT MERGE — mutation check for #121

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,17 @@ on:
     branches: [main, master]
   pull_request:
 
+# Read-only by default: nothing in this workflow writes to the repo, and a token that
+# cannot write is one that cannot be abused by a compromised action.
+permissions:
+  contents: read
+
+# One run per ref. Pushing twice to a PR should not leave the first run burning a Windows
+# runner nobody will read.
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
 # Literals, not secrets. The app reads these through `option_env!` with fallbacks
 # (auth/oauth.rs), so CI only needs them to be present, never to be real. Hoisted to the
 # workflow level in DBSYNC-38 so every job inherits them and none can be forgotten.
@@ -19,17 +30,28 @@ env:
 # old job's steps cannot run on Windows — the Finder Sync checks shell out to `xcrun
 # swiftc`, and `bundle:dev` produces a macOS `.app`. Adding `strategy.matrix.os` to the
 # monolith would have broken all three. Slices #121 and #122 add Windows on top of this
-# shape; this change deliberately adds no platform of its own, so that a later red build
-# on Windows is attributable to Windows rather than to the restructuring.
+# shape. Splitting first is what made a later red build on Windows attributable to
+# Windows rather than to the restructuring.
 #
-# Everything runs on macOS for now. The frontend job is platform-independent and would be
-# roughly ten times cheaper on `ubuntu-latest`, but moving it is an optimisation with its
-# own risk (npm's platform-specific optional packages) and does not belong in a change
-# whose whole point is to be provably green first.
+# `rust` now runs on both platforms (#121). `macos-app` and `frontend` stay on macOS:
+# the first is macOS-only by construction, the second is platform-independent and would
+# be cheaper on `ubuntu-latest` — an optimisation with its own risk (npm's
+# platform-specific optional packages), worth doing on its own and not here.
 jobs:
-  # Portable Rust. Becomes a macOS + Windows matrix in #121 — the reason this ticket exists.
+  # Portable Rust, on every platform that ships.
   rust:
-    runs-on: macos-latest
+    # THE POINT OF DBSYNC-38 (GitHub #121). Until this leg existed, everything behind
+    # `#[cfg(windows)]` — five modules, ~4000 lines, `cloud_filter.rs` alone at 2024 —
+    # had never been compiled by any pipeline, and the ~22 unit tests inside them had
+    # only ever run on the maintainer's own machine. A PR could delete a function
+    # `cloud_filter.rs` calls and CI would report green.
+    strategy:
+      # NOT the default. With fail-fast on, a macOS failure cancels the Windows job —
+      # cancelling precisely the signal this leg exists to buy. Load-bearing, not taste.
+      fail-fast: false
+      matrix:
+        os: [macos-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
       - name: Install Rust
@@ -39,10 +61,24 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           # Distinct per job, or `rust` and `macos-app` evict each other and the cache
-          # buys nothing. The runner OS is part of the key by default, which is what keeps
-          # the Windows leg from thrashing against this one later.
+          # buys nothing. rust-cache appends the runner OS and arch to the key, so the
+          # two matrix legs get separate caches without any help from us.
           prefix-key: rust-checks
           workspaces: apps/desktop/src-tauri
+          # Only the default branch writes. A 10 GB budget shared by every open PR would
+          # evict main's cache — the one every new PR starts from — to store caches that
+          # no other branch can even read.
+          save-if: ${{ github.ref == 'refs/heads/main' }}
+          # Keep the cache from a red run. This leg is expected to go red while the
+          # Windows code is compiled for the first time, and discarding the cache on
+          # each failure would make every retry a cold build of the `windows` 0.61
+          # family plus `rusqlite` compiling SQLite from C.
+          cache-on-failure: true
+          # `option_env!` does not force a rebuild when this changes, so without it in the
+          # key a cached artifact can embed a stale value and nothing reports it. Harmless
+          # at `dummy`; a green-but-wrong binary the day the release workflow wires a real
+          # key.
+          env-vars: CARGO CC CFLAGS CXX CMAKE RUST DROPBOX_APP_KEY
 
       # No `npm install` here, and the reason is narrower than "the Rust tests don't need
       # the frontend" — it is conditional, so read this before changing the command.
@@ -82,9 +118,15 @@ jobs:
         with:
           prefix-key: macos-app
           workspaces: apps/desktop/src-tauri
+          save-if: ${{ github.ref == 'refs/heads/main' }}
+          cache-on-failure: true
+          env-vars: CARGO CC CFLAGS CXX CMAKE RUST DROPBOX_APP_KEY
 
       - name: Install dependencies
-        run: npm install
+        # `ci`, not `install`: it fails when package-lock.json disagrees with package.json
+        # instead of quietly resolving something new. A check that cannot fail is not a
+        # check, and on a runner the lockfile is the whole point.
+        run: npm ci
 
       - name: Finder Sync extension checks
         # Compiles the real BadgeDiff.swift with `swiftc` and runs its checks. macOS-only
@@ -113,7 +155,10 @@ jobs:
           cache: 'npm'
 
       - name: Install dependencies
-        run: npm install
+        # `ci`, not `install`: it fails when package-lock.json disagrees with package.json
+        # instead of quietly resolving something new. A check that cannot fail is not a
+        # check, and on a runner the lockfile is the whole point.
+        run: npm ci
 
       - name: Frontend build and typecheck
         # `npm run build` is `tsc && vite build`, so this is the typecheck too.

--- a/apps/desktop/src-tauri/src/cloud_filter.rs
+++ b/apps/desktop/src-tauri/src/cloud_filter.rs
@@ -110,6 +110,8 @@ fn mark_registration_activity() {
 /// shell may still be evicting placeholders, so a locally-vanished tracked file must
 /// NOT be propagated as a Dropbox delete. Checked by the sync pipeline's delete paths.
 pub(crate) fn in_post_registration_grace() -> bool {
+    let _mutation_check: u32 = "DBSYNC-38: deliberate break, must turn the Windows leg red";
+
     LAST_REGISTRATION_AT
         .get()
         .and_then(|m| m.lock().ok().and_then(|g| *g))


### PR DESCRIPTION
Throwaway. A deliberate type error in `cloud_filter.rs` (cfg(windows) only).

Expected: `rust (windows-latest)` RED, `rust (macos-latest)` GREEN.

Already demonstrated locally: with this break in place, `cargo check` on macOS reports `Finished`. The error is invisible to every machine this project develops on.

Closing and deleting as soon as the run reports.