### PR TITLE
ci(#DBSYNC-38): build the Windows app and type-check the shell-menu crate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -180,8 +180,61 @@ jobs:
       - name: Frontend build and typecheck
         # `npm run build` is `tsc && vite build`, so this is the typecheck too.
         #
-        # It is knowingly duplicated: `tauri-before-build.mjs` runs the same build
-        # unconditionally, so `bundle:dev` above repeats it (and `bundle:win` will, in
-        # #122). At roughly half a second it is not worth engineering away — recorded here
-        # so it is not later mistaken for a defect.
+        # It is knowingly duplicated three times: `tauri-before-build.mjs` runs the same
+        # build unconditionally, so `bundle:dev` and `bundle:win` each repeat it. At
+        # roughly half a second it is not worth engineering away — recorded here so it is
+        # not later mistaken for a defect.
         run: npm --workspace apps/desktop run build
+
+  # Windows artefacts: the app links, and the Explorer shell extension type-checks
+  # (DBSYNC-38, GitHub #122).
+  windows-app:
+    runs-on: windows-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+        with:
+          # Distinct from the `rust` job's Windows leg: that one builds the debug profile
+          # for tests, this one builds release through `tauri build`. They share almost no
+          # artefacts, so a shared key would mean two jobs overwriting each other's cache
+          # for no benefit.
+          prefix-key: windows-app
+          # Two workspaces. `shell-menu` is a SEPARATE cargo project — its own Cargo.toml
+          # and Cargo.lock, referenced by no workspace — so rust-cache has to be told about
+          # it explicitly or its target dir is never cached.
+          workspaces: |
+            apps/desktop/src-tauri
+            apps/desktop/native/windows/shell-menu
+          save-if: ${{ github.ref == 'refs/heads/main' }}
+          cache-on-failure: true
+          env-vars: DROPBOX
+
+      - name: Install dependencies
+        # First time npm runs on a Windows runner in this pipeline. The risk worth naming
+        # is pruned platform-specific optional dependencies — `npm ci` installs strictly
+        # from the lockfile, and package-lock.json does carry the full matrix, including
+        # @rollup/rollup-win32-x64-msvc and @tauri-apps/cli-win32-x64-msvc.
+        run: npm ci
+
+      - name: Build Windows app
+        # `bundle:win` is `tauri build --no-bundle`: it proves the app links, and
+        # deliberately produces no installer. Mirrors the macOS choice — packaging belongs
+        # to the release workflow (DBSYNC-72 Slice 5), never to a PR check.
+        run: npm --workspace apps/desktop run bundle:win
+
+      - name: Check the Explorer shell-menu crate
+        # An independent cargo project that NO CI step has ever built, while
+        # `windows_shell_menu.rs` registers its output at runtime. One `check` covers both
+        # of its targets: the cdylib/rlib and the `dropbox_sync_cloudmenu` COM ExeServer
+        # binary (DBSYNC-62).
+        #
+        # `check`, not `build`: nothing here consumes the DLL, so type-checking is the
+        # signal and linking would be pure cost.
+        run: cargo check --manifest-path apps/desktop/native/windows/shell-menu/Cargo.toml


### PR DESCRIPTION
Slice 3 of 3 for [DBSYNC-38](https://manuelbsan.atlassian.net/browse/DBSYNC-38) — GitHub #122. Blocked by #121, merged.

## The gap this closes

`apps/desktop/native/windows/shell-menu/` is a **separate cargo project** — its own `Cargo.toml` and `Cargo.lock`, referenced by no workspace, ten source files, the Explorer context-menu COM server. **No CI step has ever built it**, while `windows_shell_menu.rs` registers its output at runtime.

Slice 2 proved the library compiles and its tests pass. This proves the app *links* and the shell extension *type-checks*.

## The change

A `windows-app` job on `windows-latest`:

- `npm --workspace apps/desktop run bundle:win` — `tauri build --no-bundle`, so it proves linking and deliberately produces **no installer**. Mirrors the macOS choice; packaging belongs to the release workflow (DBSYNC-72 Slice 5), never to a PR check.
- `cargo check --manifest-path .../shell-menu/Cargo.toml` — one invocation covers both targets: the cdylib/rlib **and** the `dropbox_sync_cloudmenu` COM ExeServer binary from DBSYNC-62. `check` rather than `build`, because nothing in CI consumes the DLL: type-checking is the signal, linking is cost.

## Cache, per #124's review

- **Its own `prefix-key`.** This job builds the *release* profile; the `rust` job's Windows leg builds *debug* for tests. They share almost no artefacts, so one key would mean two jobs overwriting each other for no benefit.
- **`shell-menu` gets an explicit `workspaces:` entry.** Being outside every workspace, rust-cache would otherwise never cache its target dir at all.
- Five caches now against a 10 GB budget. Eviction happens on `main` and degrades every PR invisibly — nothing reports a cache miss as a problem. Worth watching rather than solving preemptively.

## Stack

`desktop-tauri`

## Test Plan

- [ ] `windows-app` green
- [ ] `bundle:win` links the app; confirm **no installer artefact** is produced
- [ ] `cargo check` on the shell-menu crate passes — the first automated build it has ever had
- [ ] `npm ci` works on a Windows runner (first time in this pipeline; pruned optional deps are the risk)
- [ ] Wall-clock delta over Slice 2 recorded

## What could not be checked locally, and why that is the point

Neither addition is verifiable on this machine:

```
$ cargo check --manifest-path apps/desktop/native/windows/shell-menu/Cargo.toml
error: OS not supported. if your application is multi-platform, use
       `[target.'cfg(windows)'.dependencies] winreg = "..."`
error: could not compile `winreg` (lib) due to 1 previous error
```

The crate refuses to build on macOS. That is exactly why a Windows job is worth having — and it means this PR's own run is the first evidence either way.

If the crate turns out to be broken, **that is a finding, not a setback**: file it as its own bug and let this land the job. Same rule as Slice 2.

#DBSYNC-38