### PR TITLE
ci(#DBSYNC-72): tag-triggered macOS release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,255 @@
+# Tag-triggered macOS release: build, sign, notarize, staple, verify, publish.
+#
+# Separate from ci.yml on purpose (GitHub #85). `ci.yml` builds UNSIGNED on every PR with
+# `DROPBOX_APP_KEY: dummy` and must stay that way — pull requests from a fork cannot read
+# secrets, and a PR check that needs an Apple identity is a PR check that fails for everyone
+# but the maintainer.
+#
+# This workflow automates ONLY what DBSYNC-72 Slice 4 (#84) proved by hand first. It
+# introduces no new signing approach: the notarization sequence below is the same
+# ditto -> notarytool submit --wait -> stapler staple -> verify that was run manually, in
+# that order, for exactly that reason. When this workflow fails, the cause is the pipeline —
+# the signing configuration is already known to work.
+#
+# Two deliberate departures from the original slice spec, both recorded on #85:
+#
+#  1. Notarization authenticates with an App Store Connect API KEY, not APPLE_ID plus an
+#     app-specific password. An app-specific password is account-wide; an API key is scoped
+#     and can be revoked on its own without touching the Apple ID. The key already existed
+#     and was used for the manual runs.
+#  2. Tauri only SIGNS here. Notarization is done explicitly in the steps below rather than
+#     by the bundler, so that what runs in CI is visibly the same sequence a human ran, and
+#     so a notarization failure is attributable to a named step.
+#
+# Required repository secrets — names only, never values:
+#
+#   APPLE_CERTIFICATE            base64 of a .p12 export of the Developer ID Application cert
+#   APPLE_CERTIFICATE_PASSWORD   password used when exporting that .p12
+#   APPLE_SIGNING_IDENTITY       e.g. "Developer ID Application: NAME (TEAMID)"
+#   APPLE_TEAM_ID                the 10-character team id
+#   APPLE_API_KEY_P8             base64 of the AuthKey_XXXXXXXXXX.p8 from App Store Connect
+#   APPLE_API_KEY_ID             the key id, i.e. the XXXXXXXXXX in that filename
+#   APPLE_API_ISSUER             App Store Connect issuer id (a UUID)
+#   DROPBOX_APP_KEY              real value; `option_env!` bakes it into the binary at build
+#   DROPBOX_REDIRECT_URI         real value; same mechanism
+#
+# The last two matter more than they look. `auth/oauth.rs` reads both through `option_env!`,
+# so a release built with ci.yml's `dummy` compiles, signs and notarizes perfectly and then
+# cannot authenticate against Dropbox at all.
+
+name: release
+
+on:
+  push:
+    tags:
+      - 'v*'
+  # Manual runs are allowed so the pipeline can be exercised without minting a public tag.
+  workflow_dispatch:
+
+permissions:
+  contents: write # required to create the GitHub release
+
+concurrency:
+  # Never cancel a release in flight: a half-finished run can leave a notarization submitted
+  # with nothing stapled, and the tag would look released when it is not.
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  macos:
+    runs-on: macos-latest
+    timeout-minutes: 45
+
+    env:
+      DROPBOX_APP_KEY: ${{ secrets.DROPBOX_APP_KEY }}
+      DROPBOX_REDIRECT_URI: ${{ secrets.DROPBOX_REDIRECT_URI }}
+      # Read by tauri-cli, which prefers this over `bundle.macOS.signingIdentity` in
+      # tauri.conf.json — that key is pinned to "-" (ad-hoc) and must stay pinned, because
+      # with no identity resolving at all the bundler skips its whole signing block and the
+      # host bundle ships with no CodeResources seal over Contents/PlugIns/*.appex.
+      APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
+      # build-appex.sh passes this to xcodebuild as DEVELOPMENT_TEAM.
+      APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          prefix-key: release-macos
+          workspaces: apps/desktop/src-tauri
+          # Never populate the cache from a release run. A release is rare and its cache
+          # would evict the entries the PR jobs actually use.
+          save-if: false
+          env-vars: DROPBOX
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Create a temporary keychain and import the signing identity
+        # A dedicated keychain, deleted unconditionally at the end of the job. The runner is
+        # ephemeral, but a keychain that outlives the job on a self-hosted runner would leave
+        # a usable Developer ID sitting on disk.
+        env:
+          APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
+          APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+        run: |
+          set -euo pipefail
+          KEYCHAIN=$RUNNER_TEMP/release.keychain-db
+          KEYCHAIN_PASSWORD=$(uuidgen)
+
+          security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN"
+          security set-keychain-settings -lut 3600 "$KEYCHAIN"
+          security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN"
+
+          # The .p12 never reaches the log: base64 is decoded straight to a file.
+          echo "$APPLE_CERTIFICATE" | base64 --decode > "$RUNNER_TEMP/certificate.p12"
+          security import "$RUNNER_TEMP/certificate.p12" \
+            -k "$KEYCHAIN" \
+            -P "$APPLE_CERTIFICATE_PASSWORD" \
+            -T /usr/bin/codesign -T /usr/bin/security
+          rm -f "$RUNNER_TEMP/certificate.p12"
+
+          # Without this, codesign blocks on a UI prompt that no one can answer and the job
+          # hangs until the timeout rather than failing.
+          security set-key-partition-list -S apple-tool:,apple: -s -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN" > /dev/null
+          security list-keychain -d user -s "$KEYCHAIN" login.keychain-db
+
+          echo "Identities available to this job:"
+          security find-identity -v -p codesigning "$KEYCHAIN" | sed 's/[0-9A-F]\{40\}/<hash>/'
+
+      - name: Verify the expected identity is the one that will be used
+        # This machine's local keychain holds Developer ID identities belonging to other
+        # organisations; the runner's does not, but the check costs nothing and states the
+        # invariant where it can fail rather than in a comment.
+        run: |
+          set -euo pipefail
+          if ! security find-identity -v -p codesigning "$RUNNER_TEMP/release.keychain-db" \
+               | grep -qF "$APPLE_SIGNING_IDENTITY"; then
+            echo "::error::APPLE_SIGNING_IDENTITY is not present in the imported keychain."
+            exit 1
+          fi
+
+      - name: Build and sign the app bundle
+        # Signing only. Notarization is the next step, on purpose — see the header.
+        run: npm --workspace apps/desktop run tauri -- build --bundles app,dmg
+
+      - name: Notarize and staple
+        env:
+          APPLE_API_KEY_P8: ${{ secrets.APPLE_API_KEY_P8 }}
+          APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
+          APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
+        run: |
+          set -euo pipefail
+          BUNDLE=apps/desktop/src-tauri/target/release/bundle
+          APP="$BUNDLE/macos/DropboxSyncDesktop.app"
+
+          KEY="$RUNNER_TEMP/AuthKey.p8"
+          echo "$APPLE_API_KEY_P8" | base64 --decode > "$KEY"
+
+          # `ditto -c -k --keepParent`, not `zip`: zip does not preserve the symlinks and
+          # extended attributes inside a bundle, and notarization of a mangled bundle fails
+          # for reasons that read like a signing problem.
+          ditto -c -k --keepParent "$APP" "$RUNNER_TEMP/DropboxSyncDesktop.zip"
+
+          xcrun notarytool submit "$RUNNER_TEMP/DropboxSyncDesktop.zip" \
+            --key "$KEY" --key-id "$APPLE_API_KEY_ID" --issuer "$APPLE_API_ISSUER" \
+            --wait --timeout 30m
+
+          # Staple the .app, then the .dmg separately. Stapling the app does not staple the
+          # disk image that contains it, and an unstapled dmg makes Gatekeeper reach the
+          # network on first open — which fails on a machine that is offline.
+          xcrun stapler staple "$APP"
+          DMG=$(find "$BUNDLE/dmg" -name '*.dmg' -maxdepth 1 | head -1)
+          if [ -n "$DMG" ]; then
+            xcrun notarytool submit "$DMG" \
+              --key "$KEY" --key-id "$APPLE_API_KEY_ID" --issuer "$APPLE_API_ISSUER" \
+              --wait --timeout 30m
+            xcrun stapler staple "$DMG"
+          fi
+
+          rm -f "$KEY"
+
+      - name: Verify the artifacts the way a user's machine will
+        # The same four checks that passed by hand on #84, run here so that a release which
+        # would be rejected on arrival fails the pipeline instead.
+        run: |
+          set -euo pipefail
+          BUNDLE=apps/desktop/src-tauri/target/release/bundle
+          APP="$BUNDLE/macos/DropboxSyncDesktop.app"
+          APPEX="$APP/Contents/PlugIns/DropboxSyncFinderSync.appex"
+
+          echo "--- host"
+          codesign -dv --verbose=4 "$APP" 2>&1 | grep -E 'Authority=Developer|TeamIdentifier'
+          echo "--- nested appex (F4: this is the one that was unverified before #84)"
+          codesign -dv --verbose=4 "$APPEX" 2>&1 | grep -E 'Authority=Developer|TeamIdentifier'
+
+          HOST_TEAM=$(codesign -dv --verbose=4 "$APP"   2>&1 | sed -n 's/^TeamIdentifier=//p')
+          APPEX_TEAM=$(codesign -dv --verbose=4 "$APPEX" 2>&1 | sed -n 's/^TeamIdentifier=//p')
+          if [ "$HOST_TEAM" != "$APPEX_TEAM" ]; then
+            echo "::error::host team $HOST_TEAM != appex team $APPEX_TEAM"
+            exit 1
+          fi
+
+          codesign --verify --deep --strict --verbose=2 "$APP"
+          xcrun stapler validate "$APP"
+          # The check that actually predicts what happens on the user's Mac.
+          spctl --assess --type execute --verbose=4 "$APP"
+
+          DMG=$(find "$BUNDLE/dmg" -name '*.dmg' -maxdepth 1 | head -1)
+          if [ -n "$DMG" ]; then
+            xcrun stapler validate "$DMG"
+          fi
+
+      - name: Package the app for upload
+        run: |
+          set -euo pipefail
+          BUNDLE=apps/desktop/src-tauri/target/release/bundle
+          # Zipped with ditto again so the stapled ticket and the bundle structure survive
+          # the round trip through GitHub's release assets.
+          ditto -c -k --keepParent "$BUNDLE/macos/DropboxSyncDesktop.app" \
+            "$RUNNER_TEMP/DropboxSyncDesktop-macos-arm64.zip"
+
+      - name: Publish the GitHub release
+        if: startsWith(github.ref, 'refs/tags/v')
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          BUNDLE=apps/desktop/src-tauri/target/release/bundle
+          ASSETS=("$RUNNER_TEMP/DropboxSyncDesktop-macos-arm64.zip")
+          DMG=$(find "$BUNDLE/dmg" -name '*.dmg' -maxdepth 1 | head -1)
+          [ -n "$DMG" ] && ASSETS+=("$DMG")
+
+          gh release create "${GITHUB_REF_NAME}" \
+            --title "${GITHUB_REF_NAME}" \
+            --generate-notes \
+            --draft \
+            "${ASSETS[@]}"
+
+      - name: Upload artifacts for a manual run
+        if: ${{ !startsWith(github.ref, 'refs/tags/v') }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: macos-release-artifacts
+          path: |
+            ${{ runner.temp }}/DropboxSyncDesktop-macos-arm64.zip
+            apps/desktop/src-tauri/target/release/bundle/dmg/*.dmg
+          if-no-files-found: error
+
+      - name: Delete the temporary keychain
+        # `always()`: the keychain must go even when signing, notarization or verification
+        # failed, which are precisely the runs where it still holds a usable identity.
+        if: always()
+        run: |
+          security delete-keychain "$RUNNER_TEMP/release.keychain-db" || true
+          security list-keychain -d user -s login.keychain-db || true
+          rm -f "$RUNNER_TEMP/AuthKey.p8" "$RUNNER_TEMP/certificate.p12" || true

--- a/README.md
+++ b/README.md
@@ -35,3 +35,38 @@ On Windows, `dev:win` compiles the release `.exe` without generating an installe
 ## License
 
 MIT — see `LICENSE`.
+
+## Releasing (macOS)
+
+Pushing a tag matching `v*` runs `.github/workflows/release.yml`: build → sign → notarize →
+staple → verify → draft GitHub release. `workflow_dispatch` runs the same job without
+minting a tag, and uploads the artifacts instead of publishing them.
+
+It automates the path that DBSYNC-72 Slice 4 proved by hand first, and it verifies its own
+output with the checks a user's Mac performs on arrival — `codesign --deep --strict`,
+`stapler validate`, and `spctl --assess`. A build that would be rejected on someone else's
+machine fails the pipeline instead of shipping.
+
+### Repository secrets it needs
+
+Names only. Never commit a value, and never echo one into a job log.
+
+| Secret | What it is |
+|---|---|
+| `APPLE_CERTIFICATE` | base64 of a `.p12` export of the Developer ID Application certificate |
+| `APPLE_CERTIFICATE_PASSWORD` | the password used when exporting that `.p12` |
+| `APPLE_SIGNING_IDENTITY` | `Developer ID Application: NAME (TEAMID)` |
+| `APPLE_TEAM_ID` | the 10-character team id |
+| `APPLE_API_KEY_P8` | base64 of `AuthKey_XXXXXXXXXX.p8` from App Store Connect |
+| `APPLE_API_KEY_ID` | the key id — the `XXXXXXXXXX` in that filename |
+| `APPLE_API_ISSUER` | App Store Connect issuer id (a UUID) |
+| `DROPBOX_APP_KEY` | the real app key |
+| `DROPBOX_REDIRECT_URI` | the real redirect URI |
+
+Notarization uses an App Store Connect **API key** rather than an Apple ID plus an
+app-specific password: an app-specific password is account-wide, while an API key is scoped
+and can be revoked on its own.
+
+The last two are easy to overlook and expensive to get wrong. `auth/oauth.rs` reads both
+through `option_env!`, so a release built with `ci.yml`'s `dummy` placeholder compiles,
+signs and notarizes perfectly — and then cannot authenticate against Dropbox at all.


### PR DESCRIPTION
## Summary

Slice 5 of DBSYNC-72 (#85). A tag-triggered `release.yml`, separate from `ci.yml`, that automates **only** what Slice 4 (#84) proved by hand: build → sign → notarize → staple → verify → draft release.

`ci.yml` is untouched and keeps building unsigned on PRs with `DROPBOX_APP_KEY: dummy`. That is not an oversight — a PR from a fork cannot read secrets, so a check requiring an Apple identity is a check that fails for everyone but the maintainer.

## The spec was wrong about the secrets, and it would have shipped

The slice listed **six**. It needs **nine**. `auth/oauth.rs` reads `DROPBOX_APP_KEY` and `DROPBOX_REDIRECT_URI` through `option_env!`, and `ci.yml` passes `dummy` for both. A release built without the real values **compiles, signs, notarizes and staples perfectly** — and then cannot authenticate against Dropbox at all. Every check in the pipeline would have been green.

## Deliberate departure: API key, not app-specific password

The spec named `APPLE_ID` + `APPLE_PASSWORD`. This uses an App Store Connect API key instead. An app-specific password is account-wide; an API key is scoped and revocable on its own without touching the Apple ID. The key already existed and is what the manual runs used. Reversible if you prefer the spec as written.

## Notarization is explicit, not delegated

Tauri only **signs** here. The `ditto -c -k --keepParent` → `notarytool submit --wait` → `stapler staple` sequence is written out, in that order, so what runs in CI is visibly the same sequence a human ran and a failure lands on a named step. That was the whole point of doing Slice 4 manually first.

The `.dmg` is notarized and stapled **separately**: stapling the `.app` does not staple the disk image containing it, and an unstapled dmg sends Gatekeeper to the network on first open — which fails on a machine that is offline.

## It verifies its own output

The four checks a user's Mac performs on arrival, run in the job:

- host and nested `.appex` carry the **same** `TeamIdentifier` — this is F4, the gap #84 closed by hand
- `codesign --verify --deep --strict`
- `xcrun stapler validate`
- `spctl --assess --type execute`

A build that would be rejected on someone else's Mac now fails the pipeline instead of shipping. DBSYNC-88 exists because that distinction is real.

## Test Plan

- [x] YAML parses; 14 steps; `ci.yml` untouched (`git status` confirms only the new file).
- [x] **`dotenv-cli` survives a missing `.env`** — every npm script here is wrapped in `dotenv -e .env --`, and there is no `.env` on a runner. Verified rather than assumed:
  ```
  $ FOO=frominherited npx dotenv -e .nonexistent-env -- node -e '...'
  exit ok, inherited env visible: frominherited
  ```
  Had it thrown, the release job would have died at the build step every time.
- [ ] **The workflow has never run.** ← the honest state

## Not verified, and this is the part that matters

**This pipeline has not executed once.** This repo has already lived what that is worth: 28 consecutive red runs with CI effectively switched off (DBSYNC-74), and the whole reason Slice 4 was done by hand first was so that a later CI failure could never be ambiguous between "the pipeline is wrong" and "the signing configuration is wrong".

So this should not merge and sit. The intended order:

1. Maintainer sets the nine secrets (names in the README hunk; values never leave their machine).
2. Merge.
3. Run via **`workflow_dispatch`** — same job, uploads artifacts instead of publishing, no public tag minted.
4. Only once that is green, tag `v0.1.0-rc1` and check the draft release's assets.

Step 3 exists so the pipeline can be proven before a tag makes it public.

## Security notes

- Temporary keychain, deleted in an `always()` step — the runs where it still holds a usable Developer ID are exactly the ones that failed partway.
- `set-key-partition-list` is set, otherwise `codesign` blocks on a UI prompt nobody can answer and the job hangs to its timeout instead of failing.
- The `.p12` and the `.p8` are decoded straight to files and removed; neither is ever echoed.
- The imported identity is checked against `APPLE_SIGNING_IDENTITY` before use. The runner's keychain is clean, but this machine's is not — it holds Developer ID identities belonging to two other organisations, and stating the invariant where it can fail beats stating it in a comment.

Closes #85 once verified.