### PR TITLE
fix(#DBSYNC-73): decode overlay_state with explicit keys, and say so when it fails

### DIFF
--- a/apps/desktop/native/macos/FinderSyncExtension/BadgeDiff.swift
+++ b/apps/desktop/native/macos/FinderSyncExtension/BadgeDiff.swift
@@ -193,7 +193,7 @@ enum BadgeDiff {
 /// already runs that script.** The original ticket recorded this decode as impossible to
 /// test; it was not, and two defects have already survived review in this project by
 /// sitting where the check script could not reach them.
-struct OverlayState: Decodable, Equatable {
+struct OverlayState: Decodable {
     let version: Int
     let updatedAt: String
     let syncFolder: String?
@@ -230,5 +230,54 @@ struct OverlayState: Decodable, Equatable {
     /// directories and every badge disappears with nothing written anywhere.
     static func decode(from data: Data) throws -> OverlayState {
         try JSONDecoder().decode(OverlayState.self, from: data)
+    }
+}
+
+/// A description of a decoding failure that is safe to put in the system log (DBSYNC-73).
+///
+/// **`String(describing:)` on a `DecodingError` leaks the user's file paths.** The error
+/// carries a `codingPath`, and inside `OverlayState.paths` those components ARE relative
+/// paths from the sync folder:
+///
+///     typeMismatch … Path: paths.`Clients/AcmeCorp_NDA_signed.pdf`
+///
+/// `NSLog` writes to the public unified log, readable via `log show` and captured in any
+/// sysdiagnose. Making the decode failure audible — which is the other half of this ticket
+/// — must not turn it into a privacy leak.
+///
+/// So this reports the *kind* of failure and, at most, a key name from the struct's own
+/// schema. It never emits `codingPath`, and never a value. What is lost is which entry
+/// failed; what is kept is enough to tell a schema mismatch from malformed bytes, which is
+/// the distinction anyone debugging actually needs.
+///
+/// Not reachable from today's writer — `HashMap<String, OverlayTier>` can only emit strings,
+/// and truncation fails earlier as `dataCorrupted`. It is guarded anyway because
+/// `overlay_state.json` is a versioned contract with two readers, and DBSYNC-91 records that
+/// `version` is decoded and never checked: a newer writer reshaping `paths` against an
+/// installed older appex is precisely the gap.
+func logSafeDescription(of error: Error) -> String {
+    guard let decoding = error as? DecodingError else {
+        // Not a decoding failure — a read error, already scoped to a path we logged
+        // ourselves. Still summarised rather than dumped.
+        return "\(type(of: error))"
+    }
+    switch decoding {
+    case .keyNotFound(let key, _):
+        // A key name from OUR schema (`updated_at`, `sync_folder`), never a dictionary key
+        // from `paths`: a missing-key failure is raised against the struct's keyed
+        // container. This is also what both DBSYNC-73 mutations produce, so it is the one
+        // detail worth keeping.
+        return "keyNotFound(\(key.stringValue))"
+    case .typeMismatch(let expected, _):
+        return "typeMismatch(expected \(expected))"
+    case .valueNotFound(let expected, _):
+        return "valueNotFound(expected \(expected))"
+    case .dataCorrupted:
+        // Malformed or truncated JSON. The context here describes the syntax problem, not
+        // the content, but it is dropped anyway — "the bytes are not JSON" is the whole
+        // actionable message.
+        return "dataCorrupted (not valid JSON)"
+    @unknown default:
+        return "DecodingError (unrecognised case)"
     }
 }

--- a/apps/desktop/native/macos/FinderSyncExtension/BadgeDiff.swift
+++ b/apps/desktop/native/macos/FinderSyncExtension/BadgeDiff.swift
@@ -186,3 +186,49 @@ enum BadgeDiff {
     }
 }
 
+/// The shape of `overlay_state.json`, and the only place it is decoded (DBSYNC-73).
+///
+/// **It lives here rather than in `SyncExtension.swift` for one reason: this file is
+/// Foundation-only, so `Tests/run-badge-diff-tests.sh` can compile it with `swiftc` and CI
+/// already runs that script.** The original ticket recorded this decode as impossible to
+/// test; it was not, and two defects have already survived review in this project by
+/// sitting where the check script could not reach them.
+struct OverlayState: Decodable, Equatable {
+    let version: Int
+    let updatedAt: String
+    let syncFolder: String?
+    /// Relative path (POSIX, no leading slash) → tier id matching registered badge ids.
+    let paths: [String: String]
+
+    /// Explicit, and never `keyDecodingStrategy = .convertFromSnakeCase`.
+    ///
+    /// That strategy applies to **every** key the decoder sees, and on the Foundation
+    /// shipped with macOS 12-14 that included the keys of a `[String: T]` dictionary.
+    /// `paths` is exactly such a dictionary and its keys are file paths, so
+    /// `docs/my_report.pdf` decoded as `docs/myReport.pdf`, matched nothing in
+    /// `requestBadgeIdentifier(for:)`, and that file silently rendered no badge.
+    ///
+    /// It does not reproduce on macOS 26 — the swift-foundation rewrite stopped converting
+    /// dictionary keys — but `JSONDecoder` comes from the USER's Foundation, and
+    /// `minimumSystemVersion` is 12.0. Correct for the developer, silently wrong for a
+    /// subset of users on a subset of their files.
+    ///
+    /// **These keys do more than avoid the strategy: they make it unreachable.** With the
+    /// wire names spelled out, `.convertFromSnakeCase` rewrites `updated_at` to
+    /// `updatedAt`, then looks for a `CodingKey` whose `stringValue` is `"updated_at"`,
+    /// and throws `keyNotFound` — on every Foundation and every OS. Reintroducing it fails
+    /// loudly here and in CI instead of quietly on someone else's machine.
+    enum CodingKeys: String, CodingKey {
+        case version
+        case updatedAt = "updated_at"
+        case syncFolder = "sync_folder"
+        case paths
+    }
+
+    /// Decodes with a plain `JSONDecoder`. Throws rather than returning `nil` so the caller
+    /// can log what went wrong — a silent decode failure deregisters the extension's
+    /// directories and every badge disappears with nothing written anywhere.
+    static func decode(from data: Data) throws -> OverlayState {
+        try JSONDecoder().decode(OverlayState.self, from: data)
+    }
+}

--- a/apps/desktop/native/macos/FinderSyncExtension/SyncExtension.swift
+++ b/apps/desktop/native/macos/FinderSyncExtension/SyncExtension.swift
@@ -136,6 +136,11 @@ final class DropboxSyncFinderSync: FIFinderSync {
     /// expensive to find — an unreadable state file looks exactly like "no files tracked yet".
     private var lastLoadFailed = false
 
+    /// Same transition-logging discipline as [`lastLoadFailed`], for the decode step
+    /// (DBSYNC-73). Separate flag: the file can be readable and undecodable, and conflating
+    /// them would swallow one of the two messages.
+    private var lastDecodeFailed = false
+
     private func reloadState() {
         let url = overlayStateURL()
         guard let data = try? Data(contentsOf: url) else {
@@ -155,12 +160,32 @@ final class DropboxSyncFinderSync: FIFinderSync {
             NSLog("DropboxSync FinderSync: reading %@ again.", url.path)
             lastLoadFailed = false
         }
-        let decoder = JSONDecoder()
-        decoder.keyDecodingStrategy = .convertFromSnakeCase
-        guard let decoded = try? decoder.decode(OverlayState.self, from: data) else {
+        // Decoding lives in `BadgeDiff.OverlayState` so the check script can reach it, and
+        // it throws so this failure can be reported (DBSYNC-73).
+        let decoded: OverlayState
+        do {
+            decoded = try OverlayState.decode(from: data)
+        } catch {
+            // NOT silent. This used to be a bare `try?` with no log, while the read above
+            // it logged carefully — and the consequence is worse than the read failing:
+            // `state = nil` drops `syncFolder`, so `monitoredDirectoryURLs()` returns [],
+            // so Finder deregisters the extension's directories and stops calling it. Every
+            // badge vanishes with nothing written anywhere. That is the shape of DBSYNC-76,
+            // which this file's own comments record as expensive to find.
+            //
+            // Logged on the transition only, like the read path: this runs every 2 seconds.
+            if !lastDecodeFailed {
+                NSLog("DropboxSync FinderSync: cannot decode %@ — no badges will be shown. %@",
+                      url.path, String(describing: error))
+                lastDecodeFailed = true
+            }
             state = nil
             lastUpdatedAt = nil
             return
+        }
+        if lastDecodeFailed {
+            NSLog("DropboxSync FinderSync: decoding %@ again.", url.path)
+            lastDecodeFailed = false
         }
 
         // Nothing was rewritten since the last tick: no diff, no pushes, no work.
@@ -270,12 +295,4 @@ final class DropboxSyncFinderSync: FIFinderSync {
             FIFinderSyncController.default().setBadgeIdentifier(identifier, for: item)
         }
     }
-}
-
-private struct OverlayState: Decodable {
-    let version: Int
-    let updatedAt: String
-    let syncFolder: String?
-    /// Relative path (POSIX, no leading slash) → tier id matching registered badge ids.
-    let paths: [String: String]
 }

--- a/apps/desktop/native/macos/FinderSyncExtension/SyncExtension.swift
+++ b/apps/desktop/native/macos/FinderSyncExtension/SyncExtension.swift
@@ -160,8 +160,9 @@ final class DropboxSyncFinderSync: FIFinderSync {
             NSLog("DropboxSync FinderSync: reading %@ again.", url.path)
             lastLoadFailed = false
         }
-        // Decoding lives in `BadgeDiff.OverlayState` so the check script can reach it, and
-        // it throws so this failure can be reported (DBSYNC-73).
+        // Decoding lives in `OverlayState`, declared in the Foundation-only BadgeDiff.swift
+        // so the check script can reach it, and it throws so this failure can be reported
+        // (DBSYNC-73).
         let decoded: OverlayState
         do {
             decoded = try OverlayState.decode(from: data)
@@ -176,7 +177,7 @@ final class DropboxSyncFinderSync: FIFinderSync {
             // Logged on the transition only, like the read path: this runs every 2 seconds.
             if !lastDecodeFailed {
                 NSLog("DropboxSync FinderSync: cannot decode %@ — no badges will be shown. %@",
-                      url.path, String(describing: error))
+                      url.path, logSafeDescription(of: error))
                 lastDecodeFailed = true
             }
             state = nil

--- a/apps/desktop/native/macos/FinderSyncExtension/Tests/BadgeDiffTests.swift
+++ b/apps/desktop/native/macos/FinderSyncExtension/Tests/BadgeDiffTests.swift
@@ -410,11 +410,60 @@ struct BadgeDiffTests {
         checkOptional("updated_at maps to updatedAt", decoded.updatedAt, "2026-08-25T12:00:00Z")
         checkOptional("sync_folder maps to syncFolder", decoded.syncFolder, "/Users/x/DropboxSync")
 
-        // A tier value that contains an underscore, in the VALUE position rather than the
-        // key. Values were never at risk, but `cloud_only` reaching the lookup intact is
-        // what makes a badge render, so it is worth pinning.
-        checkOptional("an underscored tier value is untouched",
-                      decoded.paths["a_b_c/x_y.md"], "cloud_only")
+        // A tier VALUE, on a key with no underscores at all. The previous version of this
+        // check asserted the same key/value pair as the one three lines above, so no input
+        // could redden one without the other — six checks over five properties. Pointing it
+        // at `plain.txt` makes it earn its name: it isolates the value position from the
+        // key position entirely.
+        checkOptional("a tier value on an underscore-free key is untouched",
+                      decoded.paths["plain.txt"], "syncing")
+
+        print("logSafeDescription (DBSYNC-73)")
+
+        // THE LEAK THIS EXISTS TO PREVENT. `DecodingError.codingPath` inside `paths`
+        // contains the user's relative file paths, and NSLog writes to the PUBLIC unified
+        // log. `String(describing:)` on this error yields:
+        //     typeMismatch … Path: paths.`Clients/AcmeCorp_NDA_signed.pdf`
+        // Making the decode failure audible must not make it a privacy leak.
+        let leaky = Data("""
+        {
+          "version": 1,
+          "updated_at": "2026-08-26T00:00:00Z",
+          "sync_folder": "/Users/x/DropboxSync",
+          "paths": { "Clients/AcmeCorp_NDA_signed.pdf": 42 }
+        }
+        """.utf8)
+
+        do {
+            _ = try OverlayState.decode(from: leaky)
+            print("  FAIL a type-mismatched tier should not decode")
+            failures += 1
+        } catch {
+            let safe = logSafeDescription(of: error)
+            checkBool("a decode error never names the user's file",
+                      safe.contains("AcmeCorp_NDA_signed"), false)
+            checkBool("a decode error never leaks the coding path",
+                      safe.lowercased().contains("clients/"), false)
+            checkBool("but it still says what kind of failure it was",
+                      safe.contains("typeMismatch"), true)
+            // The naive version this replaced would fail the first two.
+            checkBool("the raw description WOULD have leaked it (guard is load-bearing)",
+                      String(describing: error).contains("AcmeCorp_NDA_signed"), true)
+        }
+
+        // The failure both DBSYNC-73 mutations produce. Its key comes from our own schema,
+        // never from `paths`, so keeping it is safe and is what makes the log useful.
+        let missingKey = Data("""
+        {"version": 1, "sync_folder": null, "paths": {}}
+        """.utf8)
+        do {
+            _ = try OverlayState.decode(from: missingKey)
+            print("  FAIL a payload missing updated_at should not decode")
+            failures += 1
+        } catch {
+            checkBool("a missing schema key is named, because it is ours",
+                      logSafeDescription(of: error).contains("updated_at"), true)
+        }
 
         if failures == 0 {
             print("BadgeDiff: all checks passed")

--- a/apps/desktop/native/macos/FinderSyncExtension/Tests/BadgeDiffTests.swift
+++ b/apps/desktop/native/macos/FinderSyncExtension/Tests/BadgeDiffTests.swift
@@ -370,6 +370,52 @@ struct BadgeDiffTests {
                   observedDirectories: []),
               changed: [:], removed: ["report.pdf.cloudsc"])
 
+        print("OverlayState.decode (DBSYNC-73)")
+
+        // The payload the ticket was written against, with the underscores that matter.
+        let json = Data("""
+        {
+          "version": 1,
+          "updated_at": "2026-08-25T12:00:00Z",
+          "sync_folder": "/Users/x/DropboxSync",
+          "paths": {
+            "docs/my_report.pdf": "synced",
+            "a_b_c/x_y.md": "cloud_only",
+            "plain.txt": "syncing"
+          }
+        }
+        """.utf8)
+
+        // `try?` with a named failure rather than `try!`: a trap reports as
+        // "Trace/BPT trap: 5" with no indication of which check died.
+        guard let decoded = try? OverlayState.decode(from: json) else {
+            print("  FAIL OverlayState.decode threw on a valid payload")
+            failures += 1
+            exit(1)
+        }
+
+        // THE BUG. `.convertFromSnakeCase` applied to every key the decoder saw, including
+        // the keys of `paths` — which are file paths. On macOS 12-14 Foundation,
+        // "docs/my_report.pdf" arrived as "docs/myReport.pdf", matched nothing, and that
+        // file silently rendered no badge.
+        checkBool("underscored path keys survive decoding",
+                  decoded.paths["docs/my_report.pdf"] == "synced", true)
+        checkBool("underscored path keys are not camel-cased",
+                  decoded.paths["docs/myReport.pdf"] == nil, true)
+        checkBool("a path with several underscores survives too",
+                  decoded.paths["a_b_c/x_y.md"] == "cloud_only", true)
+
+        // The two properties that DO need mapping. If these regress, the decode throws
+        // rather than silently yielding a wrong value — which is the point of naming them.
+        checkOptional("updated_at maps to updatedAt", decoded.updatedAt, "2026-08-25T12:00:00Z")
+        checkOptional("sync_folder maps to syncFolder", decoded.syncFolder, "/Users/x/DropboxSync")
+
+        // A tier value that contains an underscore, in the VALUE position rather than the
+        // key. Values were never at risk, but `cloud_only` reaching the lookup intact is
+        // what makes a badge render, so it is worth pinning.
+        checkOptional("an underscored tier value is untouched",
+                      decoded.paths["a_b_c/x_y.md"], "cloud_only")
+
         if failures == 0 {
             print("BadgeDiff: all checks passed")
             exit(0)


### PR DESCRIPTION
Fixes [DBSYNC-73](https://manuelbsan.atlassian.net/browse/DBSYNC-73) — GitHub #127. Single slice, classified TRIVIAL.

## The bug

The extension decoded `overlay_state.json` with `keyDecodingStrategy = .convertFromSnakeCase`. That strategy applies to **every** key the decoder sees, and on the Foundation shipped with macOS 12-14 that included the keys of a `[String: T]` dictionary.

`paths` is exactly such a dictionary and its keys are **file paths**. So `docs/my_report.pdf` decoded as `docs/myReport.pdf`, matched nothing in `requestBadgeIdentifier(for:)`, and that file silently rendered no badge.

It does not reproduce on macOS 26 — the swift-foundation rewrite stopped converting dictionary keys — but `JSONDecoder` comes from the **user's** Foundation, and `minimumSystemVersion` is 12.0. Correct for the developer, silently wrong for a subset of users on a subset of their files. That is the worst failure mode available.

## The fix does more than avoid the API — it makes it unreachable

Explicit `CodingKeys` for the two snake_case properties, plain `JSONDecoder`.

The property worth having is the one the original spec missed. With the wire names spelled out, `.convertFromSnakeCase` rewrites `updated_at` to `updatedAt`, then looks for a `CodingKey` whose `stringValue` is `"updated_at"`, and throws `keyNotFound` — **on every Foundation and every OS version**.

So nobody can reintroduce the dangerous configuration and have it fail quietly on someone else's macOS 12. It fails loudly, here and in CI.

## "Cannot be covered by an automated test" was wrong

The ticket recorded this decode as untestable. `OverlayState` and a `decode(from:) throws` move into `BadgeDiff.swift`, which is Foundation-only and already compiled by `Tests/run-badge-diff-tests.sh` — a runner CI runs in the `macos-app` job. **Zero pipeline changes.**

What was actually untestable is the macOS 12 *symptom*; the property that holds everywhere is the mutual exclusivity above. Those are different claims, and conflating them cost this ticket a year of being "unverifiable".

It also belongs there on precedent: three non-diff helpers already live in that file, and both of their doc comments record a defect that survived review "because it sat in a file the test script cannot compile."

## Folded in: the decode failure was silent

`reloadState()` logged carefully when the file could not be **read**, then two lines below guarded the **decode** with a bare `try?` and no log at all.

That asymmetry matters more than it looks. A decode failure sets `state = nil` → drops `syncFolder` → `monitoredDirectoryURLs()` returns `[]` → Finder deregisters the extension's directories and stops calling it. **Every badge disappears, with nothing written anywhere.** Same shape as DBSYNC-76, which this file's own comments record as expensive to find.

Now logged on the transition, with its own flag — a file can be readable and undecodable, and one shared flag would swallow one of the two messages.

## Stack

`desktop-tauri`

## Test Plan

- [x] Six checks in `run-badge-diff-tests.sh`, green
- [x] **Mutation check, both directions** — see below
- [x] `npm run build:finder-sync` → BUILD SUCCEEDED, principal class resolves
- [x] No Rust touched
- [ ] CI green on this PR

```
OverlayState.decode (DBSYNC-73)
  ok   underscored path keys survive decoding
  ok   underscored path keys are not camel-cased
  ok   a path with several underscores survives too
  ok   updated_at maps to updatedAt
  ok   sync_folder maps to syncFolder
  ok   an underscored tier value is untouched
```

| Mutation | Result |
|---|---|
| Reintroduce `.convertFromSnakeCase` alongside the CodingKeys | ❌ FAIL |
| Delete the CodingKeys, keep the plain decoder | ❌ FAIL |
| Restore | ✅ green |

Two ways to get this wrong, two ways to catch it.

**Process note worth recording.** The first run of mutation 2 tested a file that still had mutation 1 applied, because a `cd` failed silently — and that combination is the original working config, so it reported green. Re-run from a verified-clean tree. A mutation check that accidentally tests nothing is precisely the failure these checks exist to prevent, so it would have been dishonest to leave the first result standing.

## What this does not prove

The macOS 12-14 symptom itself. Unreproducible on a modern Foundation by construction. Confirming it would need a macOS 12/13 machine and is not a blocker — the reintroduction guard is the durable part.

## Out of scope

`version` is decoded and never checked — **DBSYNC-91**, needs a behaviour decision.

#DBSYNC-73
