### PR TITLE
fix(#DBSYNC-90): point the blame-ignore file at a commit that exists

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -7,14 +7,22 @@
 # mechanical — a reformat, a mass rename — never one that changes behaviour, or blame
 # will hide the change that actually broke something.
 #
-# MEASURED, and smaller than expected: of the 720 lines the reformat below touched, only
-# 14 end up attributed to it, because most were line splits whose first fragment keeps its
-# original author. Ignoring the commit does not move those 14 either — they are genuinely
-# new text with no predecessor line to fall back to, so `blame` has nowhere to send them.
+# WRITE THE SHA AFTER MERGING, NOT BEFORE. This repo squash-merges, so the commit you
+# reformat on does not survive: its SHA is gone from main and git silently ignores an
+# entry it cannot resolve. The first version of this file listed the pre-squash SHA and
+# was therefore inert — it took a fresh look to notice, because nothing errors.
 #
-# So this file changes nothing measurable for the commit it lists. It is kept as policy
-# for the next mass change rather than as a repair of this one; DBSYNC-90 originally
-# called blame damage "the main cost of doing it at all", and that was wrong.
+# MEASURED, and smaller than expected: of the 720 lines the reformat touched, only 14 end
+# up attributed to it — most were line splits whose first fragment keeps its original
+# author. Ignoring the commit does not move those 14 either, with the config or with an
+# explicit --ignore-rev: they are new text with no predecessor line, so blame has nowhere
+# to send them.
+#
+# So this file changes nothing measurable for the entry below. It is kept as policy for
+# the next mass change. DBSYNC-90 originally called blame damage "the main cost of doing
+# it at all"; the real cost was 14 lines.
 
-# style(#DBSYNC-90): apply cargo fmt — 22 files, rustfmt defaults, zero logic change
-36b3af1b380ec369d1e8dab8325a27d91682cd11
+# style(#DBSYNC-90): format the Rust tree and enforce cargo fmt in CI (#129)
+# Squashed, so this also carries the ci.yml step and this file — two non-mechanical files
+# whose blame is not precious. Named here rather than quietly ignored.
+65403789e6ceac9f03a0d15f778f362eb831bbc7


### PR DESCRIPTION
Follow-up to #129, fixing something that PR created.

## What happened

`.git-blame-ignore-revs` listed the SHA of the reformat commit as it existed **on the branch**. This repo squash-merges, so that commit never reached `main` — the entry resolves to nothing.

## Why nobody noticed

Git does not complain. Verified with a deliberately bogus all-zeros SHA:

```
git -c blame.ignoreRevsFile=<file-with-0000...> blame …
→ works normally, no error, no warning
```

An unresolvable entry is silently skipped. So the file was inert **twice over** — once by measurement (the 14 lines that cannot be re-attributed anyway) and once by this accident. Only the second is fixable, and only the second was invisible.

## The fix

Points at `6540378`, the squashed commit, which is in `main`'s history.

That commit also carries the `ci.yml` step and this file itself. The file's own rule says only purely mechanical commits belong here, and the squash made that impossible to honour exactly — so the comment says so rather than leaving a reader to discover it.

The instruction that would have prevented the whole thing is now at the top of the file: **write the SHA after merging, not before.**

## Test Plan

- [x] `git merge-base --is-ancestor` confirms the new SHA is in `main`
- [ ] CI green

No code change; one text file.

#DBSYNC-90