### PR TITLE
style(#DBSYNC-90): format the Rust tree and enforce cargo fmt in CI

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,20 @@
+# Revisions to skip when running `git blame`.
+#
+# Enable locally with:
+#     git config blame.ignoreRevsFile .git-blame-ignore-revs
+#
+# GitHub honours this file automatically. Only ever add commits that are PURELY
+# mechanical — a reformat, a mass rename — never one that changes behaviour, or blame
+# will hide the change that actually broke something.
+#
+# MEASURED, and smaller than expected: of the 720 lines the reformat below touched, only
+# 14 end up attributed to it, because most were line splits whose first fragment keeps its
+# original author. Ignoring the commit does not move those 14 either — they are genuinely
+# new text with no predecessor line to fall back to, so `blame` has nowhere to send them.
+#
+# So this file changes nothing measurable for the commit it lists. It is kept as policy
+# for the next mass change rather than as a repair of this one; DBSYNC-90 originally
+# called blame damage "the main cost of doing it at all", and that was wrong.
+
+# style(#DBSYNC-90): apply cargo fmt — 22 files, rustfmt defaults, zero logic change
+36b3af1b380ec369d1e8dab8325a27d91682cd11

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,6 +110,17 @@ jobs:
       - name: Rust tests
         run: cargo test --manifest-path apps/desktop/src-tauri/Cargo.toml
 
+      - name: Rust formatting
+        # Added by DBSYNC-90, after `cargo fmt` was applied to the tree. Deliberately NOT
+        # part of DBSYNC-38: turning this on before formatting would have made every job
+        # red on layout rather than on defects, which is how this workflow earned being
+        # switched off for six weeks.
+        #
+        # Runs on both matrix legs. rustfmt is deterministic, so the Windows leg is
+        # redundant in principle — but a divergence there would be a real finding about the
+        # toolchain, and it costs a second.
+        run: cargo fmt --manifest-path apps/desktop/src-tauri/Cargo.toml --check
+
       - name: Rust lints
         # Not `-D warnings`: main currently carries pre-existing warnings, and failing the
         # build on them would put this workflow straight back to permanently red — which is

--- a/apps/desktop/src-tauri/src/auth/oauth.rs
+++ b/apps/desktop/src-tauri/src/auth/oauth.rs
@@ -119,10 +119,7 @@ pub fn start_oauth() -> AppResult<(String, String, String)> {
     Ok((auth_url, state, verifier))
 }
 
-pub async fn complete_oauth(
-    code: String,
-    verifier: Zeroizing<String>,
-) -> AppResult<TokenResponse> {
+pub async fn complete_oauth(code: String, verifier: Zeroizing<String>) -> AppResult<TokenResponse> {
     let app_key = resolve_app_key()?;
     let redirect_uri = resolve_redirect_uri();
     let client = Client::builder()

--- a/apps/desktop/src-tauri/src/auth_session.rs
+++ b/apps/desktop/src-tauri/src/auth_session.rs
@@ -353,9 +353,9 @@ pub(crate) fn refresh_tray_tooltip(state: &AppState) {
 mod tests {
     use super::{refresh_token_guarded, TokenSession};
     use chrono::{Duration, Utc};
-    use zeroize::Zeroizing;
     use std::sync::atomic::{AtomicUsize, Ordering};
     use std::sync::{Arc, Mutex};
+    use zeroize::Zeroizing;
 
     fn fresh_session() -> TokenSession {
         TokenSession {

--- a/apps/desktop/src-tauri/src/cloud_filter.rs
+++ b/apps/desktop/src-tauri/src/cloud_filter.rs
@@ -37,7 +37,7 @@ use windows::Storage::Provider::{
     StorageProviderPopulationPolicy, StorageProviderSyncRootInfo, StorageProviderSyncRootManager,
 };
 use windows::Storage::StorageFolder;
-use windows::Win32::Foundation::{CloseHandle, E_ABORT, HANDLE, HLOCAL, LocalFree, NTSTATUS};
+use windows::Win32::Foundation::{CloseHandle, LocalFree, E_ABORT, HANDLE, HLOCAL, NTSTATUS};
 use windows::Win32::Security::Authorization::ConvertSidToStringSidW;
 use windows::Win32::Security::{GetTokenInformation, TokenUser, TOKEN_QUERY, TOKEN_USER};
 use windows::Win32::Storage::CloudFilters::{
@@ -55,7 +55,7 @@ use windows::Win32::Storage::CloudFilters::{
     CF_OPERATION_PARAMETERS_0, CF_OPERATION_PARAMETERS_0_0, CF_OPERATION_PARAMETERS_0_6,
     CF_OPERATION_PARAMETERS_0_7, CF_OPERATION_TRANSFER_DATA_FLAG_NONE,
     CF_OPERATION_TYPE_ACK_DELETE, CF_OPERATION_TYPE_ACK_RENAME, CF_OPERATION_TYPE_TRANSFER_DATA,
-    CF_PLACEHOLDER_CREATE_FLAG_MARK_IN_SYNC, CF_PLACEHOLDER_CREATE_INFO, CF_PIN_STATE_PINNED,
+    CF_PIN_STATE_PINNED, CF_PLACEHOLDER_CREATE_FLAG_MARK_IN_SYNC, CF_PLACEHOLDER_CREATE_INFO,
     CF_REVERT_FLAG_NONE, CF_SET_IN_SYNC_FLAG_NONE, CF_SET_PIN_FLAG_NONE,
 };
 use windows::Win32::Storage::FileSystem::{
@@ -98,10 +98,7 @@ const POST_REGISTRATION_GRACE: Duration = Duration::from_secs(15 * 60);
 
 /// Record that a sync-root (un)registration just happened (starts the grace window).
 fn mark_registration_activity() {
-    if let Ok(mut g) = LAST_REGISTRATION_AT
-        .get_or_init(|| Mutex::new(None))
-        .lock()
-    {
+    if let Ok(mut g) = LAST_REGISTRATION_AT.get_or_init(|| Mutex::new(None)).lock() {
         *g = Some(Instant::now());
     }
 }
@@ -135,7 +132,10 @@ const MATERIALIZATION_GRACE_WINDOW: Duration = Duration::from_secs(120);
 /// any already-expired entries so the map doesn't grow unbounded across a long-running
 /// session (no separate GC needed).
 pub(crate) fn mark_materialization(prefix: &str) {
-    if let Ok(mut m) = MATERIALIZATION_IN_FLIGHT.get_or_init(|| Mutex::new(HashMap::new())).lock() {
+    if let Ok(mut m) = MATERIALIZATION_IN_FLIGHT
+        .get_or_init(|| Mutex::new(HashMap::new()))
+        .lock()
+    {
         let now = Instant::now();
         m.retain(|_, at| {
             now.checked_duration_since(*at)
@@ -158,7 +158,10 @@ fn materialization_grace_contains(
     window: Duration,
 ) -> bool {
     entries.iter().any(|(prefix, at)| {
-        let in_window = now.checked_duration_since(*at).map(|d| d < window).unwrap_or(true);
+        let in_window = now
+            .checked_duration_since(*at)
+            .map(|d| d < window)
+            .unwrap_or(true);
         in_window && (rel == prefix || rel.starts_with(&format!("{prefix}/")))
     })
 }
@@ -290,8 +293,14 @@ pub(crate) fn apply_folder_state(abs: &Path) -> bool {
         };
         // Convert to a placeholder (ignore "already a placeholder") + mark in-sync.
         // NEVER pin: pinning a directory would force-hydrate every child.
-        let conv = CfConvertToPlaceholder(handle, None, 0, CF_CONVERT_FLAG_MARK_IN_SYNC, None, None);
-        let sync = CfSetInSyncState(handle, CF_IN_SYNC_STATE_IN_SYNC, CF_SET_IN_SYNC_FLAG_NONE, None);
+        let conv =
+            CfConvertToPlaceholder(handle, None, 0, CF_CONVERT_FLAG_MARK_IN_SYNC, None, None);
+        let sync = CfSetInSyncState(
+            handle,
+            CF_IN_SYNC_STATE_IN_SYNC,
+            CF_SET_IN_SYNC_FLAG_NONE,
+            None,
+        );
         let _ = CloseHandle(handle);
         // DBSYNC-67: CfConvertToPlaceholder only succeeds on an EMPTY directory —
         // once the folder holds placeholder children it returns 0x8007017C
@@ -328,7 +337,10 @@ pub(crate) fn notify_shell_folders_changed(sync_folder: Option<&str>, folder_rel
         return;
     };
     let root = Path::new(folder);
-    tracing::debug!(count = folder_rels.len(), "SHChangeNotify(SHCNE_UPDATEITEM) refreshing folder overlays");
+    tracing::debug!(
+        count = folder_rels.len(),
+        "SHChangeNotify(SHCNE_UPDATEITEM) refreshing folder overlays"
+    );
     for rel in folder_rels {
         if rel.is_empty() {
             continue;
@@ -487,7 +499,10 @@ fn connect_provider(folder: &str) {
         Ok(key) => {
             *guard = Some(key.0);
             set_connected_root(folder);
-            tracing::info!(folder, "cfapi provider connected (on-demand hydration + event-driven deletes)");
+            tracing::info!(
+                folder,
+                "cfapi provider connected (on-demand hydration + event-driven deletes)"
+            );
         }
         Err(e) => {
             tracing::warn!(folder, error = %e, "CfConnectSyncRoot failed; on-demand hydration disabled");
@@ -524,7 +539,12 @@ fn clear_cancel(transfer_key: i64) {
 fn app_state() -> Option<crate::state::AppState> {
     use tauri::Manager;
     let handle = crate::state::APP_HANDLE.get()?;
-    Some(handle.try_state::<crate::state::AppState>()?.inner().clone())
+    Some(
+        handle
+            .try_state::<crate::state::AppState>()?
+            .inner()
+            .clone(),
+    )
 }
 
 /// Join a CfAPI-normalized, DRIVE-LESS path (e.g. `\Users\me\Dropbox\file.txt`) with
@@ -595,7 +615,14 @@ unsafe extern "system" fn on_fetch_data(
         }
         Err(e) => {
             tracing::warn!(error = %e, "cfapi fetch-data failed; failing the open");
-            let _ = cf_transfer(conn, transfer, std::ptr::null(), offset, length, STATUS_UNSUCCESSFUL);
+            let _ = cf_transfer(
+                conn,
+                transfer,
+                std::ptr::null(),
+                offset,
+                length,
+                STATUS_UNSUCCESSFUL,
+            );
         }
     }
 }
@@ -657,7 +684,10 @@ fn mark_in_flight(slot: &'static OnceLock<Mutex<HashMap<String, bool>>>, rel: &s
     }
 }
 
-fn take_in_flight(slot: &'static OnceLock<Mutex<HashMap<String, bool>>>, rel: &str) -> Option<bool> {
+fn take_in_flight(
+    slot: &'static OnceLock<Mutex<HashMap<String, bool>>>,
+    rel: &str,
+) -> Option<bool> {
     slot.get()?.lock().ok()?.remove(rel)
 }
 
@@ -741,7 +771,11 @@ unsafe extern "system" fn on_notify_delete(
     let is_dir = if params.is_null() {
         false
     } else {
-        (*params).Anonymous.Delete.Flags.contains(CF_CALLBACK_DELETE_FLAG_IS_DIRECTORY)
+        (*params)
+            .Anonymous
+            .Delete
+            .Flags
+            .contains(CF_CALLBACK_DELETE_FLAG_IS_DIRECTORY)
     };
     let _: Option<String> = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
         let rel = full_local_path(info).and_then(|abs| rel_under_connected_root(&abs))?;
@@ -810,7 +844,11 @@ unsafe extern "system" fn on_notify_rename(
     let is_dir = if params.is_null() {
         false
     } else {
-        (*params).Anonymous.Rename.Flags.contains(CF_CALLBACK_RENAME_FLAG_IS_DIRECTORY)
+        (*params)
+            .Anonymous
+            .Rename
+            .Flags
+            .contains(CF_CALLBACK_RENAME_FLAG_IS_DIRECTORY)
     };
     let _: Option<String> = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
         let rel = full_local_path(info).and_then(|abs| rel_under_connected_root(&abs))?;
@@ -863,11 +901,13 @@ unsafe extern "system" fn on_notify_rename_completion(
     let outcome: Option<(String, Option<String>)> =
         std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
             let root = connected_root()?;
-            let source_abs =
-                full_path_from(info.VolumeDosName, params.Anonymous.RenameCompletion.SourcePath)?;
+            let source_abs = full_path_from(
+                info.VolumeDosName,
+                params.Anonymous.RenameCompletion.SourcePath,
+            )?;
             let source_rel = crate::path_util::relpath_under(&root, &source_abs).ok()?;
-            let target_rel =
-                full_local_path(info).and_then(|target_abs| classify_rename_target(&root, &target_abs));
+            let target_rel = full_local_path(info)
+                .and_then(|target_abs| classify_rename_target(&root, &target_abs));
             Some((source_rel, target_rel))
         }))
         .unwrap_or(None);
@@ -899,7 +939,11 @@ unsafe extern "system" fn on_notify_rename_completion(
 /// One `CfExecute(CF_OPERATION_TYPE_ACK_DELETE)` — unconditionally lets the
 /// platform's delete proceed (we never veto). Mirrors `cf_transfer`'s
 /// `CF_OPERATION_INFO` / `CF_OPERATION_PARAMETERS` construction.
-unsafe fn ack_delete(conn: CF_CONNECTION_KEY, transfer: i64, status: NTSTATUS) -> windows::core::Result<()> {
+unsafe fn ack_delete(
+    conn: CF_CONNECTION_KEY,
+    transfer: i64,
+    status: NTSTATUS,
+) -> windows::core::Result<()> {
     let op_info = CF_OPERATION_INFO {
         StructSize: std::mem::size_of::<CF_OPERATION_INFO>() as u32,
         Type: CF_OPERATION_TYPE_ACK_DELETE,
@@ -925,7 +969,11 @@ unsafe fn ack_delete(conn: CF_CONNECTION_KEY, transfer: i64, status: NTSTATUS) -
 /// One `CfExecute(CF_OPERATION_TYPE_ACK_RENAME)` — unconditionally lets the
 /// platform's rename/move proceed (we never veto). Mirrors `cf_transfer`'s
 /// `CF_OPERATION_INFO` / `CF_OPERATION_PARAMETERS` construction.
-unsafe fn ack_rename(conn: CF_CONNECTION_KEY, transfer: i64, status: NTSTATUS) -> windows::core::Result<()> {
+unsafe fn ack_rename(
+    conn: CF_CONNECTION_KEY,
+    transfer: i64,
+    status: NTSTATUS,
+) -> windows::core::Result<()> {
     let op_info = CF_OPERATION_INFO {
         StructSize: std::mem::size_of::<CF_OPERATION_INFO>() as u32,
         Type: CF_OPERATION_TYPE_ACK_RENAME,
@@ -982,7 +1030,8 @@ static PENDING_DELETES_LAST_ACTIVITY: OnceLock<Mutex<Option<Instant>>> = OnceLoc
 /// cleared by the worker itself once the buffer has been empty for a couple of
 /// polls (with a re-check to avoid dropping a push that lands in that exact
 /// window — see `run_delete_flush_worker`).
-static DELETE_FLUSH_RUNNING: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
+static DELETE_FLUSH_RUNNING: std::sync::atomic::AtomicBool =
+    std::sync::atomic::AtomicBool::new(false);
 
 /// How long the buffer must be quiet (no new pushes) before it is flushed.
 /// Comfortably longer than the gap between consecutive descendant
@@ -1139,8 +1188,7 @@ fn flush_pending_deletes(state: &crate::state::AppState, batch: Vec<PendingDelet
     }
     // DBSYNC-70: measure where a coalesced folder-delete flush spends its time.
     let flush_start = std::time::Instant::now();
-    let entries: Vec<(String, bool)> =
-        batch.iter().map(|p| (p.rel.clone(), p.is_dir)).collect();
+    let entries: Vec<(String, bool)> = batch.iter().map(|p| (p.rel.clone(), p.is_dir)).collect();
     let roots = minimal_delete_roots(&entries);
 
     for (rel, is_dir) in &roots {
@@ -1297,8 +1345,15 @@ fn stream_range(
             break;
         }
         unsafe {
-            cf_transfer(conn, transfer, buf.as_ptr() as *const _, pos, filled as i64, STATUS_SUCCESS)
-                .map_err(|e| AppError::Other(format!("CfExecute(TRANSFER_DATA): {e}")))?;
+            cf_transfer(
+                conn,
+                transfer,
+                buf.as_ptr() as *const _,
+                pos,
+                filled as i64,
+                STATUS_SUCCESS,
+            )
+            .map_err(|e| AppError::Other(format!("CfExecute(TRANSFER_DATA): {e}")))?;
         }
         pos += filled as i64;
         remaining -= filled as i64;
@@ -1423,7 +1478,9 @@ pub(crate) fn hydrate_folder(abs: &Path) -> usize {
             continue;
         }
         // Stat only — is_dehydrated_placeholder uses symlink_metadata, no open/recall.
-        if crate::path_util::is_dehydrated_placeholder(entry.path()) && hydrate_placeholder(entry.path()) {
+        if crate::path_util::is_dehydrated_placeholder(entry.path())
+            && hydrate_placeholder(entry.path())
+        {
             n += 1;
         }
     }
@@ -1461,7 +1518,12 @@ fn reconcile_after_hydration(abs: &Path) {
             FILE_FLAG_BACKUP_SEMANTICS,
             None,
         ) {
-            let r = CfSetInSyncState(handle, CF_IN_SYNC_STATE_IN_SYNC, CF_SET_IN_SYNC_FLAG_NONE, None);
+            let r = CfSetInSyncState(
+                handle,
+                CF_IN_SYNC_STATE_IN_SYNC,
+                CF_SET_IN_SYNC_FLAG_NONE,
+                None,
+            );
             let _ = CloseHandle(handle);
             tracing::debug!(file = %abs.display(), result = ?r, "cfapi reconcile after hydration (mark in-sync)");
         }
@@ -1644,27 +1706,47 @@ fn register_winrt(folder: &str) -> windows::core::Result<()> {
     tracing::info!(sync_root_id = %id, folder, "cfapi register: begin");
     let info = step!("new", StorageProviderSyncRootInfo::new());
     step!("SetId", info.SetId(&HSTRING::from(&id)));
-    let op = step!("GetFolderFromPathAsync", StorageFolder::GetFolderFromPathAsync(&HSTRING::from(folder)));
+    let op = step!(
+        "GetFolderFromPathAsync",
+        StorageFolder::GetFolderFromPathAsync(&HSTRING::from(folder))
+    );
     let hfolder = step!("GetFolder.get", op.get());
     step!("SetPath", info.SetPath(&hfolder));
-    step!("SetDisplayNameResource", info.SetDisplayNameResource(&HSTRING::from("DropboxSync")));
+    step!(
+        "SetDisplayNameResource",
+        info.SetDisplayNameResource(&HSTRING::from("DropboxSync"))
+    );
     if let Some(icon) = icon_spec() {
-        step!("SetIconResource", info.SetIconResource(&HSTRING::from(icon)));
+        step!(
+            "SetIconResource",
+            info.SetIconResource(&HSTRING::from(icon))
+        );
     }
-    step!("SetHydrationPolicy", info.SetHydrationPolicy(StorageProviderHydrationPolicy::Full));
+    step!(
+        "SetHydrationPolicy",
+        info.SetHydrationPolicy(StorageProviderHydrationPolicy::Full)
+    );
     // Let the platform dehydrate unpinned in-sync files (and let us call
     // CfDehydratePlaceholder directly) — required for on-demand / the cloud icon
     // (DBSYNC-59). Only affects UNPINNED files, so DBSYNC-41's pinned files (and the
     // status column) are unchanged.
     step!(
         "SetHydrationPolicyModifier",
-        info.SetHydrationPolicyModifier(StorageProviderHydrationPolicyModifier::AutoDehydrationAllowed)
+        info.SetHydrationPolicyModifier(
+            StorageProviderHydrationPolicyModifier::AutoDehydrationAllowed
+        )
     );
-    step!("SetPopulationPolicy", info.SetPopulationPolicy(StorageProviderPopulationPolicy::AlwaysFull));
+    step!(
+        "SetPopulationPolicy",
+        info.SetPopulationPolicy(StorageProviderPopulationPolicy::AlwaysFull)
+    );
     step!("SetProviderId", info.SetProviderId(PROVIDER_ID));
     step!("SetVersion", info.SetVersion(&HSTRING::from("1.0.0.0")));
     // Context is a required provider-defined blob; a small non-empty buffer suffices.
-    let ctx = step!("CreateContext", CryptographicBuffer::CreateFromByteArray(b"DropboxSync"));
+    let ctx = step!(
+        "CreateContext",
+        CryptographicBuffer::CreateFromByteArray(b"DropboxSync")
+    );
     step!("SetContext", info.SetContext(&ctx));
     // Clear any stale/partial registration for this id first, so a leftover entry
     // (e.g. one whose nav-pane node was stripped by `enable-status-column`, or a
@@ -1758,13 +1840,17 @@ fn apply_file_state(abs: &Path, is_synced: bool, reconvert: bool) -> bool {
         let revert = if reconvert {
             // Best-effort: strips a stale/orphaned placeholder identity. Errors
             // (e.g. plain file, or already ours) are harmless — we convert next.
-            format!("{:?}", CfRevertPlaceholder(handle, CF_REVERT_FLAG_NONE, None))
+            format!(
+                "{:?}",
+                CfRevertPlaceholder(handle, CF_REVERT_FLAG_NONE, None)
+            )
         } else {
             "skip".into()
         };
         // Convert if not already a placeholder (ignore "already a placeholder").
         // Keeps the file's bytes — no download.
-        let conv = CfConvertToPlaceholder(handle, None, 0, CF_CONVERT_FLAG_MARK_IN_SYNC, None, None);
+        let conv =
+            CfConvertToPlaceholder(handle, None, 0, CF_CONVERT_FLAG_MARK_IN_SYNC, None, None);
         // Pin so the platform never dehydrates it — our `.cloudsc` menu owns freeing
         // space, and we keep NO live provider connection, so a dehydrated placeholder
         // here would be UNRECOVERABLE (no fetch handler to re-download it). If pinning

--- a/apps/desktop/src-tauri/src/cloudsc_ops.rs
+++ b/apps/desktop/src-tauri/src/cloudsc_ops.rs
@@ -11,9 +11,7 @@ use crate::cloudsc::{
 };
 use crate::dropbox_transfer::{delete_remote_file_internal, download_remote_file_internal};
 use crate::error::{AppError, AppResult};
-use crate::models::{
-    CloudscMeta, CloudscPlaceholderInfo, DropboxListFolderResponse,
-};
+use crate::models::{CloudscMeta, CloudscPlaceholderInfo, DropboxListFolderResponse};
 use crate::path_util::{
     hash_file, is_ignored_local_path, is_path_allowed, normalize_dropbox_path, parse_prefix_csv,
     relpath_under, safe_join,
@@ -88,7 +86,9 @@ pub(crate) fn index_remote_folder_children_as_cloudsc_placeholders_internal(
             .map_err(|e| AppError::Network(format!("list_folder request failed: {e}")))?;
         if !response.status().is_success() {
             let status = response.status();
-            let body = response.text().unwrap_or_else(|_| "<unreadable body>".to_string());
+            let body = response
+                .text()
+                .unwrap_or_else(|_| "<unreadable body>".to_string());
             // A local directory with no Dropbox counterpart (e.g. a local-only
             // folder pending upload) is not an error for this indexer — it simply
             // has nothing to placeholder. Don't spam the log or fail the sweep.
@@ -192,8 +192,15 @@ pub(crate) fn index_remote_folder_children_as_cloudsc_placeholders_internal(
                                 .map(crate::remote_index::parse_rfc3339_ts_to_unix)
                                 .unwrap_or(0);
                             if create_remote_only_placeholder(
-                                state, local_dir, &child_name, &relative, &path_display, ch, rv,
-                                sz, mts,
+                                state,
+                                local_dir,
+                                &child_name,
+                                &relative,
+                                &path_display,
+                                ch,
+                                rv,
+                                sz,
+                                mts,
                             ) {
                                 created += 1;
                                 created_names.push(child_name.clone());
@@ -273,7 +280,9 @@ pub(crate) fn index_remote_folder_children_as_cloudsc_placeholders_internal(
             .map_err(|e| AppError::Network(format!("list_folder/continue request failed: {e}")))?;
         if !response.status().is_success() {
             let status = response.status();
-            let body = response.text().unwrap_or_else(|_| "<unreadable body>".to_string());
+            let body = response
+                .text()
+                .unwrap_or_else(|_| "<unreadable body>".to_string());
             return Err(AppError::Dropbox {
                 status: status.as_u16(),
                 message: format!("list_folder/continue for {remote_folder_path_display}: {body}"),
@@ -290,8 +299,8 @@ pub(crate) fn index_remote_folder_children_as_cloudsc_placeholders_internal(
     // (any list error returns earlier), so a failed/partial listing never deletes
     // placeholders. Hydrated content (real files/dirs) is untouched — only
     // `.cloudsc` files are considered.
-    for dir_entry in
-        fs::read_dir(local_dir).map_err(|e| AppError::Io(format!("failed reading local dir: {e}")))?
+    for dir_entry in fs::read_dir(local_dir)
+        .map_err(|e| AppError::Io(format!("failed reading local dir: {e}")))?
     {
         let dir_entry = match dir_entry {
             Ok(e) => e,
@@ -352,10 +361,16 @@ fn create_remote_only_placeholder(
     ) {
         return false;
     }
-    if let Err(e) = state.db.upsert_local_file(rel, content_hash, size, modified_ts) {
+    if let Err(e) = state
+        .db
+        .upsert_local_file(rel, content_hash, size, modified_ts)
+    {
         tracing::warn!(rel, error = %e, "remote-only placeholder: local index upsert failed");
     }
-    if let Err(e) = state.db.upsert_remote_file(rel, content_hash, rev, modified_ts) {
+    if let Err(e) = state
+        .db
+        .upsert_remote_file(rel, content_hash, rev, modified_ts)
+    {
         tracing::warn!(rel, error = %e, "remote-only placeholder: remote index upsert failed");
     }
     true
@@ -503,13 +518,16 @@ pub(crate) fn index_materialized_folders_as_cloudsc_placeholders_internal(
         .map_err(|e| AppError::Io(format!("failed creating sync folder: {e}")))?;
 
     let mut created = 0usize;
-    for entry in WalkDir::new(&sync_folder).into_iter().filter_map(|e| e.ok()) {
+    for entry in WalkDir::new(&sync_folder)
+        .into_iter()
+        .filter_map(|e| e.ok())
+    {
         if !entry.file_type().is_dir() {
             continue;
         }
         let dir = entry.path();
         let rel = relpath_under(&sync_folder, dir)?; // "" for the sync root itself
-        // "" for root, "/Cocina", ...; a malformed path skips this folder only.
+                                                     // "" for root, "/Cocina", ...; a malformed path skips this folder only.
         let remote_path = match normalize_dropbox_path(&rel) {
             Ok(p) => p,
             Err(e) => {
@@ -517,11 +535,16 @@ pub(crate) fn index_materialized_folders_as_cloudsc_placeholders_internal(
                 continue;
             }
         };
-        match index_remote_folder_children_as_cloudsc_placeholders_internal(state, &remote_path, dir)
-        {
+        match index_remote_folder_children_as_cloudsc_placeholders_internal(
+            state,
+            &remote_path,
+            dir,
+        ) {
             Ok(n) => created += n,
             // One unreadable folder must not abort the whole sweep.
-            Err(e) => tracing::error!(remote_path = %remote_path, error = %e, "index remote folder failed"),
+            Err(e) => {
+                tracing::error!(remote_path = %remote_path, error = %e, "index remote folder failed")
+            }
         }
     }
 
@@ -848,7 +871,12 @@ fn dehydrate_one_file_cfapi(state: &AppState, root: &Path, rel: &str) -> AppResu
     let name = name.to_string_lossy().to_string();
 
     dehydrate_file_atomic(state, rel, &abs, &row, || {
-        crate::cloud_filter::create_dehydrated_placeholder(parent, &name, &remote_path, row.size_bytes)
+        crate::cloud_filter::create_dehydrated_placeholder(
+            parent,
+            &name,
+            &remote_path,
+            row.size_bytes,
+        )
     })
 }
 
@@ -1007,7 +1035,11 @@ pub(crate) fn recover_stray_dehydrate_asides(state: &AppState) -> AppResult<usiz
 /// on a partial enumeration). The full subtree is enumerated BEFORE any mutation so a
 /// remove+recreate never perturbs the in-flight walk. Returns the freed rels.
 #[cfg(windows)]
-fn dehydrate_folder_cfapi(state: &AppState, root: &Path, folder_rel: &str) -> AppResult<Vec<String>> {
+fn dehydrate_folder_cfapi(
+    state: &AppState,
+    root: &Path,
+    folder_rel: &str,
+) -> AppResult<Vec<String>> {
     if folder_rel.is_empty() {
         return Err(AppError::Sync(
             "cannot free up space on the sync root itself".to_string(),
@@ -1283,9 +1315,7 @@ fn probe_remote_folder_empty(state: &AppState, rel: &str) -> AppResult<RemoteFol
             "include_deleted": false
         }))
         .send()
-        .map_err(|e| {
-            AppError::Network(format!("list_folder (prune probe) request failed: {e}"))
-        })?;
+        .map_err(|e| AppError::Network(format!("list_folder (prune probe) request failed: {e}")))?;
 
     if !response.status().is_success() {
         let status = response.status();
@@ -1549,9 +1579,15 @@ mod tests {
         let sync = tmp.path().join("synced");
         let state = build_state(&sync);
         std::fs::write(sync.join("b.txt"), b"local edit").unwrap();
-        state.db.upsert_local_file("b.txt", "LOCALHASH", 10, 0).unwrap();
+        state
+            .db
+            .upsert_local_file("b.txt", "LOCALHASH", 10, 0)
+            .unwrap();
         // Remote hash differs → the local copy has unsynced changes.
-        state.db.upsert_remote_file("b.txt", "REMOTEHASH", "rev", 0).unwrap();
+        state
+            .db
+            .upsert_remote_file("b.txt", "REMOTEHASH", "rev", 0)
+            .unwrap();
 
         let err = dehydrate_path_internal(&state, "b.txt").unwrap_err();
         assert!(format!("{err}").contains("not fully synced"), "got: {err}");
@@ -1569,8 +1605,14 @@ mod tests {
         // bytes were edited after the last index (watcher hasn't caught up). The
         // authoritative re-hash must catch this and refuse — never lose the edit.
         std::fs::write(sync.join("d.txt"), b"edited after the last index update").unwrap();
-        state.db.upsert_local_file("d.txt", "STALE_SYNCED", 5, 0).unwrap();
-        state.db.upsert_remote_file("d.txt", "STALE_SYNCED", "rev", 0).unwrap();
+        state
+            .db
+            .upsert_local_file("d.txt", "STALE_SYNCED", 5, 0)
+            .unwrap();
+        state
+            .db
+            .upsert_remote_file("d.txt", "STALE_SYNCED", "rev", 0)
+            .unwrap();
 
         let err = dehydrate_path_internal(&state, "d.txt").unwrap_err();
         assert!(format!("{err}").contains("not fully synced"), "got: {err}");
@@ -1613,7 +1655,10 @@ mod tests {
         std::fs::create_dir_all(abs.parent().unwrap()).unwrap();
         std::fs::write(&abs, bytes).unwrap();
         let (h, _, _) = hash_file(&abs).unwrap();
-        state.db.upsert_local_file(rel, &h, bytes.len() as i64, 0).unwrap();
+        state
+            .db
+            .upsert_local_file(rel, &h, bytes.len() as i64, 0)
+            .unwrap();
         state.db.upsert_remote_file(rel, &h, "rev", 0).unwrap();
     }
 
@@ -1629,7 +1674,10 @@ mod tests {
 
         let n = dehydrate_path_internal(&state, "dir").unwrap();
         assert_eq!(n, 1);
-        assert!(!sync.join("dir").exists(), "the whole local subtree is freed");
+        assert!(
+            !sync.join("dir").exists(),
+            "the whole local subtree is freed"
+        );
         assert!(
             sync.join("dir.cloudsc").exists(),
             "one folder-level placeholder written"
@@ -1653,8 +1701,14 @@ mod tests {
         track_synced_file(&state, &sync, "dir/ok.txt", b"ok");
         // An unsynced sibling (on-disk bytes hash != remote hash).
         std::fs::write(sync.join("dir/edited.txt"), b"local only").unwrap();
-        state.db.upsert_local_file("dir/edited.txt", "LOCAL", 10, 0).unwrap();
-        state.db.upsert_remote_file("dir/edited.txt", "REMOTE", "rev", 0).unwrap();
+        state
+            .db
+            .upsert_local_file("dir/edited.txt", "LOCAL", 10, 0)
+            .unwrap();
+        state
+            .db
+            .upsert_remote_file("dir/edited.txt", "REMOTE", "rev", 0)
+            .unwrap();
 
         let err = dehydrate_path_internal(&state, "dir").unwrap_err();
         assert!(format!("{err}").contains("unsynced"), "got: {err}");
@@ -1780,9 +1834,15 @@ mod tests {
             "must not collapse while an ignored file remains"
         );
         assert!(sync.join("dir").is_dir(), "folder kept");
-        assert!(sync.join("dir/.DS_Store").exists(), "ignored file preserved");
+        assert!(
+            sync.join("dir/.DS_Store").exists(),
+            "ignored file preserved"
+        );
         assert!(!sync.join("dir/a.txt").exists());
-        assert!(sync.join("dir/a.txt.cloudsc").exists(), "freed file → per-file placeholder");
+        assert!(
+            sync.join("dir/a.txt.cloudsc").exists(),
+            "freed file → per-file placeholder"
+        );
     }
 
     #[test]
@@ -1798,8 +1858,14 @@ mod tests {
         let n = dehydrate_path_internal(&state, "dir").unwrap();
 
         assert_eq!(n, 1);
-        assert!(!sync.join("dir").exists(), "subtree freed incl. the .cloudsc child");
-        assert!(sync.join("dir.cloudsc").exists(), "collapsed to one folder placeholder");
+        assert!(
+            !sync.join("dir").exists(),
+            "subtree freed incl. the .cloudsc child"
+        );
+        assert!(
+            sync.join("dir.cloudsc").exists(),
+            "collapsed to one folder placeholder"
+        );
         let meta = read_cloudsc_placeholder_file(&sync.join("dir.cloudsc")).unwrap();
         assert_eq!(meta.tag, "folder");
     }
@@ -1862,7 +1928,10 @@ mod tests {
             !sync.join("gone.txt.dbsync-dehydrate.tmp").exists(),
             "aside copy must be dropped on success"
         );
-        assert!(abs.exists(), "the placeholder file (created by the closure) is present");
+        assert!(
+            abs.exists(),
+            "the placeholder file (created by the closure) is present"
+        );
         assert!(
             state.db.get_local_file("gone.txt").unwrap().is_some(),
             "row must be re-tracked with the original hash on success"
@@ -1884,7 +1953,11 @@ mod tests {
         let sync = tmp.path().join("synced");
         let state = build_state(&sync);
         let content = b"only surviving copy, crash happened before placeholder create";
-        std::fs::write(sync.join(format!("foo.txt{DEHYDRATE_ASIDE_SUFFIX}")), content).unwrap();
+        std::fs::write(
+            sync.join(format!("foo.txt{DEHYDRATE_ASIDE_SUFFIX}")),
+            content,
+        )
+        .unwrap();
 
         let n = recover_stray_dehydrate_asides(&state).unwrap();
 
@@ -1896,7 +1969,9 @@ mod tests {
             "recovered file must have the aside's content"
         );
         assert!(
-            !sync.join(format!("foo.txt{DEHYDRATE_ASIDE_SUFFIX}")).exists(),
+            !sync
+                .join(format!("foo.txt{DEHYDRATE_ASIDE_SUFFIX}"))
+                .exists(),
             "aside must be gone after recovery"
         );
     }
@@ -1924,7 +1999,9 @@ mod tests {
             "the existing original must be left untouched"
         );
         assert!(
-            !sync.join(format!("bar.txt{DEHYDRATE_ASIDE_SUFFIX}")).exists(),
+            !sync
+                .join(format!("bar.txt{DEHYDRATE_ASIDE_SUFFIX}"))
+                .exists(),
             "stale aside must be removed"
         );
     }

--- a/apps/desktop/src-tauri/src/commands.rs
+++ b/apps/desktop/src-tauri/src/commands.rs
@@ -467,9 +467,7 @@ pub fn resolve_conflict(
 /// deletion and confirmed it is an intentional bulk delete.
 #[tauri::command]
 pub fn confirm_pending_deletions(state: tauri::State<AppState>) -> Result<(), String> {
-    state
-        .db
-        .set_app_config("mass_delete_override_once", "1")?;
+    state.db.set_app_config("mass_delete_override_once", "1")?;
     Ok(())
 }
 

--- a/apps/desktop/src-tauri/src/dropbox_transfer.rs
+++ b/apps/desktop/src-tauri/src/dropbox_transfer.rs
@@ -142,7 +142,11 @@ fn retry_transient<T>(
 /// download; deliberately does NOT touch the DB index, the sync-root target path,
 /// or the conflict guard (that is `download_remote_file_internal`'s job).
 #[cfg(windows)]
-pub(crate) fn download_to_path(state: &AppState, path_display: &str, target: &Path) -> AppResult<()> {
+pub(crate) fn download_to_path(
+    state: &AppState,
+    path_display: &str,
+    target: &Path,
+) -> AppResult<()> {
     let token = get_access_token(state)?;
     fetch_and_write_file(&state.http_client, &token, path_display, target)
 }
@@ -158,7 +162,10 @@ fn fetch_and_write_file(
             .map_err(|e| AppError::Io(format!("failed to create parent directory: {e}")))?;
     }
 
-    let file_name = target.file_name().map(|n| n.to_string_lossy().to_string()).unwrap_or_default();
+    let file_name = target
+        .file_name()
+        .map(|n| n.to_string_lossy().to_string())
+        .unwrap_or_default();
     let temp = target.with_file_name(format!(
         "{file_name}.dropboxsync-tmp-{}-{}",
         std::process::id(),
@@ -190,7 +197,9 @@ fn fetch_and_write_file(
 
     if !download_resp.status().is_success() {
         let status = download_resp.status();
-        let body = download_resp.text().unwrap_or_else(|_| "<unreadable body>".to_string());
+        let body = download_resp
+            .text()
+            .unwrap_or_else(|_| "<unreadable body>".to_string());
         return Err(AppError::Dropbox {
             status: status.as_u16(),
             message: format!("download for {path_display}: {body}"),
@@ -281,7 +290,9 @@ pub(crate) fn list_remote_folder(
 
     if !response.status().is_success() {
         let status = response.status();
-        let body = response.text().unwrap_or_else(|_| "<unreadable body>".to_string());
+        let body = response
+            .text()
+            .unwrap_or_else(|_| "<unreadable body>".to_string());
         return Err(AppError::Dropbox {
             status: status.as_u16(),
             message: format!("list_folder: {body}"),
@@ -351,7 +362,10 @@ fn start_upload_session(client: &Client, token: &str) -> AppResult<String> {
     let resp = client
         .post("https://content.dropboxapi.com/2/files/upload_session/start")
         .bearer_auth(token)
-        .header("Dropbox-API-Arg", serde_json::json!({ "close": false }).to_string())
+        .header(
+            "Dropbox-API-Arg",
+            serde_json::json!({ "close": false }).to_string(),
+        )
         .header("Content-Type", "application/octet-stream")
         .body(Vec::<u8>::new())
         .timeout(Duration::from_secs(120))
@@ -365,7 +379,9 @@ fn start_upload_session(client: &Client, token: &str) -> AppResult<String> {
 
     if !resp.status().is_success() {
         let status = resp.status();
-        let body = resp.text().unwrap_or_else(|_| "<unreadable body>".to_string());
+        let body = resp
+            .text()
+            .unwrap_or_else(|_| "<unreadable body>".to_string());
         return Err(AppError::Dropbox {
             status: status.as_u16(),
             message: format!("upload_session/start: {body}"),
@@ -411,7 +427,9 @@ fn append_upload_chunk(
 
     if !resp.status().is_success() {
         let status = resp.status();
-        let body = resp.text().unwrap_or_else(|_| "<unreadable body>".to_string());
+        let body = resp
+            .text()
+            .unwrap_or_else(|_| "<unreadable body>".to_string());
         return Err(AppError::Dropbox {
             status: status.as_u16(),
             message: format!("upload_session/append_v2: {body}"),
@@ -458,7 +476,9 @@ fn finish_upload_session(
 
     if !resp.status().is_success() {
         let status = resp.status();
-        let body = resp.text().unwrap_or_else(|_| "<unreadable body>".to_string());
+        let body = resp
+            .text()
+            .unwrap_or_else(|_| "<unreadable body>".to_string());
         return Err(AppError::Dropbox {
             status: status.as_u16(),
             message: format!("upload_session/finish: {body}"),
@@ -558,7 +578,11 @@ fn emit_transfer_progress(event_name: &'static str, path: &str, transferred: u64
         total,
     };
 
-    match handle.emit_to(EventTarget::webview_window("main"), event_name, event.clone()) {
+    match handle.emit_to(
+        EventTarget::webview_window("main"),
+        event_name,
+        event.clone(),
+    ) {
         Ok(()) => {}
         Err(e) => {
             tracing::error!(error = %e, event = event_name, "emit_to webview_window(main) failed");
@@ -583,7 +607,11 @@ fn emit_sync_conflict(path: &str, conflict_path: &str, reason: &str) {
         reason: reason.to_string(),
     };
 
-    match handle.emit_to(EventTarget::webview_window("main"), "sync-conflict", event.clone()) {
+    match handle.emit_to(
+        EventTarget::webview_window("main"),
+        "sync-conflict",
+        event.clone(),
+    ) {
         Ok(()) => {}
         Err(e) => {
             tracing::error!(error = %e, "emit_to webview_window(main) failed");
@@ -672,7 +700,9 @@ fn upload_via_session(
         .unwrap_or(0);
 
     let (mut session_id, mut offset) = match state.db.get_upload_checkpoint(job_id)? {
-        Some((sid, off, ck_len, ck_mtime)) if off <= len && ck_len == len && ck_mtime == file_mtime => {
+        Some((sid, off, ck_len, ck_mtime))
+            if off <= len && ck_len == len && ck_mtime == file_mtime =>
+        {
             file.seek(SeekFrom::Start(off))
                 .map_err(|e| AppError::Io(format!("failed seeking to resume upload: {e}")))?;
             (sid, off)
@@ -740,7 +770,14 @@ fn upload_via_session(
         if is_final_chunk(offset, n, len) {
             let chunk_offset = offset;
             let result = retry_transient("upload_session/finish", 4, || {
-                finish_upload_session(client, token, &session_id, chunk_offset, dropbox_path, &buf[..n])
+                finish_upload_session(
+                    client,
+                    token,
+                    &session_id,
+                    chunk_offset,
+                    dropbox_path,
+                    &buf[..n],
+                )
             });
             match result {
                 Ok(()) => {
@@ -775,9 +812,13 @@ fn upload_via_session(
             match result {
                 Ok(()) => {
                     offset += n as u64;
-                    state
-                        .db
-                        .save_upload_checkpoint(job_id, &session_id, offset, len, file_mtime)?;
+                    state.db.save_upload_checkpoint(
+                        job_id,
+                        &session_id,
+                        offset,
+                        len,
+                        file_mtime,
+                    )?;
                     emit_upload_progress(dropbox_path, offset, len);
                 }
                 Err(e) if !restarted && e.is_session_invalid() => {
@@ -909,7 +950,9 @@ pub(crate) fn upload_local_file_internal(
 
             if !resp.status().is_success() {
                 let status = resp.status();
-                let body = resp.text().unwrap_or_else(|_| "<unreadable body>".to_string());
+                let body = resp
+                    .text()
+                    .unwrap_or_else(|_| "<unreadable body>".to_string());
                 return Err(AppError::Dropbox {
                     status: status.as_u16(),
                     message: format!("upload for {dropbox_path}: {body}"),
@@ -986,7 +1029,9 @@ pub(crate) fn delete_remote_file_internal(
 
     if !resp.status().is_success() {
         let status = resp.status();
-        let body = resp.text().unwrap_or_else(|_| "<unreadable body>".to_string());
+        let body = resp
+            .text()
+            .unwrap_or_else(|_| "<unreadable body>".to_string());
         if matches!(
             classify_delete_response(false, &body),
             DeleteOutcome::AlreadyGoneOrConflict
@@ -1096,12 +1141,15 @@ pub(crate) fn download_remote_file_internal(state: &AppState, path_display: &str
     // The downloaded content hash IS the Dropbox content_hash (DBSYNC-9), which
     // is exactly what the deletion / should-download checks compare, so the row
     // is correct even if the best-effort metadata fetch (for rev/mtime) fails.
-    let (rev, remote_mtime) = match crate::remote_index::fetch_remote_file_metadata(state, &relative)
+    let (rev, remote_mtime) =
+        match crate::remote_index::fetch_remote_file_metadata(state, &relative) {
+            Ok(Some(meta)) => (meta.rev, meta.modified_ts),
+            _ => (String::new(), modified_ts),
+        };
+    if let Err(e) = state
+        .db
+        .upsert_remote_file(&relative, &hash, &rev, remote_mtime)
     {
-        Ok(Some(meta)) => (meta.rev, meta.modified_ts),
-        _ => (String::new(), modified_ts),
-    };
-    if let Err(e) = state.db.upsert_remote_file(&relative, &hash, &rev, remote_mtime) {
         tracing::warn!(file_path = %relative, error = %e, "failed recording remote provenance after hydrate");
     }
     Ok(())
@@ -1120,7 +1168,8 @@ pub(crate) fn hydrate_remote_folder_internal(
     let include_prefixes = parse_prefix_csv(state.db.get_include_prefixes_csv()?);
     let exclude_prefixes = parse_prefix_csv(state.db.get_exclude_prefixes_csv()?);
 
-    fs::create_dir_all(&folder).map_err(|e| AppError::Io(format!("failed to create sync folder: {e}")))?;
+    fs::create_dir_all(&folder)
+        .map_err(|e| AppError::Io(format!("failed to create sync folder: {e}")))?;
 
     let client = &state.http_client;
     let mut downloaded = 0usize;
@@ -1143,7 +1192,9 @@ pub(crate) fn hydrate_remote_folder_internal(
 
     if !response.status().is_success() {
         let status = response.status();
-        let body = response.text().unwrap_or_else(|_| "<unreadable body>".to_string());
+        let body = response
+            .text()
+            .unwrap_or_else(|_| "<unreadable body>".to_string());
         return Err(AppError::Dropbox {
             status: status.as_u16(),
             message: format!("list_folder for {folder_path_display}: {body}"),
@@ -1178,7 +1229,9 @@ pub(crate) fn hydrate_remote_folder_internal(
             fetch_and_write_file(client, &token, path_display, &target)?;
 
             let (hash, size_bytes, modified_ts) = hash_file(&target)?;
-            state.db.upsert_local_file(&relative, &hash, size_bytes, modified_ts)?;
+            state
+                .db
+                .upsert_local_file(&relative, &hash, size_bytes, modified_ts)?;
             downloaded += 1;
         }
 
@@ -1219,7 +1272,8 @@ pub(crate) fn pull_remote_snapshot_internal(state: &AppState) -> AppResult<usize
         .db
         .get_sync_folder()?
         .ok_or_else(|| AppError::Sync("sync folder not configured".to_string()))?;
-    fs::create_dir_all(&folder).map_err(|e| AppError::Io(format!("failed to create sync folder: {e}")))?;
+    fs::create_dir_all(&folder)
+        .map_err(|e| AppError::Io(format!("failed to create sync folder: {e}")))?;
 
     let client = &state.http_client;
     let mut downloaded = 0usize;
@@ -1247,7 +1301,9 @@ pub(crate) fn pull_remote_snapshot_internal(state: &AppState) -> AppResult<usize
         })?;
     if !list_folder_resp.status().is_success() {
         let status = list_folder_resp.status();
-        let body = list_folder_resp.text().unwrap_or_else(|_| "<unreadable body>".to_string());
+        let body = list_folder_resp
+            .text()
+            .unwrap_or_else(|_| "<unreadable body>".to_string());
         return Err(AppError::Dropbox {
             status: status.as_u16(),
             message: format!("list_folder: {body}"),
@@ -1304,7 +1360,9 @@ pub(crate) fn pull_remote_snapshot_internal(state: &AppState) -> AppResult<usize
             })?;
         if !continue_resp.status().is_success() {
             let status = continue_resp.status();
-            let body = continue_resp.text().unwrap_or_else(|_| "<unreadable body>".to_string());
+            let body = continue_resp
+                .text()
+                .unwrap_or_else(|_| "<unreadable body>".to_string());
             return Err(AppError::Dropbox {
                 status: status.as_u16(),
                 message: format!("list_folder/continue: {body}"),
@@ -1428,10 +1486,7 @@ mod tests {
 
     #[test]
     fn classify_delete_response_success_is_deleted() {
-        assert_eq!(
-            classify_delete_response(true, ""),
-            DeleteOutcome::Deleted
-        );
+        assert_eq!(classify_delete_response(true, ""), DeleteOutcome::Deleted);
     }
 
     #[test]
@@ -1618,7 +1673,11 @@ mod tests {
     #[test]
     fn download_would_conflict_false_when_target_absent() {
         assert!(!download_would_conflict(false, "on-disk-hash", None));
-        assert!(!download_would_conflict(false, "on-disk-hash", Some("baseline-hash")));
+        assert!(!download_would_conflict(
+            false,
+            "on-disk-hash",
+            Some("baseline-hash")
+        ));
     }
 
     #[test]
@@ -1628,12 +1687,20 @@ mod tests {
 
     #[test]
     fn download_would_conflict_false_when_hash_matches_baseline() {
-        assert!(!download_would_conflict(true, "same-hash", Some("same-hash")));
+        assert!(!download_would_conflict(
+            true,
+            "same-hash",
+            Some("same-hash")
+        ));
     }
 
     #[test]
     fn download_would_conflict_true_when_hash_diverges() {
-        assert!(download_would_conflict(true, "local-hash", Some("baseline-hash")));
+        assert!(download_would_conflict(
+            true,
+            "local-hash",
+            Some("baseline-hash")
+        ));
     }
 
     #[test]
@@ -1648,7 +1715,8 @@ mod tests {
 
         // A sibling with DIFFERENT content does not count as a dedup match.
         std::fs::write(
-            dir.path().join("report (conflicted copy 20260101000000).txt"),
+            dir.path()
+                .join("report (conflicted copy 20260101000000).txt"),
             b"some other content",
         )
         .expect("write other copy");
@@ -1656,7 +1724,8 @@ mod tests {
 
         // A sibling holding the SAME content as the target dedupes (retry case).
         std::fs::write(
-            dir.path().join("report (conflicted copy 20260101000005).txt"),
+            dir.path()
+                .join("report (conflicted copy 20260101000005).txt"),
             b"local edit",
         )
         .expect("write matching copy");
@@ -1667,7 +1736,8 @@ mod tests {
     fn is_session_invalid_error_detects_known_markers() {
         assert!(AppError::Dropbox {
             status: 409,
-            message: "upload_session/append_v2: {\"error\": {\".tag\": \"lookup_failed\"}}".to_string()
+            message: "upload_session/append_v2: {\"error\": {\".tag\": \"lookup_failed\"}}"
+                .to_string()
         }
         .is_session_invalid());
         assert!(AppError::Dropbox {
@@ -1693,7 +1763,9 @@ mod tests {
         // must NOT be treated as session-invalid.
         assert!(!AppError::Dropbox {
             status: 409,
-            message: "upload_session/finish: {\"error_summary\": \"too_many_write_operations/...\"}".to_string()
+            message:
+                "upload_session/finish: {\"error_summary\": \"too_many_write_operations/...\"}"
+                    .to_string()
         }
         .is_session_invalid());
     }

--- a/apps/desktop/src-tauri/src/finder_extension.rs
+++ b/apps/desktop/src-tauri/src/finder_extension.rs
@@ -173,7 +173,9 @@ fn log_diagnostics_once(enabled: bool) {
                     "<none>".to_string()
                 } else {
                     let utf8: *const std::ffi::c_char = msg_send![ident, UTF8String];
-                    std::ffi::CStr::from_ptr(utf8).to_string_lossy().into_owned()
+                    std::ffi::CStr::from_ptr(utf8)
+                        .to_string_lossy()
+                        .into_owned()
                 }
             })
         }
@@ -303,7 +305,10 @@ mod tests {
     #[cfg(not(target_os = "macos"))]
     #[test]
     fn non_macos_is_not_applicable_never_disabled() {
-        assert_eq!(finder_extension_state(), FinderExtensionState::NotApplicable);
+        assert_eq!(
+            finder_extension_state(),
+            FinderExtensionState::NotApplicable
+        );
     }
 
     /// On macOS the call must return *something* without panicking, whatever the user's
@@ -351,7 +356,10 @@ mod tests {
         assert_eq!(wire(FinderExtensionState::Enabled), "\"enabled\"");
         assert_eq!(wire(FinderExtensionState::Disabled), "\"disabled\"");
         assert_eq!(wire(FinderExtensionState::Translocated), "\"translocated\"");
-        assert_eq!(wire(FinderExtensionState::NotApplicable), "\"notApplicable\"");
+        assert_eq!(
+            wire(FinderExtensionState::NotApplicable),
+            "\"notApplicable\""
+        );
     }
 
     /// The exact path the instrumented build logged on the machine that reproduced DBSYNC-88.

--- a/apps/desktop/src-tauri/src/flyout_geometry.rs
+++ b/apps/desktop/src-tauri/src/flyout_geometry.rs
@@ -89,8 +89,16 @@ fn clamp_into(x: f64, y: f64, m: MonitorBox, win_w: f64, win_h: f64) -> (f64, f6
     let min_y = m.y;
     let max_y = m.y + m.height - win_h;
 
-    let cx = if max_x >= min_x { x.clamp(min_x, max_x) } else { min_x };
-    let cy = if max_y >= min_y { y.clamp(min_y, max_y) } else { min_y };
+    let cx = if max_x >= min_x {
+        x.clamp(min_x, max_x)
+    } else {
+        min_x
+    };
+    let cy = if max_y >= min_y {
+        y.clamp(min_y, max_y)
+    } else {
+        min_y
+    };
     (cx, cy)
 }
 
@@ -101,8 +109,18 @@ mod tests {
     // Two 1440x900@2x displays side by side, primary on the left. Physical pixels.
     fn side_by_side() -> Vec<MonitorBox> {
         vec![
-            MonitorBox { x: 0.0, y: 0.0, width: 2880.0, height: 1800.0 },
-            MonitorBox { x: 2880.0, y: 0.0, width: 2880.0, height: 1800.0 },
+            MonitorBox {
+                x: 0.0,
+                y: 0.0,
+                width: 2880.0,
+                height: 1800.0,
+            },
+            MonitorBox {
+                x: 2880.0,
+                y: 0.0,
+                width: 2880.0,
+                height: 1800.0,
+            },
         ]
     }
 
@@ -111,8 +129,18 @@ mod tests {
     // is testable on a machine with one display.
     fn stacked() -> Vec<MonitorBox> {
         vec![
-            MonitorBox { x: 0.0, y: 0.0, width: 2880.0, height: 1800.0 },
-            MonitorBox { x: 0.0, y: -1800.0, width: 2880.0, height: 1800.0 },
+            MonitorBox {
+                x: 0.0,
+                y: 0.0,
+                width: 2880.0,
+                height: 1800.0,
+            },
+            MonitorBox {
+                x: 0.0,
+                y: -1800.0,
+                width: 2880.0,
+                height: 1800.0,
+            },
         ]
     }
 
@@ -153,7 +181,12 @@ mod tests {
     #[cfg(target_os = "macos")]
     #[test]
     fn macos_hangs_the_flyout_below_the_menu_bar() {
-        let tray = TrayRect { x: 1400.0, y: 0.0, width: 44.0, height: 48.0 };
+        let tray = TrayRect {
+            x: 1400.0,
+            y: 0.0,
+            width: 44.0,
+            height: 48.0,
+        };
         let m = side_by_side()[0];
         let (_, y) = flyout_origin(tray, m, 720.0, 1200.0, 16.0);
         assert_eq!(y, 64.0, "below the 48px tray rect plus the 16px gap");
@@ -162,7 +195,12 @@ mod tests {
     #[cfg(not(target_os = "macos"))]
     #[test]
     fn other_platforms_keep_the_bottom_taskbar_anchor() {
-        let tray = TrayRect { x: 1400.0, y: 1752.0, width: 44.0, height: 48.0 };
+        let tray = TrayRect {
+            x: 1400.0,
+            y: 1752.0,
+            width: 44.0,
+            height: 48.0,
+        };
         let m = side_by_side()[0];
         let (_, y) = flyout_origin(tray, m, 720.0, 1200.0, 16.0);
         assert!(y < 1752.0, "the window sits above a bottom taskbar");
@@ -170,7 +208,12 @@ mod tests {
 
     #[test]
     fn the_flyout_is_right_aligned_to_the_icon() {
-        let tray = TrayRect { x: 1400.0, y: 0.0, width: 44.0, height: 48.0 };
+        let tray = TrayRect {
+            x: 1400.0,
+            y: 0.0,
+            width: 44.0,
+            height: 48.0,
+        };
         let m = side_by_side()[0];
         let (x, _) = flyout_origin(tray, m, 720.0, 1200.0, 16.0);
         assert_eq!(x, 1400.0 + 44.0 - 720.0);
@@ -181,7 +224,12 @@ mod tests {
     #[test]
     fn clamping_keeps_the_window_on_the_second_screen() {
         let monitors = side_by_side();
-        let tray = TrayRect { x: 5700.0, y: 0.0, width: 44.0, height: 48.0 };
+        let tray = TrayRect {
+            x: 5700.0,
+            y: 0.0,
+            width: 44.0,
+            height: 48.0,
+        };
         let m = monitor_for_point(&monitors, 5720.0, 20.0).unwrap();
         let (x, _) = flyout_origin(tray, m, 720.0, 1200.0, 16.0);
         assert!(x >= 2880.0, "must not spill onto the primary");
@@ -192,8 +240,18 @@ mod tests {
     /// A crash in the click handler is worse than an awkwardly placed window.
     #[test]
     fn a_window_larger_than_the_display_does_not_panic() {
-        let tiny = MonitorBox { x: 0.0, y: 0.0, width: 400.0, height: 300.0 };
-        let tray = TrayRect { x: 300.0, y: 0.0, width: 44.0, height: 48.0 };
+        let tiny = MonitorBox {
+            x: 0.0,
+            y: 0.0,
+            width: 400.0,
+            height: 300.0,
+        };
+        let tray = TrayRect {
+            x: 300.0,
+            y: 0.0,
+            width: 44.0,
+            height: 48.0,
+        };
         let (x, y) = flyout_origin(tray, tiny, 720.0, 1200.0, 16.0);
         assert_eq!((x, y), (0.0, 0.0));
     }
@@ -211,8 +269,18 @@ mod tests {
     /// module uses invented layouts — this one is the hardware the bug was reported on.
     fn maintainer_layout() -> Vec<MonitorBox> {
         vec![
-            MonitorBox { x: 0.0, y: 0.0, width: 3360.0, height: 2100.0 },
-            MonitorBox { x: -6016.0, y: -1076.0, width: 6016.0, height: 3384.0 },
+            MonitorBox {
+                x: 0.0,
+                y: 0.0,
+                width: 3360.0,
+                height: 2100.0,
+            },
+            MonitorBox {
+                x: -6016.0,
+                y: -1076.0,
+                width: 6016.0,
+                height: 3384.0,
+            },
         ]
     }
 
@@ -275,7 +343,11 @@ mod tests {
         let layout = maintainer_layout();
 
         let m = monitor_for_point(&layout, CLICK_ON_BUILT_IN.0, CLICK_ON_BUILT_IN.1).unwrap();
-        assert_eq!((m.x, m.y), (0.0, 0.0), "click on the built-in must pick the built-in");
+        assert_eq!(
+            (m.x, m.y),
+            (0.0, 0.0),
+            "click on the built-in must pick the built-in"
+        );
 
         let m = monitor_for_point(&layout, CLICK_ON_EXTERNAL.0, CLICK_ON_EXTERNAL.1).unwrap();
         assert_eq!(
@@ -306,7 +378,12 @@ mod tests {
             let monitor = monitor_for_point(&layout, click.0, click.1).unwrap();
             assert_eq!((monitor.x, monitor.y), (expected.x, expected.y));
 
-            let tray = TrayRect { x: click.0, y: expected.y, width: 44.0, height: 48.0 };
+            let tray = TrayRect {
+                x: click.0,
+                y: expected.y,
+                width: 44.0,
+                height: 48.0,
+            };
             let (x, y) = flyout_origin(tray, monitor, win_w, win_h, gap);
 
             assert!(
@@ -325,11 +402,26 @@ mod tests {
     #[test]
     fn a_non_retina_second_display_is_handled_by_its_own_geometry() {
         let monitors = vec![
-            MonitorBox { x: 0.0, y: 0.0, width: 2880.0, height: 1800.0 },
-            MonitorBox { x: 2880.0, y: 0.0, width: 1920.0, height: 1080.0 },
+            MonitorBox {
+                x: 0.0,
+                y: 0.0,
+                width: 2880.0,
+                height: 1800.0,
+            },
+            MonitorBox {
+                x: 2880.0,
+                y: 0.0,
+                width: 1920.0,
+                height: 1080.0,
+            },
         ];
         let m = monitor_for_point(&monitors, 3000.0, 10.0).unwrap();
-        let tray = TrayRect { x: 4700.0, y: 0.0, width: 22.0, height: 24.0 };
+        let tray = TrayRect {
+            x: 4700.0,
+            y: 0.0,
+            width: 22.0,
+            height: 24.0,
+        };
         let (x, _) = flyout_origin(tray, m, 360.0, 600.0, 8.0);
         assert!(x >= 2880.0 && x + 360.0 <= 4800.0);
     }

--- a/apps/desktop/src-tauri/src/fs_watcher.rs
+++ b/apps/desktop/src-tauri/src/fs_watcher.rs
@@ -192,10 +192,7 @@ mod tests {
     #[test]
     fn path_outside_root_maps_to_none() {
         let root = Path::new("/sync/root");
-        assert_eq!(
-            map_event_path(root, root, Path::new("/etc/passwd")),
-            None
-        );
+        assert_eq!(map_event_path(root, root, Path::new("/etc/passwd")), None);
     }
 
     #[test]

--- a/apps/desktop/src-tauri/src/open_handlers.rs
+++ b/apps/desktop/src-tauri/src/open_handlers.rs
@@ -94,9 +94,10 @@ pub(crate) fn handle_cloudsc_paths_from_os(app_handle: &AppHandle, paths: Vec<Pa
     for path in paths {
         match resolve_cloudsc_rel_path(&app_state, &path) {
             Ok(rel) => {
-                if let Err(e) = app_state
-                    .db
-                    .enqueue_job("hydrate_cloudsc", Some(rel.as_str()), None)
+                if let Err(e) =
+                    app_state
+                        .db
+                        .enqueue_job("hydrate_cloudsc", Some(rel.as_str()), None)
                 {
                     tracing::error!(file_path = %rel, error = %e, "enqueue hydrate_cloudsc failed");
                     continue;

--- a/apps/desktop/src-tauri/src/overlay_state.rs
+++ b/apps/desktop/src-tauri/src/overlay_state.rs
@@ -59,7 +59,10 @@ fn active_job_paths(db: &db::Db) -> AppResult<HashSet<String>> {
 }
 
 fn unresolved_conflict_paths(db: &db::Db) -> AppResult<HashSet<String>> {
-    Ok(db.list_unresolved_conflict_local_paths()?.into_iter().collect())
+    Ok(db
+        .list_unresolved_conflict_local_paths()?
+        .into_iter()
+        .collect())
 }
 
 /// Recomputes per-file overlay tiers and atomically writes `overlay_state.json` under [`db::app_data_dir`].

--- a/apps/desktop/src-tauri/src/path_util.rs
+++ b/apps/desktop/src-tauri/src/path_util.rs
@@ -213,11 +213,7 @@ pub(crate) fn normalize_dropbox_path(input: &str) -> AppResult<String> {
 /// NUL byte, and not absolute (no leading `/` or `\`, no drive/UNC prefix).
 /// Used before joining any remote-derived path onto the local sync folder.
 pub(crate) fn validate_relative(rel: &str) -> AppResult<()> {
-    if has_traversal(rel)
-        || is_os_absolute(rel)
-        || rel.starts_with('/')
-        || rel.starts_with('\\')
-    {
+    if has_traversal(rel) || is_os_absolute(rel) || rel.starts_with('/') || rel.starts_with('\\') {
         return Err(AppError::Sync(format!(
             "rejected unsafe relative path: {rel:?}"
         )));
@@ -534,8 +530,7 @@ mod tests {
         let tmp = NamedTempFile::new().expect("tempfile");
         let (hash, size, mtime) = hash_file(tmp.path()).expect("hash_file");
         assert_eq!(
-            hash,
-            "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+            hash, "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
             "empty file must match SHA-256 of empty bytes"
         );
         assert_eq!(size, 0);
@@ -616,11 +611,17 @@ mod tests {
     #[test]
     fn normalize_accepts_legit_paths() {
         assert_eq!(normalize_dropbox_path("").unwrap(), "");
-        assert_eq!(normalize_dropbox_path("Cocina/Pizza").unwrap(), "/Cocina/Pizza");
+        assert_eq!(
+            normalize_dropbox_path("Cocina/Pizza").unwrap(),
+            "/Cocina/Pizza"
+        );
         // A leading '/' is the Dropbox root convention and must be preserved.
         assert_eq!(normalize_dropbox_path("/Cocina").unwrap(), "/Cocina");
         // Windows separators are canonicalised to '/'.
-        assert_eq!(normalize_dropbox_path("Cocina\\Pizza").unwrap(), "/Cocina/Pizza");
+        assert_eq!(
+            normalize_dropbox_path("Cocina\\Pizza").unwrap(),
+            "/Cocina/Pizza"
+        );
     }
 
     #[test]
@@ -657,7 +658,10 @@ mod tests {
             "\\\\unc\\x",
             "x\0y",
         ] {
-            assert!(validate_relative(bad).is_err(), "expected rejection for {bad:?}");
+            assert!(
+                validate_relative(bad).is_err(),
+                "expected rejection for {bad:?}"
+            );
         }
     }
 
@@ -719,6 +723,9 @@ mod tests {
 
         let (_hash, size, mtime) = hash_file(tmp.path()).expect("hash_file");
         assert_eq!(size, content.len() as i64);
-        assert!(mtime > 0, "modified timestamp must be non-zero for a newly created file");
+        assert!(
+            mtime > 0,
+            "modified timestamp must be non-zero for a newly created file"
+        );
     }
 }

--- a/apps/desktop/src-tauri/src/remote_index.rs
+++ b/apps/desktop/src-tauri/src/remote_index.rs
@@ -94,12 +94,14 @@ pub(crate) fn fetch_remote_file_metadata(
             "include_deleted": false
         }))
         .send()
-        .map_err(|e| AppError::Network(format!("get_metadata request failed for {relative}: {e}")))?;
+        .map_err(|e| {
+            AppError::Network(format!("get_metadata request failed for {relative}: {e}"))
+        })?;
 
     if response.status().is_success() {
-        let entry: DropboxEntry = response
-            .json()
-            .map_err(|e| AppError::Other(format!("get_metadata parse failed for {relative}: {e}")))?;
+        let entry: DropboxEntry = response.json().map_err(|e| {
+            AppError::Other(format!("get_metadata parse failed for {relative}: {e}"))
+        })?;
         if entry.tag != "file" {
             return Ok(None);
         }
@@ -121,7 +123,9 @@ pub(crate) fn fetch_remote_file_metadata(
     }
 
     let status = response.status();
-    let body = response.text().unwrap_or_else(|_| "<unreadable body>".to_string());
+    let body = response
+        .text()
+        .unwrap_or_else(|_| "<unreadable body>".to_string());
     if status.as_u16() == 409 && (body.contains("not_found") || body.contains("path")) {
         return Ok(None);
     }
@@ -193,7 +197,9 @@ pub(crate) fn fetch_all_remote_file_metadata(
             .map_err(|e| AppError::Network(format!("list_folder request failed: {e}")))?;
         if !response.status().is_success() {
             let status = response.status();
-            let body = response.text().unwrap_or_else(|_| "<unreadable body>".to_string());
+            let body = response
+                .text()
+                .unwrap_or_else(|_| "<unreadable body>".to_string());
             return Err(AppError::Dropbox {
                 status: status.as_u16(),
                 message: format!("list_folder for account root: {body}"),
@@ -228,7 +234,9 @@ pub(crate) fn fetch_all_remote_file_metadata(
             .map_err(|e| AppError::Network(format!("list_folder/continue request failed: {e}")))?;
         if !response.status().is_success() {
             let status = response.status();
-            let body = response.text().unwrap_or_else(|_| "<unreadable body>".to_string());
+            let body = response
+                .text()
+                .unwrap_or_else(|_| "<unreadable body>".to_string());
             return Err(AppError::Dropbox {
                 status: status.as_u16(),
                 message: format!("list_folder/continue for account root: {body}"),
@@ -491,9 +499,7 @@ pub(crate) fn seed_remote_delta_cursor(state: &AppState) -> AppResult<String> {
         )?;
     }
 
-    state
-        .db
-        .set_app_config(REMOTE_DELTA_CURSOR_KEY, &cursor)?;
+    state.db.set_app_config(REMOTE_DELTA_CURSOR_KEY, &cursor)?;
     Ok(cursor)
 }
 
@@ -636,7 +642,10 @@ mod tests {
         assert_eq!(key, "/docs/report.txt");
         assert_eq!(meta.content_hash, "hash123");
         assert_eq!(meta.rev, "rev1");
-        assert_eq!(meta.modified_ts, parse_rfc3339_ts_to_unix("2024-01-02T03:04:05Z"));
+        assert_eq!(
+            meta.modified_ts,
+            parse_rfc3339_ts_to_unix("2024-01-02T03:04:05Z")
+        );
     }
 
     #[test]
@@ -737,7 +746,10 @@ mod tests {
             409,
             r#"{"error_summary":"reset/...","error":{".tag":"reset"}}"#
         ));
-        assert!(!is_reset_error(409, r#"{"error_summary":"path/not_found/.."}"#));
+        assert!(!is_reset_error(
+            409,
+            r#"{"error_summary":"path/not_found/.."}"#
+        ));
         assert!(!is_reset_error(200, "reset/whatever"));
     }
 
@@ -749,14 +761,20 @@ mod tests {
 
         let n = reconcile_remote_absent(&state, "a.txt").unwrap();
         assert_eq!(n, 1);
-        assert_eq!(job_targets(&state, "local_delete"), vec!["a.txt".to_string()]);
+        assert_eq!(
+            job_targets(&state, "local_delete"),
+            vec!["a.txt".to_string()]
+        );
     }
 
     #[test]
     fn reconcile_remote_absent_keeps_diverged_local_as_conflict() {
         let state = build_state();
         state.db.upsert_remote_file("b.txt", "H", "rev", 0).unwrap();
-        state.db.upsert_local_file("b.txt", "DIFFERENT", 3, 0).unwrap();
+        state
+            .db
+            .upsert_local_file("b.txt", "DIFFERENT", 3, 0)
+            .unwrap();
 
         let n = reconcile_remote_absent(&state, "b.txt").unwrap();
         assert_eq!(n, 0, "a diverged local file must NOT be deleted");
@@ -786,7 +804,10 @@ mod tests {
     #[test]
     fn reconcile_remote_present_enqueues_download_on_remote_change() {
         let state = build_state();
-        state.db.upsert_remote_file("e.txt", "OLD", "rev0", 0).unwrap();
+        state
+            .db
+            .upsert_remote_file("e.txt", "OLD", "rev0", 0)
+            .unwrap();
         state.db.upsert_local_file("e.txt", "OLD", 3, 0).unwrap();
 
         let meta = RemoteFileMeta {
@@ -798,7 +819,12 @@ mod tests {
         assert_eq!(n, 1);
         assert_eq!(job_targets(&state, "download"), vec!["e.txt".to_string()]);
         assert_eq!(
-            state.db.get_remote_file("e.txt").unwrap().unwrap().content_hash,
+            state
+                .db
+                .get_remote_file("e.txt")
+                .unwrap()
+                .unwrap()
+                .content_hash,
             "NEW"
         );
     }
@@ -806,7 +832,10 @@ mod tests {
     #[test]
     fn reconcile_remote_present_no_download_when_unchanged() {
         let state = build_state();
-        state.db.upsert_remote_file("f.txt", "SAME", "rev0", 0).unwrap();
+        state
+            .db
+            .upsert_remote_file("f.txt", "SAME", "rev0", 0)
+            .unwrap();
         state.db.upsert_local_file("f.txt", "SAME", 3, 0).unwrap();
 
         let meta = RemoteFileMeta {
@@ -842,8 +871,15 @@ mod tests {
             remote_sweep_delete_candidates(&state, &local_files, &remote_by_path, &pending_targets)
                 .unwrap();
 
-        assert_eq!(absent.len(), 30, "every tracked file is absent from the snapshot");
-        assert_eq!(delete_candidates, 30, "every absent file matches its last-synced hash");
+        assert_eq!(
+            absent.len(),
+            30,
+            "every tracked file is absent from the snapshot"
+        );
+        assert_eq!(
+            delete_candidates, 30,
+            "every absent file matches its last-synced hash"
+        );
         assert!(
             is_mass_deletion(delete_candidates, local_files.len()),
             "30/30 candidates must trip the breaker"
@@ -869,21 +905,42 @@ mod tests {
         // Diverged local copy: absent from remote, but local hash no longer matches
         // the last-synced remote hash → NOT a delete candidate (becomes a conflict
         // via reconcile_remote_absent, never counted toward the breaker).
-        state.db.upsert_remote_file("diverged.txt", "H", "rev", 0).unwrap();
-        state.db.upsert_local_file("diverged.txt", "DIFFERENT", 3, 0).unwrap();
+        state
+            .db
+            .upsert_remote_file("diverged.txt", "H", "rev", 0)
+            .unwrap();
+        state
+            .db
+            .upsert_local_file("diverged.txt", "DIFFERENT", 3, 0)
+            .unwrap();
 
         // Never indexed remotely: absent from the snapshot, but there's no prior
         // remote row, so it can't be a remote-wins delete either.
-        state.db.upsert_local_file("never_indexed.txt", "H", 3, 0).unwrap();
+        state
+            .db
+            .upsert_local_file("never_indexed.txt", "H", 3, 0)
+            .unwrap();
 
         // Present in this sweep's snapshot: excluded from `absent` entirely.
-        state.db.upsert_remote_file("present.txt", "H", "rev", 0).unwrap();
-        state.db.upsert_local_file("present.txt", "H", 3, 0).unwrap();
+        state
+            .db
+            .upsert_remote_file("present.txt", "H", "rev", 0)
+            .unwrap();
+        state
+            .db
+            .upsert_local_file("present.txt", "H", 3, 0)
+            .unwrap();
 
         // Pending job: skipped like `.cloudsc` files, even though it would
         // otherwise be a clean delete candidate.
-        state.db.upsert_remote_file("pending.txt", "H", "rev", 0).unwrap();
-        state.db.upsert_local_file("pending.txt", "H", 3, 0).unwrap();
+        state
+            .db
+            .upsert_remote_file("pending.txt", "H", "rev", 0)
+            .unwrap();
+        state
+            .db
+            .upsert_local_file("pending.txt", "H", 3, 0)
+            .unwrap();
 
         let local_files = state.db.list_local_files().unwrap();
         let mut remote_by_path: HashMap<String, RemoteFileMeta> = HashMap::new();
@@ -985,7 +1042,10 @@ mod tests {
             &pending_targets,
         )
         .unwrap();
-        assert_eq!(enqueued, 30, "an explicit override lets the reviewed batch through");
+        assert_eq!(
+            enqueued, 30,
+            "an explicit override lets the reviewed batch through"
+        );
         assert_eq!(job_targets(&state, "local_delete").len(), 30);
         assert!(
             state

--- a/apps/desktop/src-tauri/src/run_events.rs
+++ b/apps/desktop/src-tauri/src/run_events.rs
@@ -37,7 +37,11 @@ pub(crate) fn handle_run_event(app_handle: &AppHandle, event: RunEvent) {
                 }
             }
         }
-        RunEvent::WindowEvent { label, event: win_evt, .. } => {
+        RunEvent::WindowEvent {
+            label,
+            event: win_evt,
+            ..
+        } => {
             match win_evt {
                 // `main` is a tray flyout, not the app: closing it (e.g. Alt+F4) just
                 // hides it, it never quits the app.

--- a/apps/desktop/src-tauri/src/sharing.rs
+++ b/apps/desktop/src-tauri/src/sharing.rs
@@ -140,7 +140,10 @@ mod tests {
 
     #[test]
     fn cloudsc_item_maps_to_its_remote_path() {
-        assert_eq!(remote_rel_from_item("dir/report.docx.cloudsc"), "dir/report.docx");
+        assert_eq!(
+            remote_rel_from_item("dir/report.docx.cloudsc"),
+            "dir/report.docx"
+        );
         assert_eq!(remote_rel_from_item("report.docx"), "report.docx");
         assert_eq!(remote_rel_from_item("folder.cloudsc"), "folder");
         // Only a trailing suffix is stripped.

--- a/apps/desktop/src-tauri/src/shell_actions.rs
+++ b/apps/desktop/src-tauri/src/shell_actions.rs
@@ -210,7 +210,10 @@ mod tests {
     fn missing_action_or_path_is_none() {
         assert_eq!(parse_action_args(&v(&["exe", "--path=/x/y"])), None);
         assert_eq!(parse_action_args(&v(&["exe", "--action=hydrate"])), None);
-        assert_eq!(parse_action_args(&v(&["exe", "--action=", "--path=/x"])), None);
+        assert_eq!(
+            parse_action_args(&v(&["exe", "--action=", "--path=/x"])),
+            None
+        );
         assert_eq!(parse_action_args(&v(&["exe"])), None);
     }
 
@@ -231,7 +234,8 @@ mod tests {
         let db_path = dir.path().join("app.db");
         std::mem::forget(dir); // keep the DB file alive for the test body
         let db = crate::storage::db::Db::new_at(&db_path).expect("db");
-        db.set_sync_folder(&folder.to_string_lossy()).expect("set folder");
+        db.set_sync_folder(&folder.to_string_lossy())
+            .expect("set folder");
         AppState {
             secure_store: crate::storage::secure_store::SecureStore::new(),
             db: Arc::new(db),

--- a/apps/desktop/src-tauri/src/state.rs
+++ b/apps/desktop/src-tauri/src/state.rs
@@ -91,12 +91,7 @@ mod tests {
                 let successes = Arc::clone(&successes);
                 std::thread::spawn(move || {
                     if flag
-                        .compare_exchange(
-                            false,
-                            true,
-                            Ordering::AcqRel,
-                            Ordering::Acquire,
-                        )
+                        .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
                         .is_ok()
                     {
                         successes.fetch_add(1, Ordering::AcqRel);

--- a/apps/desktop/src-tauri/src/storage/db.rs
+++ b/apps/desktop/src-tauri/src/storage/db.rs
@@ -1438,12 +1438,19 @@ mod tests {
 
         // DBSYNC-31: two enqueues of the same (job_type, target_path) collapse into ONE
         // active job (partial-unique index + ON CONFLICT), instead of two rows.
-        db.enqueue_job("upload", Some("a.txt"), Some("a.txt")).unwrap();
-        db.enqueue_job("upload", Some("a.txt"), Some("a.txt")).unwrap();
-        assert_eq!(db.count_active_jobs().unwrap(), 1, "duplicate active upload collapsed");
+        db.enqueue_job("upload", Some("a.txt"), Some("a.txt"))
+            .unwrap();
+        db.enqueue_job("upload", Some("a.txt"), Some("a.txt"))
+            .unwrap();
+        assert_eq!(
+            db.count_active_jobs().unwrap(),
+            1,
+            "duplicate active upload collapsed"
+        );
 
         // A different job_type for the same path is a distinct active job.
-        db.enqueue_job("delete", Some("a.txt"), Some("a.txt")).unwrap();
+        db.enqueue_job("delete", Some("a.txt"), Some("a.txt"))
+            .unwrap();
         assert_eq!(db.count_active_jobs().unwrap(), 2);
 
         // active_job_paths reports the path (used for dedup / conflict routing).
@@ -1459,20 +1466,25 @@ mod tests {
             .unwrap()
             .id;
         db.mark_job_completed(upload_id).unwrap();
-        db.enqueue_job("upload", Some("a.txt"), Some("a.txt")).unwrap();
+        db.enqueue_job("upload", Some("a.txt"), Some("a.txt"))
+            .unwrap();
         let uploads = db
             .list_recent_jobs(50)
             .unwrap()
             .into_iter()
             .filter(|j| j.job_type == "upload")
             .count();
-        assert_eq!(uploads, 2, "a new active upload coexists with the completed one");
+        assert_eq!(
+            uploads, 2,
+            "a new active upload coexists with the completed one"
+        );
     }
 
     #[test]
     fn enqueue_delete_job_persists_parent_rev() {
         let db = Db::new_at(&unique_db_path()).expect("db init");
-        db.enqueue_delete_job("a.txt", Some("rev123")).expect("enqueue");
+        db.enqueue_delete_job("a.txt", Some("rev123"))
+            .expect("enqueue");
 
         let jobs = db.list_recent_jobs(10).expect("jobs");
         assert_eq!(jobs.len(), 1);
@@ -1487,8 +1499,10 @@ mod tests {
         // DBSYNC-65 (Slice 1) crux regression: re-enqueuing an already-active delete
         // for the same target must refresh `delete_parent_rev`, not keep the stale
         // value captured by the first enqueue.
-        db.enqueue_delete_job("a.txt", Some("old_rev")).expect("first enqueue");
-        db.enqueue_delete_job("a.txt", Some("new_rev")).expect("second enqueue");
+        db.enqueue_delete_job("a.txt", Some("old_rev"))
+            .expect("first enqueue");
+        db.enqueue_delete_job("a.txt", Some("new_rev"))
+            .expect("second enqueue");
 
         assert_eq!(
             db.count_active_jobs().unwrap(),
@@ -1505,11 +1519,13 @@ mod tests {
         let db = Db::new_at(&unique_db_path()).expect("db init");
         // DBSYNC-31 AC4: the CHECK constraint rejects an unknown job_type at the DB layer.
         assert!(
-            db.enqueue_job("bogus_type", Some("a.txt"), Some("a.txt")).is_err(),
+            db.enqueue_job("bogus_type", Some("a.txt"), Some("a.txt"))
+                .is_err(),
             "an out-of-set job_type must be rejected"
         );
         // A valid job_type still enqueues.
-        db.enqueue_job("upload", Some("a.txt"), Some("a.txt")).unwrap();
+        db.enqueue_job("upload", Some("a.txt"), Some("a.txt"))
+            .unwrap();
         assert_eq!(db.count_active_jobs().unwrap(), 1);
     }
 
@@ -1657,7 +1673,10 @@ mod tests {
             .expect("g2")
             .is_none());
         // Boundary-collision sibling and unrelated tree survive.
-        assert!(db.get_remote_file("UNET-other/keep.txt").expect("g3").is_some());
+        assert!(db
+            .get_remote_file("UNET-other/keep.txt")
+            .expect("g3")
+            .is_some());
         assert!(db.get_remote_file("Otra/keep.txt").expect("g4").is_some());
     }
 
@@ -1688,7 +1707,8 @@ mod tests {
 
         assert_eq!(db.get_sync_folder().expect("get after clear"), None);
         assert_eq!(
-            db.get_include_prefixes_csv().expect("get prefixes after clear"),
+            db.get_include_prefixes_csv()
+                .expect("get prefixes after clear"),
             Some("Fotos,Videos/2024".to_string()),
             "local prefs must survive disconnect"
         );

--- a/apps/desktop/src-tauri/src/sync_pipeline.rs
+++ b/apps/desktop/src-tauri/src/sync_pipeline.rs
@@ -11,13 +11,12 @@ use crate::dropbox_transfer::{
 };
 use crate::error::{AppError, AppResult};
 use crate::models::SyncTickResult;
+use crate::overlay_state;
 use crate::path_util::{
     backoff_seconds, create_conflicted_copy, hash_file, is_builtin_ignored_local_path,
-    is_editor_temp_path, is_ignored_local_path,
-    normalize_dropbox_path, safe_join,
+    is_editor_temp_path, is_ignored_local_path, normalize_dropbox_path, safe_join,
 };
 use crate::remote_index::refresh_remote_index_and_enqueue_downloads_internal;
-use crate::overlay_state;
 use crate::state::AppState;
 use crate::storage::db::FileIndexRow;
 
@@ -127,7 +126,9 @@ fn process_local_file_change(
 
     match known {
         None => {
-            state.db.enqueue_job("upload", Some(relative), Some(relative))?;
+            state
+                .db
+                .enqueue_job("upload", Some(relative), Some(relative))?;
             state
                 .db
                 .upsert_local_file(relative, &hash, size_bytes, modified_ts)?;
@@ -161,7 +162,9 @@ fn process_local_file_change(
                 crate::sharing::notify_conflict(relative);
                 Ok(1)
             } else {
-                state.db.enqueue_job("upload", Some(relative), Some(relative))?;
+                state
+                    .db
+                    .enqueue_job("upload", Some(relative), Some(relative))?;
                 state
                     .db
                     .upsert_local_file(relative, &hash, size_bytes, modified_ts)?;
@@ -198,7 +201,9 @@ fn process_local_file_deletion(
     // (Slice 2) can detect whether the remote copy changed since this delete was
     // observed. Not yet read/enforced — plumbing only.
     let parent_rev = state.db.get_remote_file(prev_rel)?.map(|r| r.rev);
-    state.db.enqueue_delete_job(prev_rel, parent_rev.as_deref())?;
+    state
+        .db
+        .enqueue_delete_job(prev_rel, parent_rev.as_deref())?;
     state.db.remove_local_file(prev_rel)?;
     Ok(1)
 }
@@ -488,7 +493,12 @@ pub(crate) fn is_mass_deletion(candidates: usize, tracked: usize) -> bool {
 /// remote→local extension) so both directions consume the same one-shot flag
 /// instead of each keeping their own.
 pub(crate) fn consume_mass_delete_override(state: &AppState) -> AppResult<bool> {
-    if state.db.get_app_config(MASS_DELETE_OVERRIDE_KEY)?.as_deref() == Some("1") {
+    if state
+        .db
+        .get_app_config(MASS_DELETE_OVERRIDE_KEY)?
+        .as_deref()
+        == Some("1")
+    {
         state.db.set_app_config(MASS_DELETE_OVERRIDE_KEY, "0")?;
         tracing::warn!("mass-deletion override consumed: allowing this deletion batch");
         return Ok(true);
@@ -1060,7 +1070,9 @@ pub(crate) fn resolve_conflict_internal(
                 .db
                 .enqueue_job("upload", Some(primary_rel), Some(primary_rel))?;
             if state.db.get_remote_file(copy_rel)?.is_some() {
-                state.db.enqueue_job("delete", Some(copy_rel), Some(copy_rel))?;
+                state
+                    .db
+                    .enqueue_job("delete", Some(copy_rel), Some(copy_rel))?;
             }
         }
         // No copy (remote-deleted scenario): the local primary IS the version to keep
@@ -1082,7 +1094,9 @@ pub(crate) fn resolve_conflict_internal(
                     .map_err(|e| AppError::Io(format!("failed removing conflicted copy: {e}")))?;
             }
             if state.db.get_remote_file(copy_rel)?.is_some() {
-                state.db.enqueue_job("delete", Some(copy_rel), Some(copy_rel))?;
+                state
+                    .db
+                    .enqueue_job("delete", Some(copy_rel), Some(copy_rel))?;
             }
         }
         // Remote was deleted and there is no copy: "follow remote" means discarding the
@@ -1105,7 +1119,9 @@ pub(crate) fn resolve_conflict_internal(
         // Dropbox promptly (the scan would eventually do this anyway).
         (ConflictAction::KeepBoth, Some(copy_rel), _) => {
             if safe_join(root, copy_rel)?.exists() {
-                state.db.enqueue_job("upload", Some(copy_rel), Some(copy_rel))?;
+                state
+                    .db
+                    .enqueue_job("upload", Some(copy_rel), Some(copy_rel))?;
             }
         }
         // Remote deleted, no copy: there is no second version to keep — restore the
@@ -1195,8 +1211,8 @@ mod tests {
     use super::{
         block_mass_deletion, cleanup_stale_upload_state, clear_mass_delete_blocked,
         is_mass_deletion, mass_delete_pause_active, process_changed_paths,
-        resolve_conflict_internal, run_sync_tick_internal, scan_local_changes_only,
-        ConflictAction, MassDeleteSource, SYNC_BATCH_CAP,
+        resolve_conflict_internal, run_sync_tick_internal, scan_local_changes_only, ConflictAction,
+        MassDeleteSource, SYNC_BATCH_CAP,
     };
     use crate::state::AppState;
     use crate::storage::db::Db;
@@ -1363,7 +1379,10 @@ mod tests {
         let state = build_state(tmp.path());
         std::fs::write(sync_root(&state).join("m.txt"), b"new-content").unwrap();
         // Index an out-of-date hash so the on-disk content is a "modification".
-        state.db.upsert_local_file("m.txt", "stale-hash", 3, 0).unwrap();
+        state
+            .db
+            .upsert_local_file("m.txt", "stale-hash", 3, 0)
+            .unwrap();
 
         let n = process_changed_paths(&state, &["m.txt".to_string()]).expect("process");
         assert_eq!(n, 1);
@@ -1606,8 +1625,14 @@ mod tests {
         let tmp = tempdir().expect("tempdir");
         let state = build_state(tmp.path());
         // A real synced file (present on remote) whose upload source is absent.
-        state.db.upsert_local_file("report.docx", "h2", 1, 0).unwrap();
-        state.db.upsert_remote_file("report.docx", "h1", "rev", 0).unwrap();
+        state
+            .db
+            .upsert_local_file("report.docx", "h2", 1, 0)
+            .unwrap();
+        state
+            .db
+            .upsert_remote_file("report.docx", "h1", "rev", 0)
+            .unwrap();
 
         crate::dropbox_transfer::upload_local_file_internal(&state, "report.docx", 1)
             .expect("must not error");
@@ -1661,7 +1686,10 @@ mod tests {
         // one that still exists on disk (a genuine failure — must be left alone).
         std::fs::write(sync.join("real.txt"), b"x").unwrap();
         for src in ["~$doc.docx", "gone.txt", "real.txt"] {
-            state.db.enqueue_job("upload", Some(src), Some(src)).unwrap();
+            state
+                .db
+                .enqueue_job("upload", Some(src), Some(src))
+                .unwrap();
             let id = state
                 .db
                 .list_recent_jobs(50)
@@ -1735,13 +1763,20 @@ mod tests {
             "LOCAL_EDIT",
             "the local edit must win at the primary path"
         );
-        assert!(!copy.exists(), "the conflicted copy is consumed by the promotion");
+        assert!(
+            !copy.exists(),
+            "the conflicted copy is consumed by the promotion"
+        );
         assert_eq!(job_targets(&state, "upload"), vec!["doc.txt".to_string()]);
         assert!(
             job_targets(&state, "delete").is_empty(),
             "copy was never on the remote → no remote delete"
         );
-        assert_eq!(unresolved_count(&state), 0, "conflict must be marked resolved");
+        assert_eq!(
+            unresolved_count(&state),
+            0,
+            "conflict must be marked resolved"
+        );
     }
 
     #[test]
@@ -1750,7 +1785,10 @@ mod tests {
         let state = build_state(tmp.path());
         write_synced(&state, "doc.txt", "REMOTE");
         write_synced(&state, COPY_REL, "LOCAL_EDIT");
-        state.db.upsert_remote_file(COPY_REL, "h", "rev1", 1).unwrap();
+        state
+            .db
+            .upsert_remote_file(COPY_REL, "h", "rev1", 1)
+            .unwrap();
         state
             .db
             .add_conflict("doc.txt", "doc.txt", "r", Some(COPY_REL), false)
@@ -1804,7 +1842,10 @@ mod tests {
         resolve_conflict_internal(&state, first_conflict_id(&state), ConflictAction::UseRemote)
             .unwrap();
 
-        assert!(!primary.exists(), "following the deleted remote removes the local file");
+        assert!(
+            !primary.exists(),
+            "following the deleted remote removes the local file"
+        );
         assert!(
             state.db.get_local_file("doc.txt").unwrap().is_none(),
             "the local index row must be untracked so the scan sees no tracked-file deletion"
@@ -1826,7 +1867,10 @@ mod tests {
         resolve_conflict_internal(&state, first_conflict_id(&state), ConflictAction::KeepBoth)
             .unwrap();
 
-        assert!(primary.exists() && copy.exists(), "both versions are kept on disk");
+        assert!(
+            primary.exists() && copy.exists(),
+            "both versions are kept on disk"
+        );
         assert_eq!(
             job_targets(&state, "upload"),
             vec![COPY_REL.to_string()],
@@ -1857,7 +1901,10 @@ mod tests {
 
     #[test]
     fn is_mass_deletion_thresholds() {
-        assert!(is_mass_deletion(200, 100_000), "absolute limit trips regardless of fraction");
+        assert!(
+            is_mass_deletion(200, 100_000),
+            "absolute limit trips regardless of fraction"
+        );
         assert!(is_mass_deletion(30, 100), ">= floor and >= 10% of tracked");
         assert!(!is_mass_deletion(24, 100), "below the absolute floor");
         assert!(!is_mass_deletion(30, 1000), "3% is under the 10% fraction");

--- a/apps/desktop/src-tauri/src/windows_file_assoc.rs
+++ b/apps/desktop/src-tauri/src/windows_file_assoc.rs
@@ -29,18 +29,13 @@ fn register_user_cloudsc_association_for_exe(exe: &Path) -> io::Result<()> {
     dot_key.set_value("", &PROG_ID)?;
 
     let (prog_key, _) = hkcu.create_subkey(format!(r"Software\Classes\{PROG_ID}"))?;
-    prog_key.set_value(
-        "",
-        &"Cloudsc placeholder (Dropbox Sync Desktop)",
-    )?;
+    prog_key.set_value("", &"Cloudsc placeholder (Dropbox Sync Desktop)")?;
 
-    let (icon_key, _) =
-        hkcu.create_subkey(format!(r"Software\Classes\{PROG_ID}\DefaultIcon"))?;
+    let (icon_key, _) = hkcu.create_subkey(format!(r"Software\Classes\{PROG_ID}\DefaultIcon"))?;
     icon_key.set_value("", &icon_ref)?;
 
-    let (cmd_key, _) = hkcu.create_subkey(format!(
-        r"Software\Classes\{PROG_ID}\shell\open\command"
-    ))?;
+    let (cmd_key, _) =
+        hkcu.create_subkey(format!(r"Software\Classes\{PROG_ID}\shell\open\command"))?;
     cmd_key.set_value("", &open_cmd)?;
 
     register_cloudsc_context_menu(&hkcu, &exe_str, &icon_ref)?;
@@ -57,11 +52,7 @@ pub(crate) const CLOUDSC_MENU_PROG_ID: &str = "DropboxSyncDesktop.CloudscMenu";
 /// (`--action/--path`). Labels are written in the system UI language (no resource
 /// DLL — the app localizes at registration). More children (Desincronizar,
 /// Créer un lien) are appended by their own tickets (DBSYNC-33 / DBSYNC-52).
-fn register_cloudsc_context_menu(
-    hkcu: &RegKey,
-    exe_str: &str,
-    icon_ref: &str,
-) -> io::Result<()> {
+fn register_cloudsc_context_menu(hkcu: &RegKey, exe_str: &str, icon_ref: &str) -> io::Result<()> {
     // Remove the previous flat verb from earlier builds, if present.
     let _ = hkcu.delete_subkey_all(format!(
         r"Software\Classes\{PROG_ID}\shell\dropboxsync_hydrate"
@@ -97,11 +88,7 @@ fn system_ui_language() -> String {
         .open_subkey(r"Control Panel\International")
         .and_then(|k| k.get_value::<String, _>("LocaleName"))
         .ok()
-        .and_then(|s| {
-            s.split(['-', '_'])
-                .next()
-                .map(|p| p.to_ascii_lowercase())
-        })
+        .and_then(|s| s.split(['-', '_']).next().map(|p| p.to_ascii_lowercase()))
         .filter(|s| !s.is_empty())
         .unwrap_or_else(|| "en".to_string())
 }

--- a/apps/desktop/src-tauri/src/windows_shell_menu.rs
+++ b/apps/desktop/src-tauri/src/windows_shell_menu.rs
@@ -72,8 +72,9 @@ fn register_com_handler(dll: &Path, exe: &Path) -> io::Result<()> {
     // 1) COM server (in-proc, apartment-threaded).
     let (clsid_key, _) = hkcu.create_subkey(format!(r"Software\Classes\CLSID\{CLSID_STR}"))?;
     clsid_key.set_value("", &"DropboxSync Explorer Command")?;
-    let (inproc, _) =
-        hkcu.create_subkey(format!(r"Software\Classes\CLSID\{CLSID_STR}\InprocServer32"))?;
+    let (inproc, _) = hkcu.create_subkey(format!(
+        r"Software\Classes\CLSID\{CLSID_STR}\InprocServer32"
+    ))?;
     inproc.set_value("", &dll.to_string_lossy().as_ref())?;
     inproc.set_value("ThreadingModel", &"Apartment")?;
 
@@ -86,8 +87,9 @@ fn register_com_handler(dll: &Path, exe: &Path) -> io::Result<()> {
     k.set_value("ExplorerCommandHandler", &CLSID_STR)?;
     // `command` subkey is required for the verb to appear on Win11; the parent
     // never executes directly (it has subcommands), so DelegateExecute is inert.
-    let (cmd, _) =
-        hkcu.create_subkey(format!(r"Software\Classes\{TARGET_CLASS}\shell\{VERB}\command"))?;
+    let (cmd, _) = hkcu.create_subkey(format!(
+        r"Software\Classes\{TARGET_CLASS}\shell\{VERB}\command"
+    ))?;
     cmd.set_value("", &"")?;
     cmd.set_value("DelegateExecute", &CLSID_STR)?;
 

--- a/apps/desktop/src-tauri/src/windows_startup.rs
+++ b/apps/desktop/src-tauri/src/windows_startup.rs
@@ -10,8 +10,8 @@
 //! always queries live.
 #![cfg(windows)]
 
-use windows::ApplicationModel::{StartupTask, StartupTaskState};
 use windows::core::HSTRING;
+use windows::ApplicationModel::{StartupTask, StartupTaskState};
 
 /// Must equal the `TaskId` of the `uap5:StartupTask` extension in
 /// `native/windows/sparse-package/AppxManifest.xml`. Never change once shipped


### PR DESCRIPTION
Closes [DBSYNC-90](https://manuelbsan.atlassian.net/browse/DBSYNC-90). Two commits: the reformat alone, then the CI check.

## Two figures in the ticket were wrong, and both were mine

**It is 22 files, not 161.** My original count came from `cargo fmt --check | grep -c "^Diff in"`, and rustfmt emits that line **per hunk**, not per file. 161 hunks across 22 files. The figure propagated into DBSYNC-90, DBSYNC-38 and several comments.

**Blame damage was overstated, badly.** The ticket called it "the main cost of doing it at all". Measured:

```
lines attributed to the reformat commit, whole tree:   14
same, with the commit ignored via .git-blame-ignore-revs: 14
same, with an explicit --ignore-rev:                      14
```

Of 720 touched lines, only 14 end up attributed to the reformat — most changes are line *splits* whose first fragment keeps its original author. And ignoring the commit does not move those 14, by either mechanism: they are genuinely new text with no predecessor line, so `blame` has nowhere to send them.

So `.git-blame-ignore-revs` **changes nothing measurable for this commit**. It is kept as policy for the next mass change, with that written into the file itself rather than left as an implication.

Had I measured first, this ticket would have been argued as "cosmetic, cheap" rather than "cosmetic, with a serious blame cost". The conclusion happens to be the same; the reasoning I gave you was not.

## What is in here

**`36b3af1` — the reformat, and nothing else.** rustfmt defaults, no `rustfmt.toml`, no manual edits. 22 files, +720/-260.

**`2e6fa54` — the check and the blame file.** `cargo fmt --check` on both matrix legs. rustfmt is deterministic so the Windows leg is redundant in principle, but a divergence there would be a real finding about the toolchain and it costs a second.

Turning this on was deliberately kept out of DBSYNC-38: doing it before the tree was formatted would have made every job red on layout rather than defects — which is exactly how this workflow earned being switched off from 2026-07-12 to 2026-08-22.

## Test Plan

- [x] `cargo test` — **197 passed before, 197 after**, identical. A reformat that changes behaviour is not a reformat
- [x] `cargo fmt --check` passes locally
- [x] Only `.rs` files in the reformat commit — verified, zero non-`.rs` paths
- [ ] CI green, including the new step on both platforms

Also worth recording, since it is the first time it has been true: **`cargo test` no longer touches the real `overlay_state.json`.** Hash identical before and after the run — DBSYNC-75's fix working in the wild rather than in a unit test.

## What this does not do

Nothing a user will notice. It is cosmetic by construction, and the honest case for it is only that future diffs stop carrying layout noise. If that is not worth a 720-line commit to you, closing this unmerged is a reasonable call and the reformat is trivially revertible.

#DBSYNC-90
