### PR TITLE
fix(#DBSYNC-91): act on overlay_state.json's version instead of decoding and discarding it

### DIFF
--- a/apps/desktop/native/macos/FinderSyncExtension/BadgeDiff.swift
+++ b/apps/desktop/native/macos/FinderSyncExtension/BadgeDiff.swift
@@ -225,12 +225,47 @@ struct OverlayState: Decodable {
         case paths
     }
 
+    /// The only contract version this reader understands (DBSYNC-91).
+    ///
+    /// Named rather than written inline so that it is greppable from the writer's end:
+    /// `overlay_state.rs` documents the bump rule, and this is the constant that rule is
+    /// actually talking about.
+    static let supportedVersion = 1
+
     /// Decodes with a plain `JSONDecoder`. Throws rather than returning `nil` so the caller
     /// can log what went wrong — a silent decode failure deregisters the extension's
     /// directories and every badge disappears with nothing written anywhere.
+    ///
+    /// **Refuses any version other than [`supportedVersion`] (DBSYNC-91.)** Before this,
+    /// `version` was decoded and never read: a file written with a bumped version and an
+    /// incompatible schema was applied exactly as if it were v1, using whatever fields
+    /// still lined up and ignoring the rest. That made the field documentation rather than
+    /// a mechanism.
+    ///
+    /// Refusing rather than best-effort follows this project's own rule, settled in
+    /// DBSYNC-84: a badge that is confidently wrong is worse than no badge. A user on a
+    /// mismatched pair sees badges missing — which they report — instead of badges that
+    /// state a sync status nobody checked.
+    ///
+    /// It is not a hypothetical pairing. DBSYNC-86 measured that every reinstall registers
+    /// a NEW plug-in instance and the old ones linger, so an old appex can genuinely be the
+    /// one Finder has loaded while a newer app writes the file.
     static func decode(from data: Data) throws -> OverlayState {
-        try JSONDecoder().decode(OverlayState.self, from: data)
+        let decoded = try JSONDecoder().decode(OverlayState.self, from: data)
+        guard decoded.version == supportedVersion else {
+            throw OverlayStateError.unsupportedVersion(decoded.version)
+        }
+        return decoded
     }
+}
+
+/// A refusal to use `overlay_state.json`, distinct from a failure to parse it (DBSYNC-91).
+///
+/// Carries the version found because the log line is required to name it: "no badges" with
+/// no reason reads to a user like the sandbox or permissions problems this extension has
+/// already had (DBSYNC-76), and those are debugged in a completely different direction.
+enum OverlayStateError: Error {
+    case unsupportedVersion(Int)
 }
 
 /// A description of a decoding failure that is safe to put in the system log (DBSYNC-73).
@@ -252,10 +287,17 @@ struct OverlayState: Decodable {
 ///
 /// Not reachable from today's writer — `HashMap<String, OverlayTier>` can only emit strings,
 /// and truncation fails earlier as `dataCorrupted`. It is guarded anyway because
-/// `overlay_state.json` is a versioned contract with two readers, and DBSYNC-91 records that
-/// `version` is decoded and never checked: a newer writer reshaping `paths` against an
-/// installed older appex is precisely the gap.
+/// `overlay_state.json` is a versioned contract with two readers, and a newer writer
+/// reshaping `paths` against an installed older appex is precisely the gap that
+/// [`OverlayState.supportedVersion`] now closes.
 func logSafeDescription(of error: Error) -> String {
+    // Handled BEFORE the `DecodingError` cast below, which would otherwise fall through to
+    // the type-name branch and report a bare "OverlayStateError" — losing the one detail
+    // this error exists to carry (DBSYNC-91). A schema version is an integer from our own
+    // contract, so unlike a `codingPath` there is nothing here to redact.
+    if case .unsupportedVersion(let found)? = error as? OverlayStateError {
+        return "unsupportedVersion(\(found))"
+    }
     guard let decoding = error as? DecodingError else {
         // Not a decoding failure — a read error, already scoped to a path we logged
         // ourselves. Still summarised rather than dumped.

--- a/apps/desktop/native/macos/FinderSyncExtension/BadgeDiff.swift
+++ b/apps/desktop/native/macos/FinderSyncExtension/BadgeDiff.swift
@@ -251,12 +251,52 @@ struct OverlayState: Decodable {
     /// a NEW plug-in instance and the old ones linger, so an old appex can genuinely be the
     /// one Finder has loaded while a newer app writes the file.
     static func decode(from data: Data) throws -> OverlayState {
-        let decoded = try JSONDecoder().decode(OverlayState.self, from: data)
+        let decoded: OverlayState
+        do {
+            decoded = try JSONDecoder().decode(OverlayState.self, from: data)
+        } catch {
+            // The version check below is unreachable when the decode itself fails, and the
+            // most plausible breaking change is exactly that case: reshape `paths` and a v1
+            // decoder throws `typeMismatch` long before it has a version to look at. A
+            // guard that only fires when the rest of the document still parses is the same
+            // half-mechanism this ticket exists to remove, moved one step later.
+            //
+            // So: if the bytes are still readable enough to yield a version, and that
+            // version is not ours, say so. Otherwise rethrow untouched.
+            //
+            // `version != supportedVersion` is not a formality. Without it, every ordinary
+            // v1 failure — the type-mismatched tier from DBSYNC-73 included — would be
+            // relabelled a version problem, which is a worse lie than the silence this
+            // ticket started from.
+            if let header = try? JSONDecoder().decode(VersionHeader.self, from: data),
+               header.version != supportedVersion {
+                throw OverlayStateError.unsupportedVersion(header.version)
+            }
+            throw error
+        }
         guard decoded.version == supportedVersion else {
             throw OverlayStateError.unsupportedVersion(decoded.version)
         }
         return decoded
     }
+}
+
+/// Just enough of `overlay_state.json` to read its version when the rest will not parse
+/// (DBSYNC-91).
+///
+/// **Only used from the failure path.** Decoding this first, then the full struct, would
+/// read better — but `JSONDecoder` parses the whole document to extract one field, so
+/// header-first means two full parses of a file that can hold thousands of path entries, on
+/// every tick of `reloadState()`'s 2-second timer, in the case where nothing is wrong.
+/// Retrying inside the `catch` keeps the healthy path at one parse and pays the second only
+/// when something has already failed.
+///
+/// Private so that nothing outside the decoder starts using it as a cheap way to peek at the
+/// file: it is not cheap, and it answers only one question.
+private struct VersionHeader: Decodable {
+    /// No `CodingKeys` needed — `version` is the one key in this contract that was never
+    /// snake-cased. See `OverlayState.CodingKeys` for why that matters here.
+    let version: Int
 }
 
 /// A refusal to use `overlay_state.json`, distinct from a failure to parse it (DBSYNC-91).

--- a/apps/desktop/native/macos/FinderSyncExtension/BadgeDiff.swift
+++ b/apps/desktop/native/macos/FinderSyncExtension/BadgeDiff.swift
@@ -321,6 +321,32 @@ enum OverlayStateError: Error {
     case unsupportedVersion(Int)
 }
 
+/// How the log line should describe what happened: `"refusing"` or `"cannot decode"`.
+///
+/// A refused file parsed perfectly — nothing failed, the reader declined it — and calling
+/// that "cannot decode" points whoever reads the log at corruption, or at the sandbox
+/// problems of DBSYNC-76, which are debugged in a completely different direction. Telling
+/// the two apart is the whole reason [`OverlayStateError`] is its own type.
+///
+/// **It lives here, and not inline at the one call site, for the same reason the decode
+/// does: `SyncExtension.swift` cannot be compiled by `Tests/run-badge-diff-tests.sh`.** A
+/// first draft put this branch there, where no check could reach it — in a change whose own
+/// argument is that unreachable code is where this project's defects survive review.
+///
+/// `switch` rather than `error is OverlayStateError`, for the same reason
+/// [`logSafeDescription`] uses one: a bare `is` check would absorb every future case into
+/// `"refusing"` silently. A future case describing a genuine parse failure would then be
+/// logged as a refusal — the precise confusion this function exists to prevent. A first
+/// draft of this function did exactly that, in the same commit that removed the pattern
+/// from `logSafeDescription`.
+func logVerb(for error: Error) -> String {
+    guard let refusal = error as? OverlayStateError else { return "cannot decode" }
+    switch refusal {
+    case .unsupportedVersion:
+        return "refusing"
+    }
+}
+
 /// A description of a decoding failure that is safe to put in the system log (DBSYNC-73).
 ///
 /// **`String(describing:)` on a `DecodingError` leaks the user's file paths.** The error
@@ -343,23 +369,10 @@ enum OverlayStateError: Error {
 /// version check does NOT make that redundant: the case that still reaches the
 /// `typeMismatch` branch is a **same-version** reshape — a writer that changes the shape of
 /// `paths` and forgets to bump `version`. That is a human mistake rather than a contract
-/// event, so no version guard can ever catch it, which is exactly why the redaction has to
-/// survive independently of one.
-/// How the log line should describe what happened: `"refusing"` or `"cannot decode"`.
-///
-/// A refused file parsed perfectly — nothing failed, the reader declined it — and calling
-/// that "cannot decode" points whoever reads the log at corruption, or at the sandbox
-/// problems of DBSYNC-76, which are debugged in a completely different direction. Telling
-/// the two apart is the whole reason [`OverlayStateError`] is its own type.
-///
-/// **It lives here, and not inline at the one call site, for the same reason the decode
-/// does: `SyncExtension.swift` cannot be compiled by `Tests/run-badge-diff-tests.sh`.** A
-/// first draft put this branch there, where no check could reach it — in a change whose own
-/// argument is that unreachable code is where this project's defects survive review.
-func logVerb(for error: Error) -> String {
-    error is OverlayStateError ? "refusing" : "cannot decode"
-}
-
+/// event, so no version guard can ever catch it. The retype route documented on
+/// [`VersionHeader.version`] lands here too, though its `codingPath` is `version` and holds
+/// nothing of the user's. Either way the redaction has to survive independently of the
+/// version check.
 func logSafeDescription(of error: Error) -> String {
     // Handled BEFORE the `DecodingError` cast below, which would otherwise fall through to
     // the type-name branch and report a bare "OverlayStateError" — losing the one detail

--- a/apps/desktop/native/macos/FinderSyncExtension/BadgeDiff.swift
+++ b/apps/desktop/native/macos/FinderSyncExtension/BadgeDiff.swift
@@ -288,14 +288,27 @@ struct OverlayState: Decodable {
 /// read better — but `JSONDecoder` parses the whole document to extract one field, so
 /// header-first means two full parses of a file that can hold thousands of path entries, on
 /// every tick of `reloadState()`'s 2-second timer, in the case where nothing is wrong.
-/// Retrying inside the `catch` keeps the healthy path at one parse and pays the second only
-/// when something has already failed.
+/// Retrying inside the `catch` keeps the healthy path at one parse.
+///
+/// The second parse is **not** rare in the case this exists for, and it would be dishonest
+/// to imply otherwise: a mismatched pair (DBSYNC-86) persists until the user reinstalls, and
+/// the `updatedAt` short-circuit in `reloadState()` only guards the success path — so a
+/// refused file is parsed twice every 2 seconds for as long as the mismatch lasts. The trade
+/// is still the right way round, because it moves the cost onto the broken case instead of
+/// the healthy one, but it is a trade rather than a free lunch.
 ///
 /// Private so that nothing outside the decoder starts using it as a cheap way to peek at the
 /// file: it is not cheap, and it answers only one question.
 private struct VersionHeader: Decodable {
     /// No `CodingKeys` needed — `version` is the one key in this contract that was never
     /// snake-cased. See `OverlayState.CodingKeys` for why that matters here.
+    ///
+    /// **`Int` bounds what the retry can rescue, and the bound is worth knowing.** A v2 that
+    /// keeps the key but changes its TYPE — a semver string, say — fails this decode too,
+    /// and the log falls back to `typeMismatch(expected Int)` with no indication that
+    /// `version` is the field in question. A v2 that *renames* the key degrades better:
+    /// `keyNotFound(version)`, because that branch keeps the key name. So this covers
+    /// "unparseable against the v1 schema", not "unparseable in any way".
     let version: Int
 }
 
@@ -326,17 +339,43 @@ enum OverlayStateError: Error {
 /// the distinction anyone debugging actually needs.
 ///
 /// Not reachable from today's writer — `HashMap<String, OverlayTier>` can only emit strings,
-/// and truncation fails earlier as `dataCorrupted`. It is guarded anyway because
-/// `overlay_state.json` is a versioned contract with two readers, and a newer writer
-/// reshaping `paths` against an installed older appex is precisely the gap that
-/// [`OverlayState.supportedVersion`] now closes.
+/// and truncation fails earlier as `dataCorrupted`. It is guarded anyway, and DBSYNC-91's
+/// version check does NOT make that redundant: the case that still reaches the
+/// `typeMismatch` branch is a **same-version** reshape — a writer that changes the shape of
+/// `paths` and forgets to bump `version`. That is a human mistake rather than a contract
+/// event, so no version guard can ever catch it, which is exactly why the redaction has to
+/// survive independently of one.
+/// How the log line should describe what happened: `"refusing"` or `"cannot decode"`.
+///
+/// A refused file parsed perfectly — nothing failed, the reader declined it — and calling
+/// that "cannot decode" points whoever reads the log at corruption, or at the sandbox
+/// problems of DBSYNC-76, which are debugged in a completely different direction. Telling
+/// the two apart is the whole reason [`OverlayStateError`] is its own type.
+///
+/// **It lives here, and not inline at the one call site, for the same reason the decode
+/// does: `SyncExtension.swift` cannot be compiled by `Tests/run-badge-diff-tests.sh`.** A
+/// first draft put this branch there, where no check could reach it — in a change whose own
+/// argument is that unreachable code is where this project's defects survive review.
+func logVerb(for error: Error) -> String {
+    error is OverlayStateError ? "refusing" : "cannot decode"
+}
+
 func logSafeDescription(of error: Error) -> String {
     // Handled BEFORE the `DecodingError` cast below, which would otherwise fall through to
     // the type-name branch and report a bare "OverlayStateError" — losing the one detail
     // this error exists to carry (DBSYNC-91). A schema version is an integer from our own
     // contract, so unlike a `codingPath` there is nothing here to redact.
-    if case .unsupportedVersion(let found)? = error as? OverlayStateError {
-        return "unsupportedVersion(\(found))"
+    //
+    // `switch` rather than `if case`, deliberately. With `if case`, adding a second
+    // `OverlayStateError` case would compile clean and fall through to the type-name branch
+    // below — reporting the bare "OverlayStateError" this block exists to prevent, and
+    // leaking whatever the new case carries if it carries a path. This way that mistake is
+    // a compile error.
+    if let refusal = error as? OverlayStateError {
+        switch refusal {
+        case .unsupportedVersion(let found):
+            return "unsupportedVersion(\(found))"
+        }
     }
     guard let decoding = error as? DecodingError else {
         // Not a decoding failure — a read error, already scoped to a path we logged

--- a/apps/desktop/native/macos/FinderSyncExtension/SyncExtension.swift
+++ b/apps/desktop/native/macos/FinderSyncExtension/SyncExtension.swift
@@ -175,9 +175,14 @@ final class DropboxSyncFinderSync: FIFinderSync {
             // which this file's own comments record as expensive to find.
             //
             // Logged on the transition only, like the read path: this runs every 2 seconds.
+            //
+            // The verb is chosen by `logVerb(for:)` rather than hardcoded: a refusal and a
+            // parse failure are different events, and "cannot decode" on a file that parsed
+            // perfectly sends the reader after corruption (DBSYNC-91). That choice lives in
+            // BadgeDiff.swift because nothing here is reachable from a check.
             if !lastDecodeFailed {
-                NSLog("DropboxSync FinderSync: cannot decode %@ — no badges will be shown. %@",
-                      url.path, logSafeDescription(of: error))
+                NSLog("DropboxSync FinderSync: %@ %@ — no badges will be shown. %@",
+                      logVerb(for: error), url.path, logSafeDescription(of: error))
                 lastDecodeFailed = true
             }
             state = nil

--- a/apps/desktop/native/macos/FinderSyncExtension/Tests/BadgeDiffTests.swift
+++ b/apps/desktop/native/macos/FinderSyncExtension/Tests/BadgeDiffTests.swift
@@ -503,6 +503,52 @@ struct BadgeDiffTests {
         checkBool("the supported version is still accepted",
                   (try? OverlayState.decode(from: json)) != nil, true)
 
+        // THE CASE THE GUARD ABOVE CANNOT REACH (DBSYNC-91 slice 2). `paths` is an object
+        // where v1 expects a string, so the decode throws before any version is available
+        // to check — and this is the SHAPE a real breaking change would most likely take.
+        // Reported as `typeMismatch` before the fallback existed, which sends whoever reads
+        // the log looking for corruption instead of a mismatched install.
+        let reshapedFuture = Data("""
+        {
+          "version": 2,
+          "updated_at": "2026-08-27T12:00:00Z",
+          "sync_folder": "/Users/x/DropboxSync",
+          "paths": { "Clients/AcmeCorp_NDA_signed.pdf": { "tier": "synced" } }
+        }
+        """.utf8)
+
+        do {
+            _ = try OverlayState.decode(from: reshapedFuture)
+            print("  FAIL a v2 payload should be refused even when v1 cannot parse it")
+            failures += 1
+        } catch {
+            let safe = logSafeDescription(of: error)
+            checkBool("an unreadable v2 is reported as a version problem",
+                      safe.contains("unsupportedVersion"), true)
+            checkBool("and not as the parse failure that happened first",
+                      safe.contains("typeMismatch"), false)
+            checkBool("the fallback path never names the user's file either",
+                      safe.contains("AcmeCorp_NDA_signed"), false)
+        }
+
+        // NEGATIVE CONTROL. Bytes with no readable version at all must not acquire one.
+        // Without this, a fallback that fired unconditionally would look green on every
+        // check above it.
+        do {
+            _ = try OverlayState.decode(from: Data("{ not json at all".utf8))
+            print("  FAIL malformed bytes should not decode")
+            failures += 1
+        } catch {
+            checkBool("malformed bytes are still reported as corruption",
+                      logSafeDescription(of: error).contains("dataCorrupted"), true)
+        }
+
+        // SECOND NEGATIVE CONTROL, and it costs nothing: the `leaky` payload above is
+        // `version: 1` with a type-mismatched tier — a genuine v1 failure. Its DBSYNC-73
+        // check ("but it still says what kind of failure it was") asserts `typeMismatch`,
+        // and it is what goes red if the fallback stops checking `version != supported`.
+        // Recorded here so the next reader knows that check is doing double duty.
+
         if failures == 0 {
             print("BadgeDiff: all checks passed")
             exit(0)

--- a/apps/desktop/native/macos/FinderSyncExtension/Tests/BadgeDiffTests.swift
+++ b/apps/desktop/native/macos/FinderSyncExtension/Tests/BadgeDiffTests.swift
@@ -482,9 +482,9 @@ struct BadgeDiffTests {
         // claimed the two cleared the same bar, and review caught that they do not.
         //
         // Kept for what it can actually catch, which is narrower than the first two attempts
-        // at this comment claimed: a String added to `.unsupportedVersion` itself, or to its
-        // branch in `logSafeDescription` — say a "near <path>" context that seemed helpful.
-        // That reddens.
+        // at this comment claimed: a String added to the `.unsupportedVersion` case, then
+        // logged by its branch — say a "near <path>" context that looked helpful. That
+        // reddens. The branch alone cannot do it: all it has in scope is `found: Int`.
         //
         // It does NOT catch a future `OverlayStateError` case carrying a path, which is what
         // the previous version of this comment promised: nothing in this suite constructs
@@ -492,7 +492,8 @@ struct BadgeDiffTests {
         // it needs its own check; this one will not notice.
         //
         // Nor is it independent even within its own scope — a leak added to
-        // `.unsupportedVersion` reddens the exact `checkOptional` below it too.
+        // `.unsupportedVersion` also reddens the exact-match `checkOptional` two lines below,
+        // the one asserting "unsupportedVersion(2)". The verb check beside it stays green.
         let futureVersion = Data("""
         {
           "version": 2,

--- a/apps/desktop/native/macos/FinderSyncExtension/Tests/BadgeDiffTests.swift
+++ b/apps/desktop/native/macos/FinderSyncExtension/Tests/BadgeDiffTests.swift
@@ -465,6 +465,44 @@ struct BadgeDiffTests {
                       logSafeDescription(of: error).contains("updated_at"), true)
         }
 
+        print("OverlayState version guard (DBSYNC-91)")
+
+        // The case a best-effort reader accepts happily: EVERYTHING is valid except the
+        // version. Same shape as the payload at the top of this section, same keys, same
+        // tiers — so nothing but `version` can be responsible for the outcome.
+        //
+        // The sensitive-looking key is deliberate. This is a new error type on a new path,
+        // and it has to clear the same privacy bar as the DecodingError one above.
+        let futureVersion = Data("""
+        {
+          "version": 2,
+          "updated_at": "2026-08-27T12:00:00Z",
+          "sync_folder": "/Users/x/DropboxSync",
+          "paths": { "Clients/AcmeCorp_NDA_signed.pdf": "synced" }
+        }
+        """.utf8)
+
+        do {
+            _ = try OverlayState.decode(from: futureVersion)
+            print("  FAIL an unknown version should be refused, not applied as v1")
+            failures += 1
+        } catch {
+            // Reaching this branch at all IS the refusal check — the `do` side above
+            // increments `failures` if the decode succeeds. A `checkBool(true, true)` here
+            // would print an extra "ok" line that no input could ever redden.
+            let safe = logSafeDescription(of: error)
+            checkBool("the refusal names the version found", safe.contains("2"), true)
+            checkBool("and says it was a version problem",
+                      safe.contains("unsupportedVersion"), true)
+            checkBool("a refusal never names the user's file",
+                      safe.contains("AcmeCorp_NDA_signed"), false)
+        }
+
+        // The other direction, and not a formality: a guard written the wrong way round
+        // refuses the only version that exists, and every check above would still pass.
+        checkBool("the supported version is still accepted",
+                  (try? OverlayState.decode(from: json)) != nil, true)
+
         if failures == 0 {
             print("BadgeDiff: all checks passed")
             exit(0)

--- a/apps/desktop/native/macos/FinderSyncExtension/Tests/BadgeDiffTests.swift
+++ b/apps/desktop/native/macos/FinderSyncExtension/Tests/BadgeDiffTests.swift
@@ -471,8 +471,18 @@ struct BadgeDiffTests {
         // version. Same shape as the payload at the top of this section, same keys, same
         // tiers — so nothing but `version` can be responsible for the outcome.
         //
-        // The sensitive-looking key is deliberate. This is a new error type on a new path,
-        // and it has to clear the same privacy bar as the DecodingError one above.
+        // The sensitive-looking key is a TRIPWIRE, and it is worth being precise about what
+        // it is and is not. `OverlayStateError` carries an `Int` and nothing else, so
+        // `String(describing:)` on it is "unsupportedVersion(2)" — there is no path in the
+        // type to leak, and no mutation of today's code can redden the check below.
+        //
+        // That makes it weaker evidence than the DecodingError privacy check above, which
+        // earns its keep through the paired control at "the raw description WOULD have
+        // leaked it". No such control is possible here; a first draft of this section
+        // claimed the two cleared the same bar, and review caught that they do not.
+        //
+        // Kept anyway, for the one thing it can catch: a future `OverlayStateError` case
+        // that carries a String — a path, a key, a `sync_folder` — reaching the log.
         let futureVersion = Data("""
         {
           "version": 2,
@@ -490,18 +500,35 @@ struct BadgeDiffTests {
             // Reaching this branch at all IS the refusal check — the `do` side above
             // increments `failures` if the decode succeeds. A `checkBool(true, true)` here
             // would print an extra "ok" line that no input could ever redden.
+            // Exact, not `contains("2")`: that also passes on `unsupportedVersion(12)` and
+            // on `unsupportedVersion(-2)`, so it was looser than its own label. Exact is no
+            // weaker against any mutation.
             let safe = logSafeDescription(of: error)
-            checkBool("the refusal names the version found", safe.contains("2"), true)
-            checkBool("and says it was a version problem",
-                      safe.contains("unsupportedVersion"), true)
-            checkBool("a refusal never names the user's file",
+            checkOptional("the refusal is reported exactly, naming the version found",
+                          safe, "unsupportedVersion(2)")
+            checkBool("a refusal never names the user's file (tripwire — see above)",
                       safe.contains("AcmeCorp_NDA_signed"), false)
         }
 
-        // The other direction, and not a formality: a guard written the wrong way round
-        // refuses the only version that exists, and every check above would still pass.
-        checkBool("the supported version is still accepted",
-                  (try? OverlayState.decode(from: json)) != nil, true)
+        // NO CHECK HERE FOR THE ACCEPT DIRECTION, and the omission is deliberate.
+        //
+        // A `checkBool("the supported version is still accepted", decode(json) != nil)`
+        // stood here and was green by construction: `json` is decoded at the top of the
+        // DBSYNC-73 section by a `guard` that calls `exit(1)`, so merely reaching this line
+        // proves the decode succeeded. Its comment claimed the opposite — that a guard
+        // written the wrong way round would leave "every check above" passing. Inverting the
+        // guard shows what actually happens:
+        //
+        //     OverlayState.decode (DBSYNC-73)
+        //       FAIL OverlayState.decode threw on a valid payload
+        //
+        // and the run exits before this section prints at all. So the accept direction IS
+        // covered, by that fatal guard, and a check here could never add to it — anything
+        // placed after line ~391 is unreachable when the accept direction breaks.
+        //
+        // Recorded rather than silently deleted because "a check that cannot fail is not
+        // evidence" is this project's rule, and this file shipped a violation of it in a
+        // change whose entire argument was mutation-tested evidence.
 
         // THE CASE THE GUARD ABOVE CANNOT REACH (DBSYNC-91 slice 2). `paths` is an object
         // where v1 expects a string, so the decode throws before any version is available
@@ -525,10 +552,14 @@ struct BadgeDiffTests {
             let safe = logSafeDescription(of: error)
             checkBool("an unreadable v2 is reported as a version problem",
                       safe.contains("unsupportedVersion"), true)
-            checkBool("and not as the parse failure that happened first",
+            // Diagnostic, not independent coverage: nothing can redden this without also
+            // reddening the check above it, since that would need a description containing
+            // both strings. It earns its line by naming the wrong answer explicitly.
+            checkBool("and not as the parse failure that happened first (diagnostic)",
                       safe.contains("typeMismatch"), false)
-            checkBool("the fallback path never names the user's file either",
-                      safe.contains("AcmeCorp_NDA_signed"), false)
+            // The privacy tripwire that stood here was a duplicate: same error type, same
+            // `logSafeDescription` branch as the one in the section above, so no input could
+            // redden one without the other. One tripwire for `OverlayStateError` is enough.
         }
 
         // NEGATIVE CONTROL. Bytes with no readable version at all must not acquire one.
@@ -541,7 +572,16 @@ struct BadgeDiffTests {
         } catch {
             checkBool("malformed bytes are still reported as corruption",
                       logSafeDescription(of: error).contains("dataCorrupted"), true)
+            // The verb the caller will log. A refusal parsed fine, so calling it "cannot
+            // decode" sends the reader after corruption or after DBSYNC-76's sandbox
+            // problems; a genuine parse failure IS a decode failure and must keep saying so.
+            // Both directions checked, because a `logVerb` stuck on either value passes one
+            // of them.
+            checkOptional("a real parse failure is still called a decode failure",
+                          logVerb(for: error), "cannot decode")
         }
+        checkOptional("a refusal is called a refusal, not a decode failure",
+                      logVerb(for: OverlayStateError.unsupportedVersion(2)), "refusing")
 
         // SECOND NEGATIVE CONTROL, and it costs nothing: the `leaky` payload above is
         // `version: 1` with a type-mismatched tier — a genuine v1 failure. Its DBSYNC-73

--- a/apps/desktop/native/macos/FinderSyncExtension/Tests/BadgeDiffTests.swift
+++ b/apps/desktop/native/macos/FinderSyncExtension/Tests/BadgeDiffTests.swift
@@ -481,8 +481,18 @@ struct BadgeDiffTests {
         // leaked it". No such control is possible here; a first draft of this section
         // claimed the two cleared the same bar, and review caught that they do not.
         //
-        // Kept anyway, for the one thing it can catch: a future `OverlayStateError` case
-        // that carries a String — a path, a key, a `sync_folder` — reaching the log.
+        // Kept for what it can actually catch, which is narrower than the first two attempts
+        // at this comment claimed: a String added to `.unsupportedVersion` itself, or to its
+        // branch in `logSafeDescription` — say a "near <path>" context that seemed helpful.
+        // That reddens.
+        //
+        // It does NOT catch a future `OverlayStateError` case carrying a path, which is what
+        // the previous version of this comment promised: nothing in this suite constructs
+        // such a case, so adding one leaves every check green. If a case like that is added,
+        // it needs its own check; this one will not notice.
+        //
+        // Nor is it independent even within its own scope — a leak added to
+        // `.unsupportedVersion` reddens the exact `checkOptional` below it too.
         let futureVersion = Data("""
         {
           "version": 2,
@@ -508,6 +518,14 @@ struct BadgeDiffTests {
                           safe, "unsupportedVersion(2)")
             checkBool("a refusal never names the user's file (tripwire — see above)",
                       safe.contains("AcmeCorp_NDA_signed"), false)
+            // The verb the caller logs, on the error `decode` ACTUALLY threw rather than a
+            // hand-built literal — which is what this checked in its first draft, sitting
+            // orphaned between two unrelated blocks. A refused file parsed fine, so "cannot
+            // decode" would send the reader after corruption or after DBSYNC-76's sandbox
+            // problems. The other direction is checked at the malformed-bytes control below;
+            // both are needed, because a `logVerb` stuck on either constant passes one.
+            checkOptional("a refusal is called a refusal, not a decode failure",
+                          logVerb(for: error), "refusing")
         }
 
         // NO CHECK HERE FOR THE ACCEPT DIRECTION, and the omission is deliberate.
@@ -523,8 +541,10 @@ struct BadgeDiffTests {
         //       FAIL OverlayState.decode threw on a valid payload
         //
         // and the run exits before this section prints at all. So the accept direction IS
-        // covered, by that fatal guard, and a check here could never add to it — anything
-        // placed after line ~391 is unreachable when the accept direction breaks.
+        // covered, by that `guard let decoded = try? OverlayState.decode(from: json)`, and a
+        // check on THAT payload after it can never add anything — the guard has already
+        // proved the decode succeeded. A check using a DIFFERENT v1 payload would be live;
+        // it is omitted as redundant rather than as impossible.
         //
         // Recorded rather than silently deleted because "a check that cannot fail is not
         // evidence" is this project's rule, and this file shipped a violation of it in a
@@ -557,9 +577,11 @@ struct BadgeDiffTests {
             // both strings. It earns its line by naming the wrong answer explicitly.
             checkBool("and not as the parse failure that happened first (diagnostic)",
                       safe.contains("typeMismatch"), false)
-            // The privacy tripwire that stood here was a duplicate: same error type, same
-            // `logSafeDescription` branch as the one in the section above, so no input could
-            // redden one without the other. One tripwire for `OverlayStateError` is enough.
+            // The privacy tripwire that stood here was a duplicate: both paths throw
+            // `.unsupportedVersion` and hit the same `logSafeDescription` branch, so no
+            // input could redden one without the other. Worth knowing that this holds only
+            // while `OverlayStateError` has one case — if the fallback ever throws a
+            // different case from the guard, this path needs its own assertion back.
         }
 
         // NEGATIVE CONTROL. Bytes with no readable version at all must not acquire one.
@@ -580,8 +602,6 @@ struct BadgeDiffTests {
             checkOptional("a real parse failure is still called a decode failure",
                           logVerb(for: error), "cannot decode")
         }
-        checkOptional("a refusal is called a refusal, not a decode failure",
-                      logVerb(for: OverlayStateError.unsupportedVersion(2)), "refusing")
 
         // SECOND NEGATIVE CONTROL, and it costs nothing: the `leaky` payload above is
         // `version: 1` with a type-mismatched tier — a genuine v1 failure. Its DBSYNC-73

--- a/apps/desktop/src-tauri/src/overlay_state.rs
+++ b/apps/desktop/src-tauri/src/overlay_state.rs
@@ -45,6 +45,15 @@ pub enum OverlayTier {
 /// additive, and a reader that does not know the value finds no badge registered for it
 /// and renders nothing — exactly what it did before the value existed. The bump rule
 /// above is for changes that would make an existing reader wrong, not merely incomplete.
+///
+/// **Bumping `version` means changing both readers in the same commit (DBSYNC-91):**
+/// - `native/macos/FinderSyncExtension/BadgeDiff.swift` — `OverlayState.supportedVersion`.
+///   It refuses anything else outright: no badges, one log line. Leaving it behind does not
+///   degrade macOS, it turns macOS off.
+/// - `native/windows/shell-menu/src/scope.rs` — reads only `sync_folder`, draws no badges,
+///   and has no version guard by decision, not by oversight. It cannot show a wrong badge,
+///   and a `sync_folder` it fails to find already costs nothing worse than a missing
+///   context menu. If a bump moves or renames that field, this is where it bites, silently.
 #[derive(Serialize)]
 struct OverlayStateFile {
     version: u32,

--- a/apps/desktop/src-tauri/src/overlay_state.rs
+++ b/apps/desktop/src-tauri/src/overlay_state.rs
@@ -46,7 +46,10 @@ pub enum OverlayTier {
 /// and renders nothing — exactly what it did before the value existed. The bump rule
 /// above is for changes that would make an existing reader wrong, not merely incomplete.
 ///
-/// **Bumping `version` means changing both readers in the same commit (DBSYNC-91):**
+/// **Bumping `version` means changing both readers that exist today, in the same commit
+/// (DBSYNC-91)** — "both", not the three surfaces listed above: the Linux emblems and the
+/// Windows status column are still aspirational, and `native/windows/shell-overlay/` holds a
+/// README and no code.
 /// - `native/macos/FinderSyncExtension/BadgeDiff.swift` — `OverlayState.supportedVersion`.
 ///   It refuses anything else outright: no badges, one log line. Leaving it behind does not
 ///   degrade macOS, it turns macOS off.


### PR DESCRIPTION
## Summary

`overlay_state.json` documents itself as a versioned contract — "bump on a breaking change" — and the macOS reader decoded `version` into `OverlayState` and never looked at it. A file with a bumped version and an incompatible schema was applied exactly as if it were v1: whatever fields still lined up were used, the rest silently ignored. The field documented a contract and enforced nothing.

Two commits, closing it from both directions.

**617d797 — refuse an unknown version.** `OverlayState.supportedVersion`, an `OverlayStateError.unsupportedVersion(Int)`, a guard in `decode`, a branch in `logSafeDescription`, and the bump rule in `overlay_state.rs` now naming both readers.

**9ef84e8 — name the version when the file will not parse against v1.** The guard above runs *after* a successful decode, so it cannot fire on the breaking change most likely to happen: reshape `paths` and v1 throws `typeMismatch` before it has a version to look at. The failure path retries a one-field header decode.

Slices #131 and #132. Both commits are independently green — the first passes 62 checks on its own.

## Stack

`desktop-tauri` — macOS Finder Sync appex (Swift) plus one Rust doc comment. No behaviour change on the Rust side.

## Jira Ticket

DBSYNC-91 — https://manuelbsan.atlassian.net/browse/DBSYNC-91

The decision was recorded on the ticket, with its reasoning, before any code was written. That was its first acceptance criterion.

## Why refuse, rather than best-effort

Best-effort is what the code already did, minus a warning. It also inverts this project's own rule, settled in DBSYNC-84: **a badge that is confidently wrong is worse than no badge**. A user on a mismatched pair now sees badges missing — which they report — instead of a sync status nobody checked.

`version <= KNOWN` was the tempting middle and was declined: it promises that v2 is a superset of v1, which no writer has ever promised. `version` is documented as bumping *on a breaking change*, so a bump is precisely the case a reader must not guess at.

The mismatched pair is measured, not hypothetical. DBSYNC-86 found that every reinstall registers a **new** plug-in instance and the old ones linger, so an old appex can genuinely be the one Finder has loaded while a newer app writes the file.

## Two things in the diff that look like style and are not

**`logSafeDescription`'s new branch sits ahead of the `DecodingError` cast.** Behind it, the function's `guard ... else { return "\(type(of: error))" }` renders a refusal as the bare string `OverlayStateError` and loses the version number — the one detail the error exists to carry. The ordering is the feature.

**The header retry sits inside the `catch`, not before the decode.** Header-first reads better and costs more: `JSONDecoder` parses the whole document to extract one field, so it means two full parses of a file that can hold thousands of path entries, on every tick of a 2-second timer, in the case where nothing is wrong. This way the healthy path parses once and the second parse is paid only when something has already failed. That is a control-flow claim readable from the diff — **no benchmark was run and none is implied.**

## `SyncExtension.swift` is untouched, deliberately

Two acceptance criteria are about its behaviour — one log line on the transition, `state` and `lastUpdatedAt` both cleared — and `reloadState()` already does all of it for anything `decode` throws. An edit there would have meant the design went wrong.

## Test Plan

- [x] `./apps/desktop/native/macos/FinderSyncExtension/Tests/run-badge-diff-tests.sh` — **58 → 62 → 66**. The 58 baseline was measured on `main` at fa8423d before any edit.
- [x] `cargo test --manifest-path apps/desktop/src-tauri/Cargo.toml` — **197**, unchanged. The Rust edit is a comment; a change here would mean something else moved.
- [x] `cargo fmt --check` — clean.
- [x] `cargo clippy` — 4 lib warnings, unchanged from before this branch.

### Mutations

**The six-mutation table that stood here was stale and partly wrong**, and review caught both problems: it mixed outputs from two different commits, and it named checks that later commits deleted. Rather than patch it in place, it is replaced by a single table run entirely against the current head — see the comment below, *Re-review findings addressed*.

Summary: **eight mutations**, each applied to a tree verified identical to baseline first and reverted before the next. Two of them (G, H) cover a function that did not exist when this PR opened. One of them (D) reddens three checks written for DBSYNC-73, before this branch existed, which makes it the strongest evidence here.

### Not proven by any of this

**Nobody has watched a real Finder refuse a real v2 file, because nothing writes v2.** Every check here is about the decoder, not about the extension end-to-end under a genuine mismatched install. Stated rather than left implied.

A v2 whose bytes are *also* malformed reports `dataCorrupted`, not a version error. Correct — there is nothing to read a version out of — but it means the fallback covers "unparseable against v1", not "unparseable at all".

## Windows: gap accepted, not fixed

`native/windows/shell-menu/src/scope.rs` is the only Windows reader that exists (`shell-overlay/` is a README). It reads **only** `sync_folder`, through `#[serde(default)] Option<String>`, and draws no badges — so the confidently-wrong-badge failure this PR is about cannot occur there. A v2 that moved that field already degrades to `None`, which is the same outcome a guard would force.

The condition attached to accepting it is the last hunk of this PR: the bump rule in `overlay_state.rs` now says a bump means changing both readers, and says what each one does when left behind. Tracked for runtime validation on DBSYNC-89.

🤖 Generated with Claude Code

