### PR TITLE
test(#DBSYNC-96): prove a rename is billed as a delete plus a full upload

### DIFF
--- a/apps/desktop/src-tauri/src/sync_pipeline.rs
+++ b/apps/desktop/src-tauri/src/sync_pipeline.rs
@@ -1582,6 +1582,88 @@ mod tests {
         assert_eq!(job_targets(&state, "upload"), vec!["m.txt".to_string()]);
     }
 
+    /// DBSYNC-96: what does a rename actually cost today?
+    ///
+    /// The claim under test is that the pipeline cannot see a rename at all — it sees a path
+    /// that vanished and a path that appeared, and bills them as a delete plus a full upload.
+    /// That claim came from reading three things (`fs_watcher` keeps only `e.path`, there is no
+    /// `move` job type, a vanished path reaches `enqueue_targeted_deletions`), and reading is
+    /// not evidence of behaviour.
+    ///
+    /// **Both paths go into ONE call on purpose.** The watcher hands over a single debounced
+    /// batch, so the old and new names arrive together. Splitting them across two calls would
+    /// be a weaker test: it could not detect a correlation even if the pipeline had one, and
+    /// would "confirm" the claim for the wrong reason.
+    #[test]
+    fn a_rename_is_billed_as_a_delete_plus_a_full_upload() {
+        let tmp = tempdir().expect("tempdir");
+        let state = build_state(tmp.path());
+        // Indexed and in sync under its old name...
+        state.db.upsert_local_file("old.txt", "h", 5, 0).unwrap();
+        // ...and on disk it now exists only under the new one. Same bytes, same inode in a
+        // real rename; the pipeline sees neither.
+        std::fs::write(sync_root(&state).join("new.txt"), b"hello").unwrap();
+
+        let n = process_changed_paths(&state, &["old.txt".to_string(), "new.txt".to_string()])
+            .expect("process");
+
+        // Two jobs, not one move.
+        assert_eq!(n, 2);
+        assert_eq!(job_targets(&state, "delete"), vec!["old.txt".to_string()]);
+        assert_eq!(job_targets(&state, "upload"), vec!["new.txt".to_string()]);
+        // And the index row does not travel: it is dropped and a fresh one is created.
+        assert!(state.db.get_local_file("old.txt").unwrap().is_none());
+        assert!(state.db.get_local_file("new.txt").unwrap().is_some());
+    }
+
+    /// The same for a directory, where the cost multiplies by the contents rather than
+    /// being paid once.
+    #[test]
+    fn a_directory_rename_re_uploads_every_child() {
+        let tmp = tempdir().expect("tempdir");
+        let state = build_state(tmp.path());
+        let root = sync_root(&state);
+
+        // Old directory: tracked folder + two tracked children, none of them on disk any more.
+        state.db.upsert_known_folder("d").unwrap();
+        state.db.upsert_local_file("d/one.txt", "h1", 3, 0).unwrap();
+        state.db.upsert_local_file("d/two.txt", "h2", 3, 0).unwrap();
+
+        // New directory on disk with the same two files.
+        std::fs::create_dir_all(root.join("e")).unwrap();
+        std::fs::write(root.join("e/one.txt"), b"aaa").unwrap();
+        std::fs::write(root.join("e/two.txt"), b"bbb").unwrap();
+
+        process_changed_paths(
+            &state,
+            &[
+                "d".to_string(),
+                "e".to_string(),
+                "e/one.txt".to_string(),
+                "e/two.txt".to_string(),
+            ],
+        )
+        .expect("process");
+
+        let mut deletes = job_targets(&state, "delete");
+        let mut uploads = job_targets(&state, "upload");
+        deletes.sort();
+        uploads.sort();
+        // Three deletes, not two: the folder row goes as well as both children.
+        assert_eq!(
+            deletes,
+            vec![
+                "d".to_string(),
+                "d/one.txt".to_string(),
+                "d/two.txt".to_string()
+            ]
+        );
+        assert_eq!(
+            uploads,
+            vec!["e/one.txt".to_string(), "e/two.txt".to_string()]
+        );
+    }
+
     #[test]
     fn targeted_removed_file_enqueues_delete() {
         let tmp = tempdir().expect("tempdir");


### PR DESCRIPTION
## Summary

DBSYNC-96 sizes stable item identity before DBSYNC-95 is allowed to start. **The deliverable is a measurement, not code** — the diff is two tests and nothing else. The findings live on the slice issues; this PR carries the one thing that had to execute.

Slices: #145 (addressing surface), #146 (rename cost), #147 (identifier questions), #148 (sizing).

## What the tests prove

A rename is billed as a **delete plus a full upload**, not a move. The index row is dropped rather than moved, so sync state is lost as well as bytes re-sent. A directory rename costs one delete per tracked descendant **plus the folder row**.

The first version of the directory test asserted two deletes and was wrong — the observed answer is three. Assertion corrected to match observation; production was not at fault.

**Both paths go into one `process_changed_paths` call on purpose.** The watcher delivers a single debounced batch, so old and new arrive together. Splitting them would have been a weaker test that could not detect a correlation even if the pipeline had one.

**Both tests were proven able to fail**, which is the part that makes them evidence:

| Mutation | Reddens |
| --- | --- |
| `enqueue_targeted_deletions` → `Ok(0)` | both rename tests, by name (+3 existing) |
| upload enqueue target corrupted | both rename tests, by name (+1 existing) |

Naming them matters — "3 tests reddened" would have been satisfied by three unrelated failures.

## The sizing, in one table

| | |
| --- | --- |
| Must convert | **23 sites** — shared engine code |
| Contingent | 15 — `cloudsc_ops.rs`, which File Provider replaces on macOS |
| Never touched | 9 — `cloud_filter.rs`, `#![cfg(windows)]` |
| `db.rs` methods needing identity | **9 of 48** |
| `db.rs` methods that are hierarchy-shaped | 7 — identifiers cannot express subtrees, so paths stay |

The architecture review's "117 sites" merged three different populations. This is **addition, not replacement**: the path-addressed API survives for Windows and for hierarchy.

**One thing got bigger.** `local_file_index` and `remote_file_index` are separate tables, and a locally created file has no remote row until its upload succeeds. So identifiers cannot be a thin mirror of Dropbox's id — a local identity space is needed. That was not in the original framing.

## What is honestly not answered

- **Does Dropbox's `id:` exist on folders and survive renames?** Needs a live call against the maintainer's account. Not made — their credentials, their decision.
- **Apple's stability requirement.** The SDK header states none; Apple's site is a JS application and returns only a page title. A fetch tool offered "typically stable and persistent" with no source; **discarded rather than recorded**, because that is precisely the shape of DBSYNC-79's fourth correction.

Mitigated but not closed: ids must be persisted anyway, because the SDK header warns identifiers *"may be recorded in system logs"* — so a path-derived identifier would leak user paths into the unified log. Same defect class as DBSYNC-91.

## A weakened safeguard, disclosed

Slice #148's plan required the amendment threshold to be written **before** the findings were read. The same agent produced the findings, so there was no moment at which that was possible. Writing one now and calling it prior would be fiction. **The threshold is the maintainer's to set**, and it is being set with the numbers already visible.

## Stack

`desktop-tauri` · **Jira:** DBSYNC-96

## Test Plan

- [x] `cargo test` — **218 passed / 0 failed**
- [x] `cargo fmt --check` — clean (it caught a mis-wrapped assertion first; fixed)
- [x] `cargo clippy` — 6 warnings, the pre-existing set
- [x] Both new tests shown to redden under two independent mutations, by name
- [x] No production code changed — the diff is tests only

## Reviewer note

The code is two tests. **The surface worth attacking is the claims**, on #145–#148: whether any count separates populations it should not, and whether any answer is stated more confidently than its source supports. Two are explicitly marked unanswered; check that nothing else should be.

🤖 Generated with Claude Code
