### PR TITLE
chore(#DBSYNC-72): make APPLE_TEAM_ID a repository variable

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,8 @@
 #   APPLE_CERTIFICATE            base64 of a .p12 export of the Developer ID Application cert
 #   APPLE_CERTIFICATE_PASSWORD   password used when exporting that .p12
 #   APPLE_SIGNING_IDENTITY       e.g. "Developer ID Application: NAME (TEAMID)"
-#   APPLE_TEAM_ID                the 10-character team id
+#   APPLE_TEAM_ID                the 10-character team id — a repository VARIABLE, not a
+#                                secret; see the comment on the env block below
 #   APPLE_API_KEY_P8             base64 of the AuthKey_XXXXXXXXXX.p8 from App Store Connect
 #   APPLE_API_KEY_ID             the key id, i.e. the XXXXXXXXXX in that filename
 #   APPLE_API_ISSUER             App Store Connect issuer id (a UUID)
@@ -69,7 +70,12 @@ jobs:
       # host bundle ships with no CodeResources seal over Contents/PlugIns/*.appex.
       APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
       # build-appex.sh passes this to xcodebuild as DEVELOPMENT_TEAM.
-      APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+      # A repository VARIABLE, not a secret. A team id is not confidential — it is
+      # stamped into every signed binary and `codesign -dv` prints it for anyone who
+      # downloads the app. Making it a secret cost real evidence: GitHub masked it in
+      # the log, so the host-vs-appex comparison below printed `TeamIdentifier=***`
+      # twice and nobody could confirm by eye that the two matched.
+      APPLE_TEAM_ID: ${{ vars.APPLE_TEAM_ID }}
 
     steps:
       - uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Names only. Never commit a value, and never echo one into a job log.
 | `APPLE_CERTIFICATE` | base64 of a `.p12` export of the Developer ID Application certificate |
 | `APPLE_CERTIFICATE_PASSWORD` | the password used when exporting that `.p12` |
 | `APPLE_SIGNING_IDENTITY` | `Developer ID Application: NAME (TEAMID)` |
-| `APPLE_TEAM_ID` | the 10-character team id |
+| `APPLE_TEAM_ID` | the 10-character team id — a repository **variable**, not a secret |
 | `APPLE_API_KEY_P8` | base64 of `AuthKey_XXXXXXXXXX.p8` from App Store Connect |
 | `APPLE_API_KEY_ID` | the key id — the `XXXXXXXXXX` in that filename |
 | `APPLE_API_ISSUER` | App Store Connect issuer id (a UUID) |


### PR DESCRIPTION
## Summary

`APPLE_TEAM_ID` was a repository secret. It should not have been.

A team id is not confidential — it is stamped into every signed binary, and `codesign -dv` prints it for anyone who downloads the app. Storing it as a secret bought nothing and cost real evidence: GitHub masked it in the run log, so the verification step printed

```
--- host
TeamIdentifier=***
--- nested appex (F4: this is the one that was unverified before #84)
TeamIdentifier=***
```

The comparison beside it was always real — done in bash, on real values, and it fails the job on a mismatch. But F4 is precisely the finding that host and nested appex might carry *different* teams, and the check that closes it printed two asterisks. A check whose output nobody can read is worth less than one they can.

## Changes

- `release.yml`: `${{ secrets.APPLE_TEAM_ID }}` → `${{ vars.APPLE_TEAM_ID }}`, with the reasoning at the env block rather than in a commit message nobody will find.
- README secrets table marks it as a variable.
- The secret was **deleted** and the variable **created** before this commit, so the next run is a real test of the substitution rather than a formality.

## Test Plan

- [x] YAML parses.
- [x] `secrets.APPLE_TEAM_ID` no longer appears anywhere; `vars.APPLE_TEAM_ID` on line 78.
- [ ] `workflow_dispatch` run on main after merge — this is the one that matters. If `vars` does not resolve, the appex is built with an empty `DEVELOPMENT_TEAM` and `build-appex.sh` warns rather than fails, so a silent regression is possible. The identity-verification step and the host-vs-appex team comparison are what would catch it.

Not merging this without that run.